### PR TITLE
Fixed a bug where negative floats were rounded up instead of down

### DIFF
--- a/lib/solidity/formatters.js
+++ b/lib/solidity/formatters.js
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** 
+/**
  * @file formatters.js
  * @author Marek Kotewicz <marek@ethdev.com>
  * @date 2015
@@ -37,7 +37,7 @@ var SolidityParam = require('./param');
  */
 var formatInputInt = function (value) {
     BigNumber.config(c.ETH_BIGNUMBER_ROUNDING_MODE);
-    var result = utils.padLeft(utils.toTwosComplement(value).round().toString(16), 64);
+    var result = utils.padLeft(utils.toTwosComplement(value).toString(16), 64);
     return new SolidityParam(result);
 };
 
@@ -158,7 +158,7 @@ var formatOutputUInt = function (param) {
  * @returns {BigNumber} input bytes formatted to real
  */
 var formatOutputReal = function (param) {
-    return formatOutputInt(param).dividedBy(new BigNumber(2).pow(128)); 
+    return formatOutputInt(param).dividedBy(new BigNumber(2).pow(128));
 };
 
 /**
@@ -169,7 +169,7 @@ var formatOutputReal = function (param) {
  * @returns {BigNumber} input bytes formatted to ureal
  */
 var formatOutputUReal = function (param) {
-    return formatOutputUInt(param).dividedBy(new BigNumber(2).pow(128)); 
+    return formatOutputUInt(param).dividedBy(new BigNumber(2).pow(128));
 };
 
 /**

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -375,7 +375,7 @@ var toBigNumber = function(number) {
  * @return {BigNumber}
  */
 var toTwosComplement = function (number) {
-    var bigNumber = toBigNumber(number);
+    var bigNumber = toBigNumber(number).round();
     if (bigNumber.lessThan(0)) {
         return new BigNumber("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16).plus(bigNumber).plus(1);
     }

--- a/test/soldity.formatters.formatInputInt.js
+++ b/test/soldity.formatters.formatInputInt.js
@@ -1,0 +1,21 @@
+var chai = require('chai');
+var assert = chai.assert;
+var formatters = require('../lib/solidity/formatters.js');
+var SolidityParam = require('../lib/solidity/param');
+
+var tests = [
+    { input: 1, result: new SolidityParam('0000000000000000000000000000000000000000000000000000000000000001') },
+    { input: 1.1, result: new SolidityParam('0000000000000000000000000000000000000000000000000000000000000001') },
+    { input: -1.1, result: new SolidityParam('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') },
+    { input: -1, result: new SolidityParam('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff') }
+];
+
+describe('formatters', function () {
+    describe('inputAddressFormatter', function () {
+        tests.forEach(function(test){
+            it('should return the correct value', function () {
+                assert.deepEqual(formatters.formatInputInt(test.input), test.result);
+            });
+        });
+    });
+});


### PR DESCRIPTION
There was an issue in combination of `solidity.formatters.formatInputInt` and `utils.toTwosComplement` where the value was rounded _after_ performing the toTwosComplement. This caused negative floats to round _AWAY_ from zero instead of rounding _TOWARDS_ zero. I'm not sure if this is a bug or intentional, but from reading the code it appears to be intended to be rounded down.

So calling a contract method that takes `int` parameter with `-1.0001` would actually call the method with `-2`, or `fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe`

Added simple unit test to demonstrate the behavior
