### PR TITLE
Decouple wallet.length from other wallet functions (add, encrypt, clear)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,14 +60,14 @@
     }
   ],
   "devDependencies": {
-    "@types/bignumber.js":"^4.0.2",
-    "@types/underscore":"^1.8.0",
+    "@types/bignumber.js": "^4.0.2",
+    "@types/underscore": "^1.8.0",
     "babel-preset-env": "^1.6.0",
     "bignumber.js": "^4.0.0",
     "bn.js": "^4.11.6",
     "bower": ">=1.4.1",
     "browserify": "^14.4.0",
-    "chai": "^3.0.0",
+    "chai": "^4.0.0",
     "coveralls": "^2.11.2",
     "crypto-js": "^3.1.4",
     "del": ">=2.0.2",

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -320,6 +320,15 @@ function Wallet(accounts) {
     this.defaultKeyName = "web3js_wallet";
 }
 
+Wallet.prototype._findSafeIndex = function (pointer) {
+    pointer = pointer || 0;
+    if (_.has(this, pointer)) {
+        return this._findSafeIndex(pointer + 1);
+    } else {
+        return pointer;
+    }
+};
+
 Wallet.prototype.create = function (numberOfAccounts, entropy) {
     for (var i = 0; i < numberOfAccounts; ++i) {
         this.add(this._accounts.create(entropy).privateKey);
@@ -334,9 +343,9 @@ Wallet.prototype.add = function (account) {
     }
     if (!this[account.address]) {
         account = this._accounts.privateKeyToAccount(account.privateKey);
-        account.index = this.length;
+        account.index = this._findSafeIndex();
 
-        this[this.length] = account;
+        this[account.index] = account;
         this[account.address] = account;
         this[account.address.toLowerCase()] = account;
 

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -329,6 +329,15 @@ Wallet.prototype._findSafeIndex = function (pointer) {
     }
 };
 
+Wallet.prototype._currentIndexes = function () {
+    var keys = Object.keys(this);
+    var indexes = keys
+        .map(function(key) { return parseInt(key); })
+        .filter(function(n) { return (n < 9e20); });
+
+    return indexes;
+};
+
 Wallet.prototype.create = function (numberOfAccounts, entropy) {
     for (var i = 0; i < numberOfAccounts; ++i) {
         this.add(this._accounts.create(entropy).privateKey);
@@ -380,19 +389,23 @@ Wallet.prototype.remove = function (addressOrIndex) {
 };
 
 Wallet.prototype.clear = function () {
-    var length = this.length;
-    for (var i = 0; i < length; i++) {
-        this.remove(i);
-    }
+    var _this = this;
+    var indexes = this._currentIndexes();
+
+    indexes.forEach(function(index) {
+        _this.remove(index);
+    });
 
     return this;
 };
 
 Wallet.prototype.encrypt = function (password, options) {
-    var accounts = [];
-    for (var i = 0; i < this.length; i++) {
-        accounts[i] = this[i].encrypt(password, options);
-    }
+    var indexes = this._currentIndexes();
+
+    var accounts = indexes.map(function(index) {
+        this[index].encrypt(password, options);
+    });
+
     return accounts;
 };
 

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -400,10 +400,11 @@ Wallet.prototype.clear = function () {
 };
 
 Wallet.prototype.encrypt = function (password, options) {
+    var _this = this;
     var indexes = this._currentIndexes();
 
     var accounts = indexes.map(function(index) {
-        this[index].encrypt(password, options);
+        return _this[index].encrypt(password, options);
     });
 
     return accounts;

--- a/test/eth.accounts.wallet.js
+++ b/test/eth.accounts.wallet.js
@@ -169,11 +169,13 @@ describe("eth", function () {
                 assert.equal(ethAccounts.wallet.length, 0);
 
                 var wallet = ethAccounts.wallet.create(5);
+                var initialAddresses = [0,1,2,3,4].map(function(n) { return wallet[n].address } );
                 assert.equal(ethAccounts.wallet.length, 5);
 
                 var thirdAddress = ethAccounts.wallet[2].address;
                 var lastAddress = ethAccounts.wallet[4].address;
-                var addressesBeforeRemoval = [0,1,3].map(function(n) { return wallet[n].address } );
+                var remainingAddresses = [0,1,3];
+                var beforeRemoval = remainingAddresses.map(function(n) { return wallet[n].address } );
 
                 ethAccounts.wallet.remove(2);
                 ethAccounts.wallet.remove(4);
@@ -185,7 +187,7 @@ describe("eth", function () {
                 assert.isUndefined(ethAccounts.wallet[lastAddress]);
                 assert.isUndefined(ethAccounts.wallet[lastAddress.toLowerCase()]);
 
-                var addressesAfterRemoval = [0,1,3].map(function(n) { return wallet[n].address } );
+                var afterRemoval = remainingAddresses.map(function(n) { return wallet[n].address } );
 
                 assert.equal(ethAccounts.wallet._findSafeIndex(), 2);
                 assert.equal(ethAccounts.wallet.length, 3);
@@ -195,11 +197,13 @@ describe("eth", function () {
                 assert.isTrue(web3.utils.isAddress(wallet[4].address));
                 assert.isUndefined(ethAccounts.wallet[5]);
 
-                var addressesAfterCreation = [0,1,3].map(function(n) { return wallet[n].address } );
+                var afterMoreCreation = remainingAddresses.map(function(n) { return wallet[n].address } );
+                var newAddresses = [0,1,2,3,4].map(function(n) { return wallet[n].address } );
 
                 // Checks for account overwrites
-                assert.sameOrderedMembers(addressesBeforeRemoval, addressesAfterCreation, "same ordered members");
-                assert.sameOrderedMembers(addressesAfterRemoval, addressesAfterCreation, "same ordered members");
+                assert.sameOrderedMembers(beforeRemoval, afterMoreCreation, "same ordered members");
+                assert.sameOrderedMembers(afterRemoval, afterMoreCreation, "same ordered members");
+                assert.notSameMembers(initialAddresses, newAddresses, "not same members");
 
                 assert.equal(ethAccounts.wallet.length, 5);
             });

--- a/test/eth.accounts.wallet.js
+++ b/test/eth.accounts.wallet.js
@@ -262,6 +262,32 @@ describe("eth", function () {
 
 
                 assert.equal(ethAccounts.wallet.length, 0);
+            });
+
+            it("encrypt then decrypt wallet", function() {
+                var ethAccounts = new Accounts();
+                var password = "qwerty";
+
+                assert.equal(ethAccounts.wallet.length, 0);
+
+                var wallet = ethAccounts.wallet.create(5);
+                var addressFromWallet = ethAccounts.wallet[0].address;
+                assert.equal(ethAccounts.wallet.length, 5);
+
+                ethAccounts.wallet.remove(2);
+                assert.equal(ethAccounts.wallet.length, 4);
+
+                var keystore = ethAccounts.wallet.encrypt(password);
+                assert.equal(keystore.length, 4);
+
+                ethAccounts.wallet.clear();
+                assert.equal(ethAccounts.wallet.length, 0);
+
+                ethAccounts.wallet.decrypt(keystore, password);
+                assert.equal(ethAccounts.wallet.length, 4);
+
+                var addressFromKeystore = ethAccounts.wallet[0].address;
+                assert.equal(addressFromKeystore, addressFromWallet);
 
             });
         });

--- a/test/eth.accounts.wallet.js
+++ b/test/eth.accounts.wallet.js
@@ -165,12 +165,13 @@ describe("eth", function () {
             });
 
             it("create 5 wallets, remove two, create two more and check for overwrites", function() {
+                var count = 5;
                 var ethAccounts = new Accounts();
                 assert.equal(ethAccounts.wallet.length, 0);
 
-                var wallet = ethAccounts.wallet.create(5);
+                var wallet = ethAccounts.wallet.create(count);
                 var initialAddresses = [0,1,2,3,4].map(function(n) { return wallet[n].address } );
-                assert.equal(ethAccounts.wallet.length, 5);
+                assert.equal(ethAccounts.wallet.length, count);
 
                 var thirdAddress = ethAccounts.wallet[2].address;
                 var lastAddress = ethAccounts.wallet[4].address;
@@ -205,7 +206,7 @@ describe("eth", function () {
                 assert.sameOrderedMembers(afterRemoval, afterMoreCreation, "same ordered members");
                 assert.notSameMembers(initialAddresses, newAddresses, "not same members");
 
-                assert.equal(ethAccounts.wallet.length, 5);
+                assert.equal(ethAccounts.wallet.length, count);
             });
 
             it("clear wallet", function() {
@@ -220,6 +221,35 @@ describe("eth", function () {
                 for (var i = 0; i < count; i++) {
                     addresses.push(wallet[i].address);
                 }
+
+                ethAccounts.wallet.clear();
+
+                for (var i = 0; i < count; i++) {
+                    assert.isUndefined(ethAccounts.wallet[i]);
+                    assert.isUndefined(ethAccounts.wallet[addresses[i]]);
+                    assert.isUndefined(ethAccounts.wallet[addresses[i].toLowerCase()]);
+                }
+
+                assert.equal(ethAccounts.wallet.length, 0);
+            });
+
+            it("remove accounts then clear wallet", function() {
+                var count = 10;
+                var ethAccounts = new Accounts();
+                assert.equal(ethAccounts.wallet.length, 0);
+
+                var wallet = ethAccounts.wallet.create(count);
+                assert.equal(ethAccounts.wallet.length, count);
+
+                var addresses = [];
+                for (var i = 0; i < count; i++) {
+                    addresses.push(wallet[i].address);
+                }
+
+                ethAccounts.wallet.remove(0);
+                assert.isUndefined(ethAccounts.wallet[0])
+                ethAccounts.wallet.remove(5);
+                assert.isUndefined(ethAccounts.wallet[5])
 
                 ethAccounts.wallet.clear();
 

--- a/test/eth.accounts.wallet.js
+++ b/test/eth.accounts.wallet.js
@@ -164,6 +164,46 @@ describe("eth", function () {
 
             });
 
+            it("create 5 wallets, remove two, create two more and check for overwrites", function() {
+                var ethAccounts = new Accounts();
+                assert.equal(ethAccounts.wallet.length, 0);
+
+                var wallet = ethAccounts.wallet.create(5);
+                assert.equal(ethAccounts.wallet.length, 5);
+
+                var thirdAddress = ethAccounts.wallet[2].address;
+                var lastAddress = ethAccounts.wallet[4].address;
+                var addressesBeforeRemoval = [0,1,3].map(function(n) { return wallet[n].address } );
+
+                ethAccounts.wallet.remove(2);
+                ethAccounts.wallet.remove(4);
+
+                assert.isUndefined(ethAccounts.wallet[2]);
+                assert.isUndefined(ethAccounts.wallet[thirdAddress]);
+                assert.isUndefined(ethAccounts.wallet[thirdAddress.toLowerCase()]);
+                assert.isUndefined(ethAccounts.wallet[4]);
+                assert.isUndefined(ethAccounts.wallet[lastAddress]);
+                assert.isUndefined(ethAccounts.wallet[lastAddress.toLowerCase()]);
+
+                var addressesAfterRemoval = [0,1,3].map(function(n) { return wallet[n].address } );
+
+                assert.equal(ethAccounts.wallet._findSafeIndex(), 2);
+                assert.equal(ethAccounts.wallet.length, 3);
+
+                ethAccounts.wallet.create(2);
+                assert.isTrue(web3.utils.isAddress(wallet[2].address));
+                assert.isTrue(web3.utils.isAddress(wallet[4].address));
+                assert.isUndefined(ethAccounts.wallet[5]);
+
+                var addressesAfterCreation = [0,1,3].map(function(n) { return wallet[n].address } );
+
+                // Checks for account overwrites
+                assert.sameOrderedMembers(addressesBeforeRemoval, addressesAfterCreation, "same ordered members");
+                assert.sameOrderedMembers(addressesAfterRemoval, addressesAfterCreation, "same ordered members");
+
+                assert.equal(ethAccounts.wallet.length, 5);
+            });
+
             it("clear wallet", function() {
                 var count = 10;
                 var ethAccounts = new Accounts();


### PR DESCRIPTION
See issue here #1077 

This adds a new function `web3.eth.accounts.wallet._findSafeIndex` which recursively counts up from 0 and finds the first unused index in the wallet, where `web3.eth.accounts.wallet.add()` will inject a new account.

An alternative fix for this error can be seen [here](https://github.com/cmditch/web3.js/commit/fd18778fdcc44e0c16f0ac0f8b2c410cd8c02f18), where instead of a new function, a new variable is added `wallet.pointerIndex` to keep track of a safe lower limit for future indexes.

Despite this recursive fix being O(n), and the alternative fix (linked above) and original `web3.eth.accounts.wallet.add()` being O(1), they all benchmark around the same @ ~1000ms for `wallet.create(500)`.

EDIT - 

Turns out `wallet.length`'s coupling to other primary wallet functions causes issues if `wallet.remove` has been used. 

This PR adds two new functions, `wallet._findSafeIndex` & `wallet._currentIndexes`, to help address these issues. `wallet.add`, `wallet.enrypt`, & `wallet.clear` refactored accordingly.

Tests have been added as well.

Chai version number was bumped to utilize chai's new array equality assertions.