### PR TITLE
add formatter for syncing States

### DIFF
--- a/lib/web3/formatters.js
+++ b/lib/web3/formatters.js
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** 
+/**
  * @file formatters.js
  * @author Marek Kotewicz <marek@ethdev.com>
  * @author Fabian Vogelsteller <fabian@ethdev.com>
@@ -81,7 +81,7 @@ var inputCallFormatter = function (options){
         options[key] = utils.fromDecimal(options[key]);
     });
 
-    return options; 
+    return options;
 };
 
 /**
@@ -106,12 +106,12 @@ var inputTransactionFormatter = function (options){
         options[key] = utils.fromDecimal(options[key]);
     });
 
-    return options; 
+    return options;
 };
 
 /**
  * Formats the output of a transaction to its proper values
- * 
+ *
  * @method outputTransactionFormatter
  * @param {Object} tx
  * @returns {Object}
@@ -130,7 +130,7 @@ var outputTransactionFormatter = function (tx){
 
 /**
  * Formats the output of a transaction receipt to its proper values
- * 
+ *
  * @method outputTransactionReceiptFormatter
  * @param {Object} receipt
  * @returns {Object}
@@ -156,7 +156,7 @@ var outputTransactionReceiptFormatter = function (receipt){
  * Formats the output of a block to its proper values
  *
  * @method outputBlockFormatter
- * @param {Object} block 
+ * @param {Object} block
  * @returns {Object}
 */
 var outputBlockFormatter = function(block) {
@@ -184,7 +184,7 @@ var outputBlockFormatter = function(block) {
 
 /**
  * Formats the output of a log
- * 
+ *
  * @method outputLogFormatter
  * @param {Object} log object
  * @returns {Object} log
@@ -225,7 +225,7 @@ var inputPostFormatter = function(post) {
         return (topic.indexOf('0x') === 0) ? topic : utils.fromUtf8(topic);
     });
 
-    return post; 
+    return post;
 };
 
 /**
@@ -277,6 +277,10 @@ var outputSyncingFormatter = function(result) {
     result.startingBlock = utils.toDecimal(result.startingBlock);
     result.currentBlock = utils.toDecimal(result.currentBlock);
     result.highestBlock = utils.toDecimal(result.highestBlock);
+    if (result.knownStates) {
+        result.knownStates = utils.toDecimal(result.knownStates);
+        result.pulledStates = utils.toDecimal(result.pulledStates);
+    }
 
     return result;
 };

--- a/test/web3.eth.isSyncing.js
+++ b/test/web3.eth.isSyncing.js
@@ -19,6 +19,24 @@ var tests = [{
         highestBlock: 11
     },
     call: 'eth_syncing'
+}, {
+    args: [],
+    formattedArgs: [],
+    result: [{
+        startingBlock: '0xb',
+        currentBlock: '0xb',
+        highestBlock: '0xb',
+        knownStates: '0xb',
+        pulledStates: '0xb'
+    }],
+    formattedResult: {
+        startingBlock: 11,
+        currentBlock: 11,
+        highestBlock: 11,
+        knownStates: 11,
+        pulledStates: 11
+    },
+    call: 'eth_syncing'
 }];
 
 describe('eth', function () {
@@ -51,7 +69,7 @@ describe('eth', function () {
                         done();
                     }
                 });
-                
+
             });
         });
     });


### PR DESCRIPTION
Hello, I've noticed that `knownStates` and `pulledStates` from `eth_syncing` are not transformed to decimal by formatter. This should solve the problem.