### PR TITLE
call filter.stopWatching asynchronously in the contract deployment.

### DIFF
--- a/lib/web3/contract.js
+++ b/lib/web3/contract.js
@@ -105,7 +105,7 @@ var checkForContractAddress = function(contract, callback){
             // stop watching after 50 blocks (timeout)
             if (count > 50) {
 
-                filter.stopWatching();
+                filter.stopWatching(function() {});
                 callbackFired = true;
 
                 if (callback)
@@ -125,7 +125,7 @@ var checkForContractAddress = function(contract, callback){
                             if(callbackFired || !code)
                                 return;
 
-                            filter.stopWatching();
+                            filter.stopWatching(function() {});
                             callbackFired = true;
 
                             if(code.length > 3) {


### PR DESCRIPTION
There are implementations like "testrpc" that does not support synchronous calls. In order to be able to deploy  contracts in this implementations, it is important to force this call asynchronous.
