### PR TITLE
Export padLeft and padRight as functions of web3

### DIFF
--- a/lib/web3.js
+++ b/lib/web3.js
@@ -100,6 +100,8 @@ Web3.prototype.isAddress = utils.isAddress;
 Web3.prototype.isChecksumAddress = utils.isChecksumAddress;
 Web3.prototype.toChecksumAddress = utils.toChecksumAddress;
 Web3.prototype.isIBAN = utils.isIBAN;
+Web3.prototype.padLeft = utils.padLeft;
+Web3.prototype.padRight = utils.padRight;
 
 
 Web3.prototype.sha3 = function(string, options) {


### PR DESCRIPTION
I'm working with `bytes12` and it's useful to have these two functions in the web3 object for formatting.