### PR TITLE
Correctly handle undefined `options.data`

### DIFF
--- a/lib/web3/contract.js
+++ b/lib/web3/contract.js
@@ -210,7 +210,7 @@ ContractFactory.prototype.new = function () {
     // throw an error if there are no options
 
     var bytes = encodeConstructorParams(this.abi, args);
-    options.data += bytes;
+    options.data = options.data ? options.data + bytes : options.data;
 
 
     if(callback) {


### PR DESCRIPTION
When `options.data` is undefined, `options.data += bytes` yields `undefined000000.....`