### PR TITLE
Update meteor installation instructions to something that works

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install web3
 ### Meteor.js
 
 ```bash
-meteor add ethereum:web3
+meteor npm install --save web3
 ```
 
 ### As Browser module


### PR DESCRIPTION
Several users have pointed out an issue with the meteor installations instructions for a significantly long amount of time. There seems to be no attempt to fix this by the developers. Instead of shunning an entire platform away, we should provide a way for meteor developers to include the package or remove it entirely.
issues:
https://github.com/ethereum/web3.js/issues/546
https://github.com/ethereum/web3.js/issues/883
https://github.com/ethereum/web3.js/issues/864