### PR TITLE
Dechunk responses separated by new lines for IPC

### DIFF
--- a/lib/web3/ipcprovider.js
+++ b/lib/web3/ipcprovider.js
@@ -93,7 +93,10 @@ IpcProvider.prototype._parseResponse = function(data) {
     
     // DE-CHUNKER
     var dechunkedData = data
+        .replace(/\}\]\n\[\{/g,'}]|--|[{') // }]\n[{
         .replace(/\}\n\{/g,'}|--|{') // }\n{
+        .replace(/\}\n\[\{/g,'}|--|[{') // }\n[{
+        .replace(/\}\]\n\{/g,'}]|--|{') // }]\n{
         .replace(/\}\{/g,'}|--|{') // }{
         .replace(/\}\]\[\{/g,'}]|--|[{') // }][{
         .replace(/\}\[\{/g,'}|--|[{') // }[{

--- a/lib/web3/ipcprovider.js
+++ b/lib/web3/ipcprovider.js
@@ -93,6 +93,7 @@ IpcProvider.prototype._parseResponse = function(data) {
     
     // DE-CHUNKER
     var dechunkedData = data
+        .replace(/\}\n\{/g,'}|--|{') // }\n{
         .replace(/\}\{/g,'}|--|{') // }{
         .replace(/\}\]\[\{/g,'}]|--|[{') // }][{
         .replace(/\}\[\{/g,'}|--|[{') // }[{


### PR DESCRIPTION
While using web3.js my IPC socket was returning responses separated by
newline. I am using latest geth develop as of today.

I was getting errors like:
```
/web3/ipcprovider.js:110 2016-02-12T12:36:34.128343Z
ubuntu-core-launcher throw errors.InvalidResponse(data);
2016-02-12T12:36:34.129359Z ubuntu-core-launcher ^
2016-02-12T12:36:34.130284Z ubuntu-core-launcher Error: Invalid JSON RPC
response:
"{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0xae4104084ad6cfb1423545196859cedf\"}\n{\"jsonrpc\":\"2.0\",\"id\":4,\"result\":\"0xce282609b9348fdc89e508bb8fd83064\"}\n{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":\"0x5bcf23128df40c8cca0f4fad2324c5f6\"}\n{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":\"0x00dd3eddc3b8421968ca34210a7978d3\"}\n"
```

You can notice that the responses are newline separated. Adding this
extra rule to the dechunking solves my problem.