### PR TITLE
test for null&undefined in function formatOutput

### DIFF
--- a/lib/web3/property.js
+++ b/lib/web3/property.js
@@ -55,7 +55,7 @@ Property.prototype.formatInput = function (arg) {
  * @return {Object}
  */
 Property.prototype.formatOutput = function (result) {
-    return this.outputFormatter && result !== null ? this.outputFormatter(result) : result;
+    return this.outputFormatter && result != null ? this.outputFormatter(result) : result;
 };
 
 /**


### PR DESCRIPTION
When an error ['Error: CONNECTION ERROR: Couldn't connect to node on IPC.'] occurs here:

```
Property.prototype.buildAsyncGet = function () {
    var property = this;
    var get = function (callback) {
        property.requestManager.sendAsync({
            method: property.getter
        }, function (err, result) {
            callback(err, property.formatOutput(result));
        });
    };
    get.request = this.request.bind(this);
    return get;
};
```

result is undefined, and in formatOutput function the test for null should be != instead of !== .
I came across it when I had an IPC connection opened to geth, then I killed the geth process, and an exception occurred:
TypeError: Cannot read property 'startingBlock' of undefined in:

```
var outputSyncingFormatter = function(result) {

    result.startingBlock = utils.toDecimal(result.startingBlock);
    result.currentBlock = utils.toDecimal(result.currentBlock);
    result.highestBlock = utils.toDecimal(result.highestBlock);

    return result;
};
```
