### PR TITLE
Fix external links in the docs

### DIFF
--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -982,7 +982,7 @@ Parameters
   - ``value`` - ``Number|String|BN|BigNumber``: (optional) The value transferred for the transaction in :ref:`wei <what-is-wei>`, also the endowment if it's a contract-creation transaction.
   - ``gas``  - ``Number``: (optional, default: To-Be-Determined) The amount of gas to use for the transaction (unused gas is refunded).
   - ``gasPrice`` - ``Number|String|BN|BigNumber``: (optional) The price of gas for this transaction in :ref:`wei <what-is-wei>`, defaults to :ref:`web3.eth.gasPrice <eth-gasprice>`.
-  - ``data`` - ``String``: (optional) Either a `ABI byte string <https://github.com/ethereum/wiki/wiki/Solidity,-Docs-and-ABI>`_ containing the data of the function call on a contract, or in the case of a contract-creation transaction the initialisation code.
+  - ``data`` - ``String``: (optional) Either a `ABI byte string <http://solidity.readthedocs.io/en/latest/abi-spec.html>`_ containing the data of the function call on a contract, or in the case of a contract-creation transaction the initialisation code.
   - ``nonce`` - ``Number``: (optional) Integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
 2. ``callback`` - ``Function``: (optional) Optional callback, returns an error object as first parameter and the result as second.
 

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -982,7 +982,7 @@ Parameters
   - ``value`` - ``Number|String|BN|BigNumber``: (optional) The value transferred for the transaction in :ref:`wei <what-is-wei>`, also the endowment if it's a contract-creation transaction.
   - ``gas``  - ``Number``: (optional, default: To-Be-Determined) The amount of gas to use for the transaction (unused gas is refunded).
   - ``gasPrice`` - ``Number|String|BN|BigNumber``: (optional) The price of gas for this transaction in :ref:`wei <what-is-wei>`, defaults to :ref:`web3.eth.gasPrice <eth-gasprice>`.
-  - ``data`` - ``String``: (optional) Either a `ABI byte string <https://github.com/ethereum/wiki/wiki/Solidity,-Docs-and-ABI`_ containing the data of the function call on a contract, or in the case of a contract-creation transaction the initialisation code.
+  - ``data`` - ``String``: (optional) Either a `ABI byte string <https://github.com/ethereum/wiki/wiki/Solidity,-Docs-and-ABI>`_ containing the data of the function call on a contract, or in the case of a contract-creation transaction the initialisation code.
   - ``nonce`` - ``Number``: (optional) Integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce.
 2. ``callback`` - ``Function``: (optional) Optional callback, returns an error object as first parameter and the result as second.
 
@@ -1648,4 +1648,3 @@ Example
 
 
 ------------------------------------------------------------------------------
-

--- a/docs/web3-utils.rst
+++ b/docs/web3-utils.rst
@@ -97,7 +97,7 @@ BN
     web3.utils.BN(mixed)
 
 The `BN.js <https://github.com/indutny/bn.js/>`_ library for calculating with big numbers in JavaScript.
-See the `BN.js documentation <https://github.com/indutny/bn.js/` for details.
+See the `BN.js documentation <https://github.com/indutny/bn.js/>`_ for details.
 
 .. note:: For safe conversion of many types, incl `BigNumber.js <http://mikemcl.github.io/bignumber.js/>`_ use :ref:`utils.toBN <utils-tobn>`
 

--- a/docs/web3-utils.rst
+++ b/docs/web3-utils.rst
@@ -17,7 +17,7 @@ randomHex
 
     web3.utils.randomHex(size)
 
-The `randomHex <https://github.com/frozeman/randomHex`_ library to generate cryptographically strong pseudo-random HEX strings from a given byte size.
+The `randomHex <https://github.com/frozeman/randomHex>`_ library to generate cryptographically strong pseudo-random HEX strings from a given byte size.
 
 ----------
 Parameters
@@ -64,9 +64,9 @@ _
 
     web3.utils._()
 
-The `underscore <http://underscorejs.org`_ library for many convenience JavaScript functions.
+The `underscore <http://underscorejs.org>`_ library for many convenience JavaScript functions.
 
-See the `underscore API reference <http://underscorejs.org`_ for details.
+See the `underscore API reference <http://underscorejs.org>`_ for details.
 
 -------
 Example
@@ -96,10 +96,10 @@ BN
 
     web3.utils.BN(mixed)
 
-The `BN.js <https://github.com/indutny/bn.js/`_ library for calculating with big numbers in JavaScript.
+The `BN.js <https://github.com/indutny/bn.js/>`_ library for calculating with big numbers in JavaScript.
 See the `BN.js documentation <https://github.com/indutny/bn.js/` for details.
 
-.. note:: For safe conversion of many types, incl `BigNumber.js <http://mikemcl.github.io/bignumber.js/`_ use :ref:`utils.toBN <utils-tobn>`
+.. note:: For safe conversion of many types, incl `BigNumber.js <http://mikemcl.github.io/bignumber.js/>`_ use :ref:`utils.toBN <utils-tobn>`
 
 ----------
 Parameters
@@ -111,7 +111,7 @@ Parameters
 Returns
 -------
 
-``Object``: The `BN.js <https://github.com/indutny/bn.js/`_ instance.
+``Object``: The `BN.js <https://github.com/indutny/bn.js/>`_ instance.
 
 -------
 Example
@@ -141,14 +141,14 @@ isBN
     web3.utils.isBN(bn)
 
 
-Checks if a given value is a `BN.js <https://github.com/indutny/bn.js/`_ instance.
+Checks if a given value is a `BN.js <https://github.com/indutny/bn.js/>`_ instance.
 
 
 ----------
 Parameters
 ----------
 
-1. ``bn`` - ``Object``: An `BN.js <https://github.com/indutny/bn.js/`_ instance.
+1. ``bn`` - ``Object``: An `BN.js <https://github.com/indutny/bn.js/>`_ instance.
 
 -------
 Returns
@@ -178,14 +178,14 @@ isBigNumber
     web3.utils.isBigNumber(bignumber)
 
 
-Checks if a given value is a `BigNumber.js <http://mikemcl.github.io/bignumber.js/`_ instance.
+Checks if a given value is a `BigNumber.js <http://mikemcl.github.io/bignumber.js/>`_ instance.
 
 
 ----------
 Parameters
 ----------
 
-1. ``bignumber`` - ``Object``: A `BigNumber.js <http://mikemcl.github.io/bignumber.js/`_ instance.
+1. ``bignumber`` - ``Object``: A `BigNumber.js <http://mikemcl.github.io/bignumber.js/>`_ instance.
 
 -------
 Returns
@@ -560,9 +560,9 @@ toBN
 
     web3.utils.toBN(number)
 
-Will safly convert any given value (including `BigNumber.js <http://mikemcl.github.io/bignumber.js/`_ instances) into a `BN.js <https://github.com/indutny/bn.js/`_ instance, for handling big numbers in JavaScript.
+Will safly convert any given value (including `BigNumber.js <http://mikemcl.github.io/bignumber.js/>`_ instances) into a `BN.js <https://github.com/indutny/bn.js/>`_ instance, for handling big numbers in JavaScript.
 
-.. note:: For just the `BN.js <https://github.com/indutny/bn.js/`_ class use :ref:`utils.BN <utils-bn>`
+.. note:: For just the `BN.js <https://github.com/indutny/bn.js/>`_ class use :ref:`utils.BN <utils-bn>`
 
 ----------
 Parameters
@@ -574,7 +574,7 @@ Parameters
 Returns
 -------
 
-``Object``: The `BN.js <https://github.com/indutny/bn.js/`_ instance.
+``Object``: The `BN.js <https://github.com/indutny/bn.js/>`_ instance.
 
 -------
 Example
@@ -923,7 +923,7 @@ toWei
     web3.utils.toWei(number [, unit])
 
 
-Converts any `ether value <http://ethdocs.org/en/latest/ether.html>`_ value into `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na`_.
+Converts any `ether value <http://ethdocs.org/en/latest/ether.html>`_ value into `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na>`_.
 
 .. note:: "wei" are the smallest ethere unit, and you should always make calculations in wei and convert only for display reasons.
 
@@ -965,7 +965,7 @@ Parameters
 Returns
 -------
 
-``String|BN``: If a number, or string is given it returns a number string, otherwise a `BN.js <https://github.com/indutny/bn.js/`_ instance.
+``String|BN``: If a number, or string is given it returns a number string, otherwise a `BN.js <https://github.com/indutny/bn.js/>`_ instance.
 
 -------
 Example
@@ -997,7 +997,7 @@ fromWei
     web3.utils.fromWei(number [, unit])
 
 
-Converts any `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na`_ value into a `ether value <http://ethdocs.org/en/latest/ether.html>`_.
+Converts any `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na>`_ value into a `ether value <http://ethdocs.org/en/latest/ether.html>`_.
 
 .. note:: "wei" are the smallest ethere unit, and you should always make calculations in wei and convert only for display reasons.
 
@@ -1039,7 +1039,7 @@ Parameters
 Returns
 -------
 
-``String|BN``: If a number, or string is given it returns a number string, otherwise a `BN.js <https://github.com/indutny/bn.js/`_ instance.
+``String|BN``: If a number, or string is given it returns a number string, otherwise a `BN.js <https://github.com/indutny/bn.js/>`_ instance.
 
 -------
 Example
@@ -1069,7 +1069,7 @@ unitMap
     web3.utils.unitMap
 
 
-Shows all possible `ether value <http://ethdocs.org/en/latest/ether.html>`_ and their amount in `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na`_.
+Shows all possible `ether value <http://ethdocs.org/en/latest/ether.html>`_ and their amount in `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na>`_.
 
 ----------
 Retrun value


### PR DESCRIPTION
Fixes some external links in the docs, which have ">" missing in the syntax and updates the ABI link under sendTransaction