### PR TITLE
Meteor 1.3+ can handle default CommonJs syntax

### DIFF
--- a/lib/web3/httpprovider.js
+++ b/lib/web3/httpprovider.js
@@ -29,12 +29,8 @@ var errors = require('./errors');
 // workaround to use httpprovider in different envs
 var XMLHttpRequest; // jshint ignore: line
 
-// meteor server environment
-if (typeof Meteor !== 'undefined' && Meteor.isServer) { // jshint ignore: line
-    XMLHttpRequest = Npm.require('xmlhttprequest').XMLHttpRequest; // jshint ignore: line
-
 // browser
-} else if (typeof window !== 'undefined' && window.XMLHttpRequest) {
+if (typeof window !== 'undefined' && window.XMLHttpRequest) {
     XMLHttpRequest = window.XMLHttpRequest; // jshint ignore: line
 
 // node


### PR DESCRIPTION
In Meteor 1.3+ the `Npm` Object is not available and leads to a crash.