### PR TITLE
Missing some checks in order to verify if given value is an object

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -523,7 +523,7 @@ var isFunction = function (object) {
  * @return {Boolean}
  */
 var isObject = function (object) {
-    return typeof object === 'object';
+    return object !== null && !(object instanceof Array) && typeof object === 'object';
 };
 
 /**


### PR DESCRIPTION
### Assumptions made:
- It's not good to return or bubble null values.  ( typeof null returns actually "object") so if null is passed to this function it will return yes and the value will be used for further calculations
- Since there is explicit check if a value is an array, we don't need to have 2 functions to return the answer when provided same value. (typeof [] also evaluates to "object")