### PR TITLE
empty string handling for asciiToHex

### DIFF
--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -138,6 +138,8 @@ var hexToAscii = function(hex) {
  * @returns {String} hex representation of input string
  */
 var asciiToHex = function(str) {
+    if(!str)
+        return "0x00";
     var hex = "";
     for(var i = 0; i < str.length; i++) {
         var code = str.charCodeAt(i);


### PR DESCRIPTION
Will return 0x00 for empty inputs.

0x was giving me inconsistent results while sending the contract deploy (if multiple 0x arguments in array). So, I used 0x00.