### PR TITLE
fix Windows issue with lerna, fix issue with method.call method.send by converting from arguments from map to array

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "./test"
   },
   "scripts": {
-    "postinstall": "node node_modules/lerna/bin/lerna.js bootstrap",
+    "postinstall": "lerna bootstrap",
     "build": "gulp",
     "watch": "gulp watch",
     "docs": "cd docs; make html;",

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -342,7 +342,7 @@ Contract.prototype._decodeEventABI = function (data) {
  */
 Contract.prototype._encodeMethodABI = function _encodeMethodABI() {
     var methodSignature = this._method.signature,
-        args = this.arguments;
+        args = Array.from(this.arguments);
 
     var signature = false,
         paramsABI = this._parent.options.jsonInterface.filter(function (json) {


### PR DESCRIPTION
lerna doesn't seem to be able to be called correctly on windows through even adding node to the front. so i recommend just augmenting the installation instructions to "node install lerna -g" for windows.

as for the Array.from fix, it was necessary to interact with any of the contracts methods either via real sendTransaction or just calls.