### PR TITLE
Upgrade outdated dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-replace": "^0.5.3",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": ">=1.2.0",
-    "istanbul": "^0.3.5",
+    "istanbul": "^0.4.4",
     "jshint": ">=2.5.0",
     "mocha": ">=2.3.3",
     "sandboxed-module": "^2.0.2",


### PR DESCRIPTION
Upgrade the test coverage tool to 0.4.x. The report HTML will get a visual overhaul.

In 0.3.x it looks like this:
![before](https://cloud.githubusercontent.com/assets/2203012/16451914/54ac9060-3e38-11e6-8794-990c219bc945.png)

Where 0.4.x is like:
![after](https://cloud.githubusercontent.com/assets/2203012/16451937/76bcd098-3e38-11e6-9438-b90d1c6f6f88.png)

This is pretty much the only sensible effect. Quite trivial but nice to have?