### PR TITLE
Add Parity signer module

### DIFF
--- a/lib/web3.js
+++ b/lib/web3.js
@@ -33,6 +33,7 @@ var Shh = require('./web3/methods/shh');
 var Net = require('./web3/methods/net');
 var Personal = require('./web3/methods/personal');
 var Swarm = require('./web3/methods/swarm');
+var Signer = require('./web3/methods/signer');
 var Settings = require('./web3/settings');
 var version = require('./version.json');
 var utils = require('./utils/utils');
@@ -45,7 +46,6 @@ var IpcProvider = require('./web3/ipcprovider');
 var BigNumber = require('bignumber.js');
 
 
-
 function Web3 (provider) {
     this._requestManager = new RequestManager(provider);
     this.currentProvider = provider;
@@ -55,6 +55,7 @@ function Web3 (provider) {
     this.net = new Net(this);
     this.personal = new Personal(this);
     this.bzz = new Swarm(this);
+    this.signer = new Signer(this);
     this.settings = new Settings();
     this.version = {
         api: version.version

--- a/lib/web3/methods/signer.js
+++ b/lib/web3/methods/signer.js
@@ -1,0 +1,61 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file signer.js
+ * @date 2017
+ */
+
+"use strict";
+
+var Method = require('../method');
+var Property = require('../property');
+var formatters = require('../formatters');
+
+function Signer(web3) {
+    this._requestManager = web3._requestManager;
+
+    var self = this;
+
+    methods().forEach(function(method) {
+        method.attachToObject(self);
+        method.setRequestManager(self._requestManager);
+    });
+
+    properties().forEach(function(p) {
+        p.attachToObject(self);
+        p.setRequestManager(self._requestManager);
+    });
+}
+
+var methods = function () {
+    return [
+    ];
+};
+
+var properties = function () {
+    var getPendingTransactions = new Property({
+        name: 'getPendingTransactions',
+        getter: 'signer_requestsToConfirm',
+    });
+
+    return [
+        getPendingTransactions
+    ];
+};
+
+
+module.exports = Signer;

--- a/lib/web3/methods/signer.js
+++ b/lib/web3/methods/signer.js
@@ -47,13 +47,13 @@ var methods = function () {
 };
 
 var properties = function () {
-    var getPendingTransactions = new Property({
-        name: 'getPendingTransactions',
+    var requestsToConfirm = new Property({
+        name: 'requestsToConfirm',
         getter: 'signer_requestsToConfirm',
     });
 
     return [
-        getPendingTransactions
+        requestsToConfirm
     ];
 };
 

--- a/lib/web3/methods/signer.js
+++ b/lib/web3/methods/signer.js
@@ -42,11 +42,58 @@ function Signer(web3) {
 }
 
 var methods = function () {
+    /**
+     * Confirms a request in the signer queue
+     */
+    var confirmRequest = new Method({
+        name: 'confirmRequest',
+        call: 'signer_confirmRequest',
+        params: 3,
+        inputFormatter: [null, null, null]
+    });
+
+    /**
+     * Confirms a request in the signer queue providing signed request
+     */
+    var confirmRequestRaw = new Method({
+        name: 'confirmRequestRaw',
+        call: 'signer_confirmRequestRaw',
+        params: 2,
+        inputFormatter: [null, null]
+    });
+
+    /**
+     * Confirms specific request with token
+     */
+    var confirmRequestWithToken = new Method({
+        name: 'confirmRequestWithToken',
+        call: 'signer_confirmRequestWithToken',
+        params: 3,
+        inputFormatter: [null, null, null]
+    });
+
+    /**
+     * Rejects a request in the signer queue
+     */
+    var rejectRequest = new Method({
+        name: 'rejectRequest',
+        call: 'signer_rejectRequest',
+        params: 1,
+        inputFormatter: [null]
+    });
+
     return [
+        confirmRequest,
+        confirmRequestRaw,
+        confirmRequestWithToken,
+        rejectRequest
     ];
 };
 
 var properties = function () {
+    /**
+     * Transactions awaiting authorization
+     */
     var requestsToConfirm = new Property({
         name: 'requestsToConfirm',
         getter: 'signer_requestsToConfirm',


### PR DESCRIPTION
It's the module exclusive to Parity that handle the transaction sign. I am not sure if it's justified to be included in this library. But this library really helps a lot in my automatically contract pipeline. 

This PR is currently without the test suite, but I've tested it with the latest Parity RPC. I'll add more test suites and docs if it's to be incorporated into Web3. 