### PR TITLE
Using 'export =' instead of 'export default' in main typescript definition for fixing #1121

### DIFF
--- a/packages/web3/index.d.ts
+++ b/packages/web3/index.d.ts
@@ -22,7 +22,6 @@ declare class Web3 {
   providers: t.Providers
   setProvider(provider: t.Provider): void
   utils: t.Utils
-
 }
 
-export default Web3
+export = Web3;


### PR DESCRIPTION
At the moment if you are using TS and importing web3 with:
* `import Web3 from 'web3';`  => TS definitions work but you get `TypeError: web3_1.default is not a constructor` in runtime.
* `import Web3 = require('web3');` or `import * as Web3 from 'web3';` => the code works but TS definitions doesn't work and you end up with `error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.` in TS compilation.

The cause for this is TS expects a ES6 module definitions inside the `index.js` file. Although it's returning the class itself through CommonJS (this is the standard node behaviour, normally preprocessors like Babel can work around this but in TS it's optional and can cause some problems with environments which are not using any loaders). With this fix the typescript definitions point out the right output type (which is the class not the module) therefore it can be imported properly by using `import Web3 = require('web3');`. I've tried to make it work as `import * as Web3 from 'web3';` which is more appropriate but typescript doesn't allow classes as direct and throws out `error TS2309: An export assignment cannot be used in a module with other exported elements.`

**TL;DR** TS doesn't allow exporting a class as the module hence creating various problems with a module compiled in CommonJS but imported as ES6. With this PR it's possible to use all the type definitions with the `import Web3 = require('web3');` import instruction just like mentioned in #1121.