### PR TITLE
Fixes in types definition

### DIFF
--- a/packages/web3/index.d.ts
+++ b/packages/web3/index.d.ts
@@ -25,4 +25,4 @@ declare class Web3 {
 
 }
 
-export = Web3
+export default Web3

--- a/packages/web3/types.d.ts
+++ b/packages/web3/types.d.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'bignumber.js' // TODO change to BN
+import { BigNumber } from 'bn.js'
 import * as us from 'underscore'
 
 
@@ -18,7 +18,7 @@ export declare interface JsonRPCResponse {
 
 type Callback<T> = (error: Error, result: T) => void
 type ABIDataTypes = "uint256" | "boolean" | "string" | "bytes" | string // TODO complete list
-export declare interface Provider {
+export declare interface IProvider {
   send(payload: JsonRPCRequest, callback: (e: Error, val: JsonRPCResponse) => void)
 }
 type PromiEventType = "transactionHash" | "receipt" | "confirmation" | "error"
@@ -232,9 +232,23 @@ export declare interface Tx {
   gasPrice?: string | number
 
 }
-export declare interface WebsocketProvider extends Provider { }
-export declare interface HttpProvider extends Provider { }
-export declare interface IpcProvider extends Provider { }
+export declare interface WebsocketProvider extends IProvider {
+  responseCallbacks: object
+  notificationCallbacks: [() => any]
+  connection: {
+    onclose(e: any): void,
+    onmessage(e: any): void,
+    onerror(e?: any): void
+  }
+  addDefaultEvents: () => void
+  on(type: string, callback: () => any): void
+  removeListener(type: string, callback: () => any): void
+  removeAllListeners(type: string): void
+  reset(): void
+}
+export declare interface HttpProvider extends IProvider { }
+export declare interface IpcProvider extends IProvider { }
+export type Provider = WebsocketProvider & IpcProvider & HttpProvider
 type Unit = "kwei" | "femtoether" | "babbage" | "mwei" | "picoether" | "lovelace" | "qwei" | "nanoether" | "shannon" | "microether" | "szabo" | "nano" | "micro" | "milliether" | "finney" | "milli" | "ether" | "kether" | "grand" | "mether" | "gether" | "tether"
 export type BlockType = "latest" | "pending" | "genesis" | number
 export declare interface Iban { }
@@ -422,4 +436,3 @@ export declare class BatchRequest {
   add(request: Request): void //
   execute(): void
 }
-


### PR DESCRIPTION
Complements #1131 and fixes some issues that broke my code after implementation of type definitons

- Create default export 
- Change `bignumber.js` to `bn.js`
- Change `Provider` interface to `IProvider` and create `Provider` type, which is a union of all the 3 providers (HttpProvider & IpcProvider & WebsocketProvider)
- Implement WebsocketProvider interface according to the current version (branch 1.0) of `web3-providers-ws`