### PR TITLE
call contract method and return null if result is 0x

### DIFF
--- a/packages/web3-eth-abi/src/types/formatters.js
+++ b/packages/web3-eth-abi/src/types/formatters.js
@@ -206,7 +206,7 @@ var formatOutputString = function (param) {
     var hex = param.dynamicPart().slice(0, 64);
     if(hex) {
         var length = (new BN(hex, 16)).toNumber() * 2;
-        return utils.hexToUtf8('0x'+ param.dynamicPart().substr(64, length).replace(/^0x/i, ''));
+        return length ? utils.hexToUtf8('0x'+ param.dynamicPart().substr(64, length).replace(/^0x/i, '')) : '';
     } else {
         return "ERROR: Strings are not yet supported as return values";
     }

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -817,7 +817,9 @@ Contract.prototype._executeMethod = function _executeMethod(){
 
                 // add output formatter for decoding
                 this._parent._ethereumCall.call.method.outputFormatter = function (result) {
-                    if(result) {
+                    if (result === '0x') {
+                        result = null;
+                    } else if (result) {
                         result = _this._parent._decodeMethodReturn(_this._method.outputs, result);
                     }
                     return result;


### PR DESCRIPTION
if str is string type and null value
```JavaScript
contract.methods.str().call((err, result) => {
  console.log(err); // null
  console.log(result); // ERROR: Strings are not yet supported as return values
});
```
after patch
```JavaScript
contract.methods.str().call((err, result) => {
  console.log(err); // null
  console.log(result); // null
});
```
if addr is address type and null value
```JavaScript
contract.methods.addr().call((err, result) => {});
```
throw exception
```
/Users/emn178/myproject/node_modules/web3/packages/web3-utils/src/index.js:234
        throw new Error('Given address "'+ address +'" is not a valid Ethereum address.');
        ^

Error: Given address "0x" is not a valid Ethereum address.
```
after patch
```JavaScript
contract.methods.addr().call((err, result) => {
  console.log(err); // null
  console.log(result); // null
});
```