### PR TITLE
add possibility to pass arbitrary data in context of a method

### DIFF
--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -62,11 +62,13 @@ SolidityFunction.prototype.extractDefaultBlock = function (args) {
  */
 SolidityFunction.prototype.toPayload = function (args) {
     var options = {};
-    if (args.length > this._inputTypes.length && utils.isObject(args[args.length -1])) {
+    if ((args.length > this._inputTypes.length || args.length === 1)
+        && !utils.isArray(args[args.length -1]) && utils.isObject(args[args.length -1])) {
         options = args[args.length - 1];
     }
-    options.to = this._address;
-    options.data = '0x' + this.signature() + coder.encodeParams(this._inputTypes, args);
+    options.to = options.to ? options.to : this._address;
+    options.data = options.data ? options.data : '0x' + this.signature() + coder.encodeParams(this._inputTypes, args);
+
     return options;
 };
 

--- a/test/contract.js
+++ b/test/contract.js
@@ -499,7 +499,7 @@ describe('contract', function () {
 
         it('should call testArr method and properly parse result', function () {
             var provider = new FakeHttpProvider2();
-            var web3 = new Web3(provider); 
+            var web3 = new Web3(provider);
             var signature = 'testArr(int[])';
             var address = '0x1234567890123456789012345678901234567891';
             provider.injectResultList([{
@@ -516,7 +516,7 @@ describe('contract', function () {
                     to: address
                 },
                     'latest'
-                    ]);
+                ]);
             });
 
             var contract = web3.eth.contract(desc).at(address);
@@ -527,7 +527,7 @@ describe('contract', function () {
         
         it('should call testArr method, properly parse result and return the result async', function (done) {
             var provider = new FakeHttpProvider2();
-            var web3 = new Web3(provider); 
+            var web3 = new Web3(provider);
             var signature = 'testArr(int[])';
             var address = '0x1234567890123456789012345678901234567891';
             provider.injectResultList([{
@@ -552,8 +552,35 @@ describe('contract', function () {
                 assert.deepEqual(new BigNumber(5), result);
                 done();
             });
+        });
 
+        it('should call contract with provided data in context of testArr method and properly parse result', function () {
+            var provider = new FakeHttpProvider2();
+            var web3 = new Web3(provider);
+            var signature = 'testArr(int[])';
+            var address = '0x1234567890123456789012345678901234567891';
+            var data = '0x' + sha3(signature).slice(0, 8) + 
+                '0000000000000000000000000000000000000000000000000000000000000020' + 
+                '0000000000000000000000000000000000000000000000000000000000000001' + 
+                '0000000000000000000000000000000000000000000000000000000000000003';
+            provider.injectResultList([{
+                result: '0x0000000000000000000000000000000000000000000000000000000000000005'
+            }]);
+
+            provider.injectValidation(function (payload) {
+                assert.equal(payload.method, 'eth_call');
+                assert.deepEqual(payload.params, [{
+                    data: data,
+                    to: address
+                },
+                    'latest'
+                ]);
+            });
+
+            var contract = web3.eth.contract(desc).at(address);
+            var result = contract.testArr({data: data});
+
+            assert.deepEqual(new BigNumber(5), result);
         });
     });
 });
-


### PR DESCRIPTION
There is situations when you want to parse `web3.eth.call(tx)` results in context of a particular method. It will be useful to be able to do `contract.myMethod.call(tx)` assuming that valid `tx.data` is already there, having the signature inside along with all the arguments encoded. The only difference is that `myMethod` output formatter is gonna be used to parse results whatever they are.