### PR TITLE
Remove incorrect address formatter from transaction argument

### DIFF
--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -243,7 +243,7 @@ var methods = function () {
         name: 'getTransaction',
         call: 'eth_getTransactionByHash',
         params: 1,
-        inputFormatter: [formatters.inputAddressFormatter],
+        inputFormatter: [null],
         outputFormatter: formatters.outputTransactionFormatter
     });
 


### PR DESCRIPTION
This function doesn't work with an address validator since transaction hashes are 64 characters long which does not validate as an address which is 40. Also, tests might be needed to ensure methods have correct input and output formatters.