### PR TITLE
Add getPastEvents to Contract type

### DIFF
--- a/packages/web3/types.d.ts
+++ b/packages/web3/types.d.ts
@@ -94,7 +94,7 @@ export declare interface EventLog {
   transactionHash: string
   blockHash: string
   blockNumber: number
-  raw?: { data: string, topics: any[] }
+  raw?: { data: string, topics: string[] }
 }
 export declare interface TransactionReceipt {
   transactionHash: string
@@ -329,9 +329,9 @@ export declare interface Contract {
     [eventName: string]: (options?: {
       filter?: object
       fromBlock?: BlockType
-      topics?: any[]
+      topics?: string[]
     }, cb?: Callback<EventLog>) => EventEmitter
-    allEvents: (options?: { filter?: object, fromBlock?: BlockType, topics?: any[] }, cb?: Callback<EventLog>) => EventEmitter
+    allEvents: (options?: { filter?: object, fromBlock?: BlockType, topics?: string[] }, cb?: Callback<EventLog>) => EventEmitter
   },
   getPastEvents(
     event: string,
@@ -339,9 +339,10 @@ export declare interface Contract {
       filter?: object,
       fromBlock?: BlockType,
       toBlock?: BlockType,
-      topics?: any[]
+      topics?: string[]
     },
-    cb?: Callback<EventLog[]>): Promise<EventLog[]>
+    cb?: Callback<EventLog[]>
+  ): Promise<EventLog[]>
 }
 export declare interface Request { }
 export declare interface Providers {

--- a/packages/web3/types.d.ts
+++ b/packages/web3/types.d.ts
@@ -332,8 +332,16 @@ export declare interface Contract {
       topics?: any[]
     }, cb?: Callback<EventLog>) => EventEmitter
     allEvents: (options?: { filter?: object, fromBlock?: BlockType, topics?: any[] }, cb?: Callback<EventLog>) => EventEmitter
-  }
-
+  },
+  getPastEvents(
+    event: string,
+    options?: {
+      filter?: object,
+      fromBlock?: BlockType,
+      toBlock?: BlockType,
+      topics?: any[]
+    },
+    cb?: Callback<EventLog[]>): Promise<EventLog[]>
 }
 export declare interface Request { }
 export declare interface Providers {


### PR DESCRIPTION
On types.d.ts, Contract type was missing getPastEvents method. This PR adds it, and also fix some topics events parameter type to be a string array, instead of `any[]`.