### PR TITLE
Correct filename in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Component
 component install ethereum/web3.js
 ```
 
-* Include `ethereum.min.js` in your html file. (not required for the meteor package)
+* Include `web3.min.js` in your html file. (not required for the meteor package)
 
 ## Usage
 Use the `web3` object directly from global namespace:


### PR DESCRIPTION
Hi, I suppose the minified file to be included in the HTML when running in the browser is `dist/web3.min.js`, for there is actually no such file as `dist/ethereum.min.js`? I've tried running `web3.min.js` and it seems to work fine.