### PR TITLE
Add timeout to Web3.js HTTP provider

### DIFF
--- a/lib/web3/errors.js
+++ b/lib/web3/errors.js
@@ -33,6 +33,8 @@ module.exports = {
     InvalidResponse: function (result){
         var message = !!result && !!result.error && !!result.error.message ? result.error.message : 'Invalid JSON RPC response: ' + JSON.stringify(result);
         return new Error(message);
+    },
+    ConnectionTimeout: function (ms){
+        return new Error('CONNECTION TIMEOUT: timeout of ' + ms + ' ms achived');
     }
 };
-

--- a/lib/web3/httpprovider.js
+++ b/lib/web3/httpprovider.js
@@ -28,11 +28,11 @@ var errors = require('./errors');
 
 // workaround to use httpprovider in different envs
 var XMLHttpRequest; // jshint ignore: line
+var XHR2 = require('xhr2');; // jshint ignore: line
 
 // browser
 if (typeof window !== 'undefined' && window.XMLHttpRequest) {
     XMLHttpRequest = window.XMLHttpRequest; // jshint ignore: line
-
 // node
 } else {
     XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest; // jshint ignore: line
@@ -41,8 +41,9 @@ if (typeof window !== 'undefined' && window.XMLHttpRequest) {
 /**
  * HttpProvider should be used to send rpc calls over http
  */
-var HttpProvider = function (host) {
+var HttpProvider = function (host, timeout) {
     this.host = host || 'http://localhost:8545';
+    this.timeout = timeout || 0;
 };
 
 /**
@@ -53,7 +54,15 @@ var HttpProvider = function (host) {
  * @return {XMLHttpRequest} object
  */
 HttpProvider.prototype.prepareRequest = function (async) {
-    var request = new XMLHttpRequest();
+    var request;
+
+    if (async) {
+      request = new XHR2();
+      request.timeout = this.timeout;
+    }else {
+      request = new XMLHttpRequest();
+    }
+
     request.open('POST', this.host, async);
     request.setRequestHeader('Content-Type','application/json');
     return request;
@@ -80,7 +89,7 @@ HttpProvider.prototype.send = function (payload) {
     try {
         result = JSON.parse(result);
     } catch(e) {
-        throw errors.InvalidResponse(request.responseText);                
+        throw errors.InvalidResponse(request.responseText);
     }
 
     return result;
@@ -94,23 +103,27 @@ HttpProvider.prototype.send = function (payload) {
  * @param {Function} callback triggered on end with (err, result)
  */
 HttpProvider.prototype.sendAsync = function (payload, callback) {
-    var request = this.prepareRequest(true); 
+    var request = this.prepareRequest(true);
 
     request.onreadystatechange = function() {
-        if (request.readyState === 4) {
+        if (request.readyState === 4 && request.timeout !== 1) {
             var result = request.responseText;
             var error = null;
 
             try {
                 result = JSON.parse(result);
             } catch(e) {
-                error = errors.InvalidResponse(request.responseText);                
+                error = errors.InvalidResponse(request.responseText);
             }
 
             callback(error, result);
         }
     };
-    
+
+    request.ontimeout = function() {
+      callback(errors.ConnectionTimeout(this.timeout));
+    };
+
     try {
         request.send(JSON.stringify(payload));
     } catch(error) {
@@ -139,4 +152,3 @@ HttpProvider.prototype.isConnected = function() {
 };
 
 module.exports = HttpProvider;
-

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
     "crypto-js": "^3.1.4",
     "utf8": "^2.1.1",
+    "xhr2": "*",
     "xmlhttprequest": "*"
   },
   "browser": {

--- a/test/helpers/FakeXHR2.js
+++ b/test/helpers/FakeXHR2.js
@@ -1,0 +1,37 @@
+var chai = require('chai');
+var assert = chai.assert;
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+
+var FakeXHR2 = function () {
+    this.responseText = "{}";
+    this.readyState = 4;
+    this.onreadystatechange = null;
+    this.async = true;
+    this.headers = {
+        'Content-Type': 'text/plain'
+    };
+};
+
+FakeXHR2.prototype.open = function (method, host, async) {
+    assert.equal(method, 'POST');
+    assert.notEqual(host, null);
+    assert.equal(async === true, true);
+    this.async = async;
+};
+
+FakeXHR2.prototype.setRequestHeader = function(name, value) {
+    this.headers[name] = value;
+};
+
+FakeXHR2.prototype.send = function (payload) {
+    assert.equal(typeof payload, 'string');
+    if (this.async) {
+        assert.equal(typeof this.onreadystatechange, 'function');
+        this.onreadystatechange();
+        return;
+    }
+    return this.responseText;
+};
+
+module.exports = FakeXHR2;

--- a/test/httpprovider.js
+++ b/test/httpprovider.js
@@ -5,6 +5,7 @@ var SandboxedModule = require('sandboxed-module');
 SandboxedModule.registerBuiltInSourceTransformer('istanbul');
 var HttpProvider = SandboxedModule.require('../lib/web3/httpprovider', {
     requires: {
+        'xhr2': require('./helpers/FakeXHR2'),
         'xmlhttprequest': require('./helpers/FakeXMLHttpRequest')
     },
     singleOnly: true
@@ -28,7 +29,7 @@ describe('lib/web3/httpprovider', function () {
                 assert.equal(typeof result, 'object');
                 done();
             });
-        }); 
+        });
     });
 
     describe('isConnected', function () {
@@ -36,7 +37,6 @@ describe('lib/web3/httpprovider', function () {
             var provider = new HttpProvider();
 
             assert.isBoolean(provider.isConnected());
-        }); 
+        });
     });
 });
-


### PR DESCRIPTION
This PR adds support for [timeout](https://www.w3.org/TR/XMLHttpRequest/#the-timeout-attribute) feature of XmlHttpRequest.

Currently, the module [ykzts/node-xmlhttprequest](https://github.com/ykzts/node-xmlhttprequest) does not implements this feature (PR [here](https://github.com/ykzts/node-xmlhttprequest/pull/35)).

Given that the timeout feature is only for the async call I've left the original module `xmlhttprequest` for the sync calls.

The module that I've used that implements XmlHttpRequest `timeout` feature is [pwnall/node-xhr2](https://github.com/pwnall/node-xhr2).
