### PR TITLE
isHex: '0x' prefix changed to be optional

### DIFF
--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -358,7 +358,7 @@ var toHex = function (value, returnType) {
  * @returns {Boolean}
  */
 var isHex = function (hex) {
-    return ((_.isString(hex) || _.isNumber(hex)) && /^(-)?0x[0-9a-f]*$/i.test(hex));
+    return ((_.isString(hex) || _.isNumber(hex)) && /^(-)?(0x)?[0-9a-f]*$/i.test(hex));
 };
 
 

--- a/test/utils.isHex.js
+++ b/test/utils.isHex.js
@@ -1,0 +1,30 @@
+var chai = require('chai');
+var utils = require('../packages/web3-utils');
+
+var assert = chai.assert;
+
+var tests = [
+    { value: function () {}, is: false},
+    { value: new Function(), is: false},
+    { value: 'function', is: false},
+    { value: {}, is: false},
+    { value: '0xc1912', is: true },
+    { value: 0xc1912, is: true },
+    { value: -0xc1912, is: true },
+    { value: 'c1912', is: true },
+    { value: '-c1912', is: true },
+    { value: 345, is: true },
+    { value: -345, is: true },
+    { value: '0xZ1912', is: false },
+    { value: 'Hello', is: false },
+];
+
+describe('lib/utils/utils', function () {
+    describe('isHex', function () {
+        tests.forEach(function (test) {
+            it('shoud test if value ' + test.value + ' is hex: ' + test.is, function () {
+                assert.equal(utils.isHex(test.value), test.is);
+            });
+        });
+    });
+});


### PR DESCRIPTION
added unit tests: utils.isHex.js
added all cases documented in web3-utils.rst - most were breaking but now pass