### PR TITLE
Propagating unpacking errors to async callback to be consistent with synchronous case

### DIFF
--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -115,10 +115,16 @@ SolidityFunction.prototype.call = function () {
 
     var self = this;
     this._eth.call(payload, defaultBlock, function (error, output) {
+        // TODO: do we really want to unpack the output if error != null?
+        var unpacked = null;
         try {
-            callback(error, self.unpackOutput(output));
-        } catch (e) {
-            callback(e, null);
+            unpacked = self.unpackOutput(output);
+        }
+        catch (e) {
+            error = error || e;
+        }
+        finally {
+            callback(error, unpacked);
         }
     });
 };

--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -115,11 +115,6 @@ SolidityFunction.prototype.call = function () {
 
     var self = this;
     this._eth.call(payload, defaultBlock, function (error, output) {
-        // similar to the synchronous case, the caller should be able to handle this error.
-        // For example:
-        //    var contract = web3.eth.contract(abi).at(NONEXISTENT_ADDRESS);
-        //    contract.myField(); // BigNumber error can be caught by caller using try/catch
-        //    contract.myField(function(err, result){...}); // err should be propagated to callback
         try {
             callback(error, self.unpackOutput(output));
         } catch (e) {

--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -115,17 +115,17 @@ SolidityFunction.prototype.call = function () {
 
     var self = this;
     this._eth.call(payload, defaultBlock, function (error, output) {
-        // TODO: do we really want to unpack the output if error != null?
+        if (error) return callback(error, null);
+
         var unpacked = null;
         try {
             unpacked = self.unpackOutput(output);
         }
         catch (e) {
-            error = error || e;
+            error = e;
         }
-        finally {
-            callback(error, unpacked);
-        }
+
+        callback(error, unpacked);
     });
 };
 

--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -111,11 +111,20 @@ SolidityFunction.prototype.call = function () {
     if (!callback) {
         var output = this._eth.call(payload, defaultBlock);
         return this.unpackOutput(output);
-    } 
-        
+    }
+
     var self = this;
     this._eth.call(payload, defaultBlock, function (error, output) {
-        callback(error, self.unpackOutput(output));
+        // similar to the synchronous case, the caller should be able to handle this error.
+        // For example:
+        //    var contract = web3.eth.contract(abi).at(NONEXISTENT_ADDRESS);
+        //    contract.myField(); // BigNumber error can be caught by caller using try/catch
+        //    contract.myField(function(err, result){...}); // err should be propagated to callback
+        try {
+            callback(error, self.unpackOutput(output));
+        } catch (e) {
+            callback(e, null);
+        }
     });
 };
 
@@ -197,11 +206,11 @@ SolidityFunction.prototype.request = function () {
     var callback = this.extractCallback(args);
     var payload = this.toPayload(args);
     var format = this.unpackOutput.bind(this);
-    
+
     return {
         method: this._constant ? 'eth_call' : 'eth_sendTransaction',
         callback: callback,
-        params: [payload], 
+        params: [payload],
         format: format
     };
 };


### PR DESCRIPTION
When making a call to a contract initialized with web3.eth.contract(abi).at(address) I couldn't find a way to recover from unpacking errors when using a callback:

This fix catches any possible error during unpacking and propagates it to the callback.

```
// Works
var contract = web3.eth.contract(abi).at(NONEXISTENT_ADDRESS);
contract.myField(); // unpacking error can be caught by caller using try/catch

// Does not work
var contract = web3.eth.contract(abi).at(NONEXISTENT_ADDRESS);
contract.myField(function(err, result){
   // this code is never reached, app crashes with:
   // BigNumber Error: new BigNumber() not a base 16 number:
}); 

// With proposed fix
var contract = web3.eth.contract(abi).at(NONEXISTENT_ADDRESS);
contract.myField(function(err, result){
    // err has a reference to the BigNumber err
}); 
```
