### PR TITLE
Use lerna without hardcoding a path

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "./test"
   },
   "scripts": {
-    "postinstall": "./node_modules/lerna/bin/lerna.js bootstrap",
+    "postinstall": "lerna bootstrap",
     "build": "gulp",
     "watch": "gulp watch",
     "docs": "cd docs; make html;",


### PR DESCRIPTION
Causing that `node_modules/.bin/lerna` is used instead of hardcoding a path which is a source or recent issues with beta version: https://github.com/ethereum/web3.js/issues/938, https://github.com/ethereum/web3.js/issues/933