### PR TITLE
git+https   on package dependency has problems in some systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+    "bignumber.js": "https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
     "crypto-js": "^3.1.4",
     "utf8": "^2.1.1",
     "xhr2": "*",


### PR DESCRIPTION
why git+https?  this creates conflicts in systems  without the proper helper (i.e. Debian 8) 

$ git clone git+https://github.com/debris/bignumber.js.git
Cloning into 'bignumber.js'...
fatal: Unable to find remote helper for 'git+https'
$ git clone https://github.com/debris/bignumber.js.git
Cloning into 'bignumber.js'...
remote: Counting objects: 468, done.
^Cceiving objects:  22% (103/468), 372.00 KiB | 168.00 KiB/s