### PR TITLE
Fix for "filterCreationErrorCallback is not a function" Error #552

### DIFF
--- a/lib/web3/filter.js
+++ b/lib/web3/filter.js
@@ -150,7 +150,9 @@ var Filter = function (requestManager, options, methods, formatter, callback, fi
             self.callbacks.forEach(function(cb){
                 cb(error);
             });
-            filterCreationErrorCallback(error);
+            if (typeof filterCreationErrorCallback === 'function') {
+              filterCreationErrorCallback(error);
+            }
         } else {
             self.filterId = id;
 

--- a/lib/web3/methods/eth.js
+++ b/lib/web3/methods/eth.js
@@ -335,8 +335,8 @@ Eth.prototype.contract = function (abi) {
     return factory;
 };
 
-Eth.prototype.filter = function (fil, callback) {
-    return new Filter(this._requestManager, fil, watches.eth(), formatters.outputLogFormatter, callback);
+Eth.prototype.filter = function (fil, callback, filterCreationErrorCallback) {
+    return new Filter(this._requestManager, fil, watches.eth(), formatters.outputLogFormatter, callback, filterCreationErrorCallback);
 };
 
 Eth.prototype.namereg = function () {


### PR DESCRIPTION
Fixes the "filterCreationErrorCallback" exception by passing in a callback function from the wrapper function in `lib/web3/methods/eth.js`. 

If no "filterCreationErrorCallback" function is provided the function call is not executed. This guarantees backwards compatibility without failing.