### PR TITLE
added signTransaction method to web3.eth

### DIFF
--- a/lib/web3/methods/eth.js
+++ b/lib/web3/methods/eth.js
@@ -61,12 +61,12 @@ function Eth(web3) {
 
     var self = this;
 
-    methods().forEach(function(method) { 
+    methods().forEach(function(method) {
         method.attachToObject(self);
         method.setRequestManager(self._requestManager);
     });
 
-    properties().forEach(function(p) { 
+    properties().forEach(function(p) {
         p.attachToObject(self);
         p.setRequestManager(self._requestManager);
     });
@@ -202,6 +202,13 @@ var methods = function () {
         inputFormatter: [formatters.inputTransactionFormatter]
     });
 
+    var signTransaction = new Method({
+        name: 'signTransaction',
+        call: 'eth_signTransaction',
+        params: 1,
+        inputFormatter: [formatters.inputTransactionFormatter]
+    });
+
     var sign = new Method({
         name: 'sign',
         call: 'eth_sign',
@@ -270,6 +277,7 @@ var methods = function () {
         call,
         estimateGas,
         sendRawTransaction,
+        signTransaction,
         sendTransaction,
         sign,
         compileSolidity,
@@ -344,4 +352,3 @@ Eth.prototype.isSyncing = function (callback) {
 };
 
 module.exports = Eth;
-


### PR DESCRIPTION
It allows to sign offline transactions, already implemented by Geth and Parity in their RPC.

Testprc tests are not included because this wasn't implemented in TestRPC and TestRPC uses web3 for their tests, so, a PR to TestRPC as well.

Tested against Geth and Parity nodes.