### PR TITLE
Add call to callback in WebsocketProvider.prototype.send on error

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -216,6 +216,7 @@ WebsocketProvider.prototype.send = function (payload, callback) {
         } else {
             console.error('no error callback');
         }
+        callback(new Error('connection not open'));
         return;
     }
 


### PR DESCRIPTION
When calling `send(payload, callback)` on a `WebsocketProvider` object, if the connection is not open the error is logged to the console but the `callback` is never called with such an error. As a consequence, the error is not bubbled up in the callbacks chain and the original caller never gets any indication of such an error condition.

This can be reproduced by trying to connect to an incorrect/misspelled URL or if the node is not up or running the WebSocket interface. 

Currently, only "connection not open on send()" is logged to console. With this change, `callback` is called with the error 'connection is not open'.

Related issues: #989