### PR TITLE
Fix bignumber dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "bignumber.js": "git+https://github.com/debris/bignumber.js#master",
+    "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
     "crypto-js": "^3.1.4",
     "utf8": "^2.1.1",
     "xmlhttprequest": "*"


### PR DESCRIPTION
Package should depend on specific version of https://github.com/debris/bignumber.js.

Closes #429 