### PR TITLE
web3.sha3 returns string with hex prefix

### DIFF
--- a/lib/web3.js
+++ b/lib/web3.js
@@ -96,7 +96,11 @@ Web3.prototype.isAddress = utils.isAddress;
 Web3.prototype.isChecksumAddress = utils.isChecksumAddress;
 Web3.prototype.toChecksumAddress = utils.toChecksumAddress;
 Web3.prototype.isIBAN = utils.isIBAN;
-Web3.prototype.sha3 = sha3;
+
+
+Web3.prototype.sha3 = function(msg) {
+    return '0x' + sha3(msg);
+};
 
 /**
  * Transforms direct icap to address

--- a/lib/web3.js
+++ b/lib/web3.js
@@ -98,8 +98,8 @@ Web3.prototype.toChecksumAddress = utils.toChecksumAddress;
 Web3.prototype.isIBAN = utils.isIBAN;
 
 
-Web3.prototype.sha3 = function(msg) {
-    return '0x' + sha3(msg);
+Web3.prototype.sha3 = function(string, options) {
+    return '0x' + sha3(string, options);
 };
 
 /**

--- a/test/web3.sha3.js
+++ b/test/web3.sha3.js
@@ -10,9 +10,11 @@ describe('web3.sha3', function () {
     it('should return sha3 with hex prefix', function() {
 	test1 = web3.sha3('test123');
 	test2 = web3.sha3('test(int)');
-	test3 = web3.sha3('sdffvkj');
+	test3 = web3.sha3('0x80', {encoding: 'hex'});
+	test4 = web3.sha3('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1', {encoding: 'hex'});
 	assert.deepEqual(test1, '0x' + sha3('test123'));
 	assert.deepEqual(test2, '0x' + sha3('test(int)'));
-	assert.deepEqual(test3, '0x' + sha3('sdffvkj'));
+	assert.deepEqual(test3, '0x' + sha3('0x80', {encoding: 'hex'}));
+	assert.deepEqual(test4, '0x' + sha3('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1', {encoding: 'hex'}));
     });
 });

--- a/test/web3.sha3.js
+++ b/test/web3.sha3.js
@@ -1,0 +1,18 @@
+var chai = require('chai');
+var assert = chai.assert;
+var Web3 = require('../index');
+var sha3 = require('../lib/utils/sha3');
+var web3 = new Web3();
+
+var method = 'sha3';
+
+describe('web3.sha3', function () {
+    it('should return sha3 with hex prefix', function() {
+	test1 = web3.sha3('test123');
+	test2 = web3.sha3('test(int)');
+	test3 = web3.sha3('sdffvkj');
+	assert.deepEqual(test1, '0x' + sha3('test123'));
+	assert.deepEqual(test2, '0x' + sha3('test(int)'));
+	assert.deepEqual(test3, '0x' + sha3('sdffvkj'));
+    });
+});


### PR DESCRIPTION
Quick fix to https://github.com/ethereum/web3.js/issues/403.
https://github.com/ethereum/wiki/wiki/JSON-RPC#web3_sha3 exemplifies a return with 0x prefix