### PR TITLE
Add callback handling in method Filter.stopWatching

### DIFF
--- a/lib/web3/filter.js
+++ b/lib/web3/filter.js
@@ -188,11 +188,17 @@ Filter.prototype.watch = function (callback) {
     return this;
 };
 
-Filter.prototype.stopWatching = function () {
+Filter.prototype.stopWatching = function (callback) {
     this.requestManager.stopPolling(this.filterId);
-    // remove filter async
-    this.implementation.uninstallFilter(this.filterId, function(){});
     this.callbacks = [];
+
+    if (utils.isFunction(callback)) {
+        this.implementation.uninstallFilter(this.filterId, callback);
+
+        return true;
+    }
+
+    return this.implementation.uninstallFilter(this.filterId);
 };
 
 Filter.prototype.get = function (callback) {

--- a/lib/web3/jsonrpc.js
+++ b/lib/web3/jsonrpc.js
@@ -20,6 +20,8 @@
  * @date 2015
  */
 
+var utils = require('../utils/utils');
+
 var Jsonrpc = function () {
     // singleton pattern
     if (arguments.callee._singletonInstance) {
@@ -66,11 +68,25 @@ Jsonrpc.prototype.toPayload = function (method, params) {
  * @returns {Boolean} true if response is valid, otherwise false
  */
 Jsonrpc.prototype.isValidResponse = function (response) {
-    return !!response &&
-        !response.error &&
-        response.jsonrpc === '2.0' &&
-        typeof response.id === 'number' &&
-        response.result !== undefined; // only undefined is not valid json object
+  var isValid = true;
+  var responses;
+
+  if (utils.isArray(response)) {
+      responses = response;
+  } else {
+      responses = [response];
+  }
+
+  for (var i = 0; i < responses.length; i++) {
+      isValid = isValid &&
+          !!responses[i] &&
+          !responses[i].error &&
+          responses[i].jsonrpc === '2.0' &&
+          typeof responses[i].id === 'number' &&
+          responses[i].result !== undefined; // only undefined is not valid json object
+  }
+
+  return isValid;
 };
 
 /**

--- a/test/polling.js
+++ b/test/polling.js
@@ -69,9 +69,13 @@ var testPolling = function (tests) {
                     } else {
                         assert.equal(result, test.secondResult[0]);
                     }
-                    filter.stopWatching();
-                    done();
+                    filter.stopWatching(function (e, r) {
+                        if (e) {
+                          throw e;
+                        }
 
+                        done();
+                    });
                 });
             });
             it('should create && successfully poll filter when passed as callback', function (done) {
@@ -105,9 +109,13 @@ var testPolling = function (tests) {
                     } else {
                         assert.equal(result, test.secondResult[0]);
                     }
-                    filter.stopWatching();
-                    done();
+                    filter.stopWatching(function (e, r) {
+                        if (e) {
+                          throw e;
+                        }
 
+                        done();
+                    });
                 });
 
                 // when


### PR DESCRIPTION
This PR allows Filter.stopWatching to be called asynchronously via callback.

In [here](https://github.com/ethereum/web3.js/blob/develop/lib/web3/filter.js#L194) 
```javascript
this.implementation.uninstallFilter(this.filterId, function(){});
```
it was ignoring exceptions so it happens to have a side effect when **running tests**: Jsonrpc.prototype.isValidResponse was failing for batch responses. 

Fixes issue https://github.com/ethereum/web3.js/issues/477.