### PR TITLE
Return an actual exception in inputAddressFormatter()

### DIFF
--- a/lib/web3/formatters.js
+++ b/lib/web3/formatters.js
@@ -268,7 +268,7 @@ var inputAddressFormatter = function (address) {
     } else if (utils.isAddress(address)) {
         return '0x' + address;
     }
-    throw 'invalid address';
+    throw new Error('invalid address');
 };
 
 


### PR DESCRIPTION
Without this, stack traces are truncated.