### PR TITLE
add missing eth_protocolVersion method

### DIFF
--- a/lib/web3/methods/eth.js
+++ b/lib/web3/methods/eth.js
@@ -314,6 +314,10 @@ var properties = function () {
             name: 'blockNumber',
             getter: 'eth_blockNumber',
             outputFormatter: utils.toDecimal
+        }),
+        new Property({
+            name: 'protocolVersion',
+            getter: 'eth_protocolVersion'
         })
     ];
 };

--- a/test/web3.eth.methods.js
+++ b/test/web3.eth.methods.js
@@ -30,6 +30,7 @@ describe('web3.eth', function() {
         u.propertyExists(web3.eth, 'accounts');
         u.propertyExists(web3.eth, 'defaultBlock');
         u.propertyExists(web3.eth, 'blockNumber');
+        u.propertyExists(web3.eth, 'protocolVersion');
     });
 });
 

--- a/test/web3.eth.protocolVersion.js
+++ b/test/web3.eth.protocolVersion.js
@@ -1,0 +1,37 @@
+var chai = require('chai');
+var assert = chai.assert;
+var Web3 = require('../index');
+var web3 = new Web3();
+var FakeHttpProvider = require('./helpers/FakeHttpProvider');
+
+var method = 'protocolVersion';
+
+var tests = [{
+    result: ['1234'],
+    call: 'eth_'+ method
+}];
+
+describe('eth.protocolVersion', function () {
+    describe(method, function () {
+        tests.forEach(function (test, index) {
+            it('property test: ' + index, function () {
+
+                // given
+                var provider = new FakeHttpProvider();
+                web3.setProvider(provider);
+                provider.injectResult(test.result);
+                provider.injectValidation(function (payload) {
+                    assert.equal(payload.jsonrpc, '2.0');
+                    assert.equal(payload.method, test.call);
+                    assert.deepEqual(payload.params, []);
+                });
+
+                // when
+                var result = web3.eth[method];
+
+                // then
+                assert.deepEqual(test.result, result);
+            });
+        });
+    });
+});


### PR DESCRIPTION
The RPC spec [describes](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_protocolversion) the `eth_protocolVersion` method which is missing in web3.
This PR adds this method as a web3 property.

