### PR TITLE
Add filterCreationErrorCallback argument to Filter constructor

### DIFF
--- a/lib/web3/filter.js
+++ b/lib/web3/filter.js
@@ -130,7 +130,7 @@ var pollFilter = function(self) {
 
 };
 
-var Filter = function (requestManager, options, methods, formatter, callback) {
+var Filter = function (requestManager, options, methods, formatter, callback, filterCreationErrorCallback) {
     var self = this;
     var implementation = {};
     methods.forEach(function (method) {
@@ -150,6 +150,7 @@ var Filter = function (requestManager, options, methods, formatter, callback) {
             self.callbacks.forEach(function(cb){
                 cb(error);
             });
+            filterCreationErrorCallback(error);
         } else {
             self.filterId = id;
 

--- a/test/web3.eth.filter.js
+++ b/test/web3.eth.filter.js
@@ -3,6 +3,7 @@ var Web3 = require('../index');
 var web3 = new Web3();
 var assert = chai.assert;
 var FakeHttpProvider = require('./helpers/FakeHttpProvider');
+var errors = require('../lib/web3/errors');
 
 var method = 'filter';
 
@@ -96,6 +97,22 @@ describe('web3.eth', function () {
                    });
                }
             });
+
+            it('should call filterCreationErrorCallback on error while filter creation', function () {
+                // given
+                var provider = new FakeHttpProvider();
+                web3.reset();
+                web3.setProvider(provider);
+                provider.injectError(errors.InvalidConnection());
+                // call
+                var args = test.args.slice();
+                args.push(undefined);
+                args.push(function (err) {
+                    assert.include(errors, err);
+                    done();
+                });
+                web3.eth[method].apply(web3.eth, args);
+            })
         });
     });
 });


### PR DESCRIPTION
When we creating filter, but node is down we can't manage if we have error or not. In current filter implementation it's impossible to check it.
