### PR TITLE
Minor change to RegExp, so it adheres to spec

### DIFF
--- a/lib/solidity/address.js
+++ b/lib/solidity/address.js
@@ -20,7 +20,7 @@ SolidityTypeAddress.prototype = new SolidityType({});
 SolidityTypeAddress.prototype.constructor = SolidityTypeAddress;
 
 SolidityTypeAddress.prototype.isType = function (name) {
-    return !!name.match(/address(\[([0-9]*)\])?/);
+    return !!name.match(/address(\[([0-9]*)\])*/);
 };
 
 module.exports = SolidityTypeAddress;


### PR DESCRIPTION
The spec says:

```
SolidityTypeAddress is a prootype that represents address type
It matches:
address
address[]
address[4]
address[][]
address[3][]
address[][6][], ...
```