### PR TITLE
Replace Content-type with Content-Type in HttpProvider

### DIFF
--- a/lib/web3/httpprovider.js
+++ b/lib/web3/httpprovider.js
@@ -35,7 +35,7 @@ HttpProvider.prototype.isConnected = function() {
     var request = new XMLHttpRequest();
 
     request.open('POST', this.host, false);
-    request.setRequestHeader('Content-type','application/json');
+    request.setRequestHeader('Content-Type','application/json');
     
     try {
         request.send(JSON.stringify({
@@ -54,7 +54,7 @@ HttpProvider.prototype.send = function (payload) {
     var request = new XMLHttpRequest();
 
     request.open('POST', this.host, false);
-    request.setRequestHeader('Content-type','application/json');
+    request.setRequestHeader('Content-Type','application/json');
     
     try {
         request.send(JSON.stringify(payload));
@@ -98,7 +98,7 @@ HttpProvider.prototype.sendAsync = function (payload, callback) {
     };
 
     request.open('POST', this.host, true);
-    request.setRequestHeader('Content-type','application/json');
+    request.setRequestHeader('Content-Type','application/json');
     
     try {
         request.send(JSON.stringify(payload));


### PR DESCRIPTION
Hey,

I've made a mistake with the header name in my previous PR, it should be `Content-Type`. It turned up that some libraries are strict about that.