### PR TITLE
Fix test coverage calculation

### DIFF
--- a/test/httpprovider.js
+++ b/test/httpprovider.js
@@ -6,7 +6,8 @@ SandboxedModule.registerBuiltInSourceTransformer('istanbul');
 var HttpProvider = SandboxedModule.require('../lib/web3/httpprovider', {
     requires: {
         'xmlhttprequest': require('./helpers/FakeXMLHttpRequest')
-    }
+    },
+    singleOnly: true
 });
 
 describe('lib/web3/httpprovider', function () {

--- a/test/ipcprovider.js
+++ b/test/ipcprovider.js
@@ -8,7 +8,8 @@ SandboxedModule.registerBuiltInSourceTransformer('istanbul');
 var IpcProvider = SandboxedModule.require('../lib/web3/ipcprovider', {
     requires: {
         'bignumber.js': require('bignumber.js'), 
-    }
+    },
+    singleOnly: true
 });
 
 describe('lib/web3/ipcprovider', function () {


### PR DESCRIPTION
The test coverage was incorrectly calculated, for it was including code from two external dependencies, namely `node_modules/crypto-js/*` and `node_modules/utf8/*`:

![coverage-before](https://cloud.githubusercontent.com/assets/2203012/16390764/f0071502-3cd6-11e6-95a9-7f8cf38640cd.png)

Removing those will give us the correct coverage stats, which is actually much higher:

![coverage-after](https://cloud.githubusercontent.com/assets/2203012/16390890/57abee44-3cd7-11e6-9d23-ad4436508168.png)

The solution is to properly configure the `sandboxed-module` library as mentioned [here](https://github.com/felixge/node-sandboxed-module/issues/39).
