### PR TITLE
Add sign hash

### DIFF
--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -179,12 +179,23 @@ Accounts.prototype.hashMessage = function hashMessage(data) {
 };
 
 Accounts.prototype.sign = function sign(data, privateKey) {
-
     var hash = this.hashMessage(data);
     var signature = Account.sign(hash, privateKey);
     var vrs = Account.decodeSignature(signature);
     return {
         message: data,
+        messageHash: hash,
+        v: vrs[0],
+        r: vrs[1],
+        s: vrs[2],
+        signature: signature
+    };
+};
+
+Accounts.prototype.signHash = function signHash(hash, privateKey) {
+    var signature = Account.sign(hash, privateKey);
+    var vrs = Account.decodeSignature(signature);
+    return {
         messageHash: hash,
         v: vrs[0],
         r: vrs[1],

--- a/test/eth.accounts.signHash.js
+++ b/test/eth.accounts.signHash.js
@@ -1,0 +1,48 @@
+var Accounts = require("./../packages/web3-eth-accounts");
+var chai = require('chai');
+var assert = chai.assert;
+var Web3 = require('../packages/web3');
+var web3 = new Web3();
+
+var tests = [
+    {
+        address: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+        privateKey: '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728',
+        // hash of 'Some data'
+        messageHash: '0x1da44b586eb0729ff70a73c326926f6ed5a25f5b056e7f47fbc6e58d86871655',
+        // signature done with personal_sign
+        signature: '0xa8037a6116c176a25e6fc224947fde9e79a2deaa0dd8b67b366fbdfdbffc01f953e41351267b20d4a89ebfe9c8f03c04de9b345add4a52f15bd026b63c8fb1501b'
+    }, {
+        address: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+        privateKey: '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728',
+        // hash of 'Some data!%$$%&@*'
+        messageHash: '0x93e52d66afce102d3542a776a87f81cce8e7dfab6836b2911c836bfd9baf068d',
+        // signature done with personal_sign
+        signature: '0x05252412b097c5d080c994d1ea12abcee6f1cae23feb225517a0b691a66e12866b3f54292f9cfef98f390670b4d010fc4af7fcd46e41d72870602c117b14921c1c'
+    }
+];
+
+
+describe("eth", function () {
+    describe("accounts", function () {
+
+        tests.forEach(function (test, i) {
+            it("sign message hash", function() {
+                var ethAccounts = new Accounts();
+
+                var data = ethAccounts.signHash(test.messageHash, test.privateKey);
+
+                assert.equal(data.signature, test.signature);
+            });
+
+            it("recover signature using message hash", function() {
+                var ethAccounts = new Accounts();
+
+                var address = ethAccounts.recover(test.messageHash, test.signature);
+
+                assert.equal(address, test.address);
+            });
+
+        });
+    });
+});


### PR DESCRIPTION
This is useful when you want to sign a message of a `soliditySha3` hash with multiple inputs (which can then be validated in a smart contract with `ecrecover` using the same inputs). In this case, you don't have the original "data" to pass into `web3.eth.accounts.sign`, so a separate method `web3.eth.accounts.signHash` makes things easier.