### PR TITLE
Pull bignumber.js library over https:// instead of git://

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "bignumber.js": "debris/bignumber.js#master",
+    "bignumber.js": "git+https://github.com/debris/bignumber.js#master",
     "crypto-js": "^3.1.4",
     "utf8": "^2.1.1",
     "xmlhttprequest": "*"


### PR DESCRIPTION
This will help people behind a filtering proxy that only allows http and https.