### PR TITLE
Add support of multiple providers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
-var web3 = require('./lib/web3');
+var Web3 = require('./lib/web3');
 var namereg = require('./lib/web3/namereg');
 
-web3.providers.HttpProvider = require('./lib/web3/httpprovider');
-web3.providers.IpcProvider = require('./lib/web3/ipcprovider');
+Web3.prototype.providers.HttpProvider = require('./lib/web3/httpprovider');
+Web3.prototype.providers.IpcProvider = require('./lib/web3/ipcprovider');
 
-web3.eth.contract = require('./lib/web3/contract');
-web3.eth.namereg = namereg.namereg;
-web3.eth.ibanNamereg = namereg.ibanNamereg;
-web3.eth.sendIBANTransaction = require('./lib/web3/transfer');
-web3.eth.iban = require('./lib/web3/iban');
+Web3.prototype.eth.contract = require('./lib/web3/contract');
+Web3.prototype.eth.namereg = namereg.namereg;
+Web3.prototype.eth.ibanNamereg = namereg.ibanNamereg;
+Web3.prototype.eth.sendIBANTransaction = require('./lib/web3/transfer');
+Web3.prototype.eth.iban = require('./lib/web3/iban');
 
 // dont override global variable
 if (typeof window !== 'undefined' && typeof window.web3 === 'undefined') {
-    window.web3 = web3;
+    window.Web3 = Web3;
 }
 
-module.exports = web3;
-
+module.exports = Web3;

--- a/lib/web3.js
+++ b/lib/web3.js
@@ -38,6 +38,7 @@ var c = require('./utils/config');
 var Property = require('./web3/property');
 var Batch = require('./web3/batch');
 var sha3 = require('./utils/sha3');
+var Eth = require('./web3/methods/eth1');
 
 var web3Properties = [
     new Property({
@@ -78,56 +79,60 @@ var setupProperties = function (obj, properties) {
 };
 
 /// setups web3 object, and it's in-browser executed methods
-var web3 = {};
-web3.providers = {};
-web3.currentProvider = null;
-web3.version = {};
-web3.version.api = version.version;
-web3.eth = {};
+function Web3(provider) {
+    this.currentProvider = provider;
+    this.requestManager = new RequestManager();
+    this.requestManager.setProvider(provider);
+    this.eth1 = new Eth(this);
+}
+Web3.prototype.providers = {};
+Web3.prototype.version = {};
+Web3.prototype.version.api = version.version;
+Web3.prototype.eth = {};
 
 /*jshint maxparams:4 */
-web3.eth.filter = function (fil, callback) {
+Web3.prototype.eth.filter = function (fil, callback) {
     return new Filter(fil, watches.eth(), formatters.outputLogFormatter, callback);
 };
 /*jshint maxparams:3 */
 
-web3.shh = {};
-web3.shh.filter = function (fil, callback) {
+Web3.prototype.shh = {};
+Web3.prototype.shh.filter = function (fil, callback) {
     return new Filter(fil, watches.shh(), formatters.outputPostFormatter, callback);
 };
-web3.net = {};
-web3.db = {};
-web3.setProvider = function (provider) {
+Web3.prototype.net = {};
+Web3.prototype.db = {};
+Web3.prototype.setProvider = function (provider) {
     this.currentProvider = provider;
     RequestManager.getInstance().setProvider(provider);
 };
-web3.isConnected = function(){
+Web3.prototype.isConnected = function(){
      return (this.currentProvider && this.currentProvider.isConnected());
 };
-web3.reset = function () {
+Web3.prototype.reset = function () {
     RequestManager.getInstance().reset();
     c.defaultBlock = 'latest';
     c.defaultAccount = undefined;
 };
-web3.toHex = utils.toHex;
-web3.toAscii = utils.toAscii;
-web3.toUtf8 = utils.toUtf8;
-web3.fromAscii = utils.fromAscii;
-web3.fromUtf8 = utils.fromUtf8;
-web3.toDecimal = utils.toDecimal;
-web3.fromDecimal = utils.fromDecimal;
-web3.toBigNumber = utils.toBigNumber;
-web3.toWei = utils.toWei;
-web3.fromWei = utils.fromWei;
-web3.isAddress = utils.isAddress;
-web3.isIBAN = utils.isIBAN;
-web3.sha3 = sha3;
-web3.createBatch = function () {
+Web3.prototype.toHex = utils.toHex;
+Web3.prototype.toAscii = utils.toAscii;
+Web3.prototype.toUtf8 = utils.toUtf8;
+Web3.prototype.fromAscii = utils.fromAscii;
+Web3.prototype.fromUtf8 = utils.fromUtf8;
+Web3.prototype.toDecimal = utils.toDecimal;
+Web3.prototype.fromDecimal = utils.fromDecimal;
+Web3.prototype.toBigNumber = utils.toBigNumber;
+Web3.prototype.toWei = utils.toWei;
+Web3.prototype.fromWei = utils.fromWei;
+Web3.prototype.isAddress = utils.isAddress;
+Web3.prototype.isIBAN = utils.isIBAN;
+Web3.prototype.sha3 = sha3;
+Web3.prototype.createBatch = function () {
     return new Batch();
 };
 
 // ADD defaultblock
-Object.defineProperty(web3.eth, 'defaultBlock', {
+Object.defineProperty(Web3.prototype.eth, 'defaultBlock', {
     get: function () {
         return c.defaultBlock;
     },
@@ -137,7 +142,7 @@ Object.defineProperty(web3.eth, 'defaultBlock', {
     }
 });
 
-Object.defineProperty(web3.eth, 'defaultAccount', {
+Object.defineProperty(Web3.prototype.eth, 'defaultAccount', {
     get: function () {
         return c.defaultAccount;
     },
@@ -149,29 +154,29 @@ Object.defineProperty(web3.eth, 'defaultAccount', {
 
 
 // EXTEND
-web3._extend = function(extension){
+Web3.prototype._extend = function(extension){
     /*jshint maxcomplexity: 6 */
 
-    if(extension.property && !web3[extension.property])
-        web3[extension.property] = {};
+    if(extension.property && !this[extension.property])
+        this[extension.property] = {};
 
-    setupMethods(web3[extension.property] || web3, extension.methods || []);
-    setupProperties(web3[extension.property] || web3, extension.properties || []);
+    setupMethods(this[extension.property] || this, extension.methods || []);
+    setupProperties(this[extension.property] || this, extension.properties || []);
 };
-web3._extend.formatters = formatters;
-web3._extend.utils = utils;
-web3._extend.Method = require('./web3/method');
-web3._extend.Property = require('./web3/property');
+Web3.prototype._extend.formatters = formatters;
+Web3.prototype._extend.utils = utils;
+Web3.prototype._extend.Method = require('./web3/method');
+Web3.prototype._extend.Property = require('./web3/property');
 
 
 /// setups all api methods
-setupProperties(web3, web3Properties);
-setupMethods(web3.net, net.methods);
-setupProperties(web3.net, net.properties);
-setupMethods(web3.eth, eth.methods);
-setupProperties(web3.eth, eth.properties);
-setupMethods(web3.db, db.methods);
-setupMethods(web3.shh, shh.methods);
+setupProperties(Web3.prototype, web3Properties);
+setupMethods(Web3.prototype.net, net.methods);
+setupProperties(Web3.prototype.net, net.properties);
+setupMethods(Web3.prototype.eth, eth.methods);
+setupProperties(Web3.prototype.eth, eth.properties);
+setupMethods(Web3.prototype.db, db.methods);
+setupMethods(Web3.prototype.shh, shh.methods);
 
-module.exports = web3;
+module.exports = Web3;
 

--- a/lib/web3/method.js
+++ b/lib/web3/method.js
@@ -168,5 +168,30 @@ Method.prototype.send = function () {
     return this.formatOutput(RequestManager.getInstance().send(payload));
 };
 
-module.exports = Method;
+Method.prototype.attachToObject1 = function (obj) {
+    var func = this.buildCall();
+//    func.request = this.request.bind(this);
+//    func.call = this.call; // that's ugly. filter.js uses it
+    var name = this.name.split('.');
+    if (name.length > 1) {
+        obj[name[0]] = obj[name[0]] || {};
+        obj[name[0]][name[1]] = func;
+    } else {
+        obj[name[0]] = func; 
+    }
+};
 
+Method.prototype.buildCall = function() {
+    var method = this;
+    return function send() {
+        var payload = method.toPayload(Array.prototype.slice.call(arguments));
+        if (payload.callback) {
+            return this.web3.requestManager.sendAsync(payload, function (err, result) {
+                payload.callback(err, method.formatOutput(result));
+            });
+        }
+        return method.formatOutput(this.web3.requestManager.send(payload));
+    };
+};
+
+module.exports = Method;

--- a/lib/web3/methods/eth1.js
+++ b/lib/web3/methods/eth1.js
@@ -1,0 +1,42 @@
+var formatters = require('../formatters');
+var utils = require('../../utils/utils');
+var Method = require('../method');
+var Property = require('../property');
+var c = require('../../utils/config');
+
+function Eth(web3) {
+    this.web3 = web3;
+}
+
+Object.defineProperty(Eth.prototype, 'defaultBlock', {
+    get: function () {
+        return c.defaultBlock;
+    },
+    set: function (val) {
+        c.defaultBlock = val;
+        return val;
+    }
+});
+
+Object.defineProperty(Eth.prototype, 'defaultAccount', {
+    get: function () {
+        return c.defaultAccount;
+    },
+    set: function (val) {
+        c.defaultAccount = val;
+        return val;
+    }
+});
+
+var methods = [
+    new Method({
+        name: 'getBalance',
+        call: 'eth_getBalance',
+        params: 2,
+        inputFormatter: [formatters.inputAddressFormatter, formatters.inputDefaultBlockNumberFormatter],
+        outputFormatter: formatters.outputBigNumberFormatter
+    })
+];
+methods.forEach(function(method) { method.attachToObject1(Eth.prototype) });
+
+module.exports = Eth;


### PR DESCRIPTION
Hey,

I'd like to add support of multiple providers to web3. I was asking about workaround for it in #297. I've created this PR to discuss the idea, it changes only `eth.getBalance()`, so now the method can work through multiple providers.

I'll add comments to the diff to mark the main points.