### PR TITLE
fix asynchronous version of Filter.get().

### DIFF
--- a/lib/web3/filter.js
+++ b/lib/web3/filter.js
@@ -211,6 +211,9 @@ Filter.prototype.get = function (callback) {
             });
         }
     } else {
+        if (this.filterId === null) {
+            throw new Error('Filter ID Error: filter().get() can\'t be chained synchronous, please provide a callback for the get() method.');
+        }
         var logs = this.implementation.getLogs(this.filterId);
         return logs.map(function (log) {
             return self.formatter ? self.formatter(log) : log;

--- a/lib/web3/filter.js
+++ b/lib/web3/filter.js
@@ -139,6 +139,7 @@ var Filter = function (options, methods, formatter, callback) {
     this.implementation = implementation;
     this.filterId = null;
     this.callbacks = [];
+    this.getPendingCallbacks = [];
     this.pollFilters = [];
     this.formatter = formatter;
     this.implementation.newFilter(this.options, function(error, id){
@@ -148,6 +149,13 @@ var Filter = function (options, methods, formatter, callback) {
             });
         } else {
             self.filterId = id;
+
+            // check if there are get pending callbacks as a consequence
+            // of calling get() with filterId unassigned.
+            self.getPendingCallbacks.forEach(function (cb){
+                self.get(cb);
+            });
+            self.getPendingCallbacks = [];
 
             // get filter logs for the already existing watch calls
             self.callbacks.forEach(function(cb){
@@ -187,15 +195,21 @@ Filter.prototype.stopWatching = function () {
 Filter.prototype.get = function (callback) {
     var self = this;
     if (utils.isFunction(callback)) {
-        this.implementation.getLogs(this.filterId, function(err, res){
-            if (err) {
-                callback(err);
-            } else {
-                callback(null, res.map(function (log) {
-                    return self.formatter ? self.formatter(log) : log;
-                }));
-            }
-        });
+        if (this.filterId === null) {
+            // If filterId is not set yet, call it back
+            // when newFilter() assigns it.
+            this.getPendingCallbacks.push(callback);
+        } else {
+            this.implementation.getLogs(this.filterId, function(err, res){
+                if (err) {
+                    callback(err);
+                } else {
+                    callback(null, res.map(function (log) {
+                        return self.formatter ? self.formatter(log) : log;
+                    }));
+                }
+            });
+        }
     } else {
         var logs = this.implementation.getLogs(this.filterId);
         return logs.map(function (log) {

--- a/lib/web3/filter.js
+++ b/lib/web3/filter.js
@@ -139,7 +139,7 @@ var Filter = function (options, methods, formatter, callback) {
     this.implementation = implementation;
     this.filterId = null;
     this.callbacks = [];
-    this.getPendingCallbacks = [];
+    this.getLogsCallbacks = [];
     this.pollFilters = [];
     this.formatter = formatter;
     this.implementation.newFilter(this.options, function(error, id){
@@ -152,10 +152,10 @@ var Filter = function (options, methods, formatter, callback) {
 
             // check if there are get pending callbacks as a consequence
             // of calling get() with filterId unassigned.
-            self.getPendingCallbacks.forEach(function (cb){
+            self.getLogsCallbacks.forEach(function (cb){
                 self.get(cb);
             });
-            self.getPendingCallbacks = [];
+            self.getLogsCallbacks = [];
 
             // get filter logs for the already existing watch calls
             self.callbacks.forEach(function(cb){
@@ -198,7 +198,7 @@ Filter.prototype.get = function (callback) {
         if (this.filterId === null) {
             // If filterId is not set yet, call it back
             // when newFilter() assigns it.
-            this.getPendingCallbacks.push(callback);
+            this.getLogsCallbacks.push(callback);
         } else {
             this.implementation.getLogs(this.filterId, function(err, res){
                 if (err) {


### PR DESCRIPTION
Calls to get(callback) are postponed while filterId is not available.