### PR TITLE
Change default and add comma

### DIFF
--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -68,8 +68,8 @@ Example
 .. code-block:: javascript
 
     var myContract = new web3.eth.Contract([...], '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe', {
-        from: '0x1234567890123456789012345678901234567891' // default from address
-        gasPrice: '20000000000000' // default gas price in wei
+        from: '0x1234567890123456789012345678901234567891', // default from address
+        gasPrice: 20000000000 // default gas price in wei
     });
 
 


### PR DESCRIPTION
I blindly copy/pasted initialization of new contract and it has 20,000 gwei for GasPrice.
In order to save some money to other people, I think we should set 20 gwei as default.
I also added missing comma there.
Also, we don't need numbers in strings, it could be just numbers.

```
web3.toWei(20, 'gwei')
"20000000000"
```