### PR TITLE
validate number of args to solidity functions

### DIFF
--- a/lib/web3/errors.js
+++ b/lib/web3/errors.js
@@ -21,8 +21,11 @@
  */
 
 module.exports = {
-    InvalidNumberOfParams: function () {
-        return new Error('Invalid number of input parameters');
+    InvalidNumberOfSolidityArgs: function () {
+        return new Error('Invalid number of arguments to Solidity function');
+    },
+    InvalidNumberOfRPCParams: function () {
+        return new Error('Invalid number of input parameters to RPC method');
     },
     InvalidConnection: function (host){
         return new Error('CONNECTION ERROR: Couldn\'t connect to node '+ host +'.');

--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -22,6 +22,7 @@
 
 var coder = require('../solidity/coder');
 var utils = require('../utils/utils');
+var errors = require('./errors');
 var formatters = require('./formatters');
 var sha3 = require('../utils/sha3');
 
@@ -55,6 +56,23 @@ SolidityFunction.prototype.extractDefaultBlock = function (args) {
 };
 
 /**
+ * Should be called to check if the number of arguments is correct
+ *
+ * @method validateArgs
+ * @param {Array} arguments
+ * @throws {Error} if it is not
+ */
+SolidityFunction.prototype.validateArgs = function (args) {
+    var inputArgs = args.filter(function (a) {
+      // filter the options object but not arguments that are arrays
+      return !(utils.isObject(a) === true && utils.isArray(a) === false);
+    });
+    if (inputArgs.length !== this._inputTypes.length) {
+        throw errors.InvalidNumberOfSolidityArgs();
+    }
+};
+
+/**
  * Should be used to create payload from arguments
  *
  * @method toPayload
@@ -66,6 +84,7 @@ SolidityFunction.prototype.toPayload = function (args) {
     if (args.length > this._inputTypes.length && utils.isObject(args[args.length -1])) {
         options = args[args.length - 1];
     }
+    this.validateArgs(args);
     options.to = this._address;
     options.data = '0x' + this.signature() + coder.encodeParams(this._inputTypes, args);
     return options;
@@ -259,4 +278,3 @@ SolidityFunction.prototype.attachToContract = function (contract) {
 };
 
 module.exports = SolidityFunction;
-

--- a/lib/web3/method.js
+++ b/lib/web3/method.js
@@ -69,7 +69,7 @@ Method.prototype.extractCallback = function (args) {
  */
 Method.prototype.validateArgs = function (args) {
     if (args.length !== this.params) {
-        throw errors.InvalidNumberOfParams();
+        throw errors.InvalidNumberOfRPCParams();
     }
 };
 
@@ -162,4 +162,3 @@ Method.prototype.request = function () {
 };
 
 module.exports = Method;
-

--- a/test/method.validateArgs.js
+++ b/test/method.validateArgs.js
@@ -39,9 +39,8 @@ describe('lib/web3/method', function () {
             var test2 = function () { method.validateArgs(args2); };
             
             // then
-            assert.throws(test, errors.InvalidNumberOfParams().message);
-            assert.throws(test2, errors.InvalidNumberOfParams().message);
+            assert.throws(test, errors.InvalidNumberOfRPCParams().message);
+            assert.throws(test2, errors.InvalidNumberOfRPCParams().message);
         });
     });
 });
-


### PR DESCRIPTION
This adds a validation check so that an error is thrown if a solidity function is called (or a sendTransaction executed) without the correct number of function arguments.