### PR TITLE
Parity compatibility

### DIFF
--- a/lib/web3/contract.js
+++ b/lib/web3/contract.js
@@ -117,7 +117,7 @@ var checkForContractAddress = function(contract, callback){
             } else {
 
                 contract._eth.getTransactionReceipt(contract.transactionHash, function(e, receipt){
-                    if(receipt && !callbackFired) {
+                    if(receipt && receipt.blockHash && !callbackFired) {
 
                         contract._eth.getCode(receipt.contractAddress, function(e, code){
                             /*jshint maxcomplexity: 6 */
@@ -178,7 +178,7 @@ var ContractFactory = function (eth, abi) {
      */
     this.new = function () {
         /*jshint maxcomplexity: 7 */
-        
+
         var contract = new Contract(this.eth, this.abi);
 
         // parse arguments


### PR DESCRIPTION
> Truffle expects null returned as receipt when transaction is still pending, parity returns normal receipt but with blockHash == null.
(https://github.com/Neufund/parity-instant-seal-byzantium-enabled#deployment-with-truffle)

This change was already proposed by @MarcoGuarducci(https://github.com/ethereum/web3.js/pull/1028) 
But we really need to merge it as soon as possible because it fixes following issues:
https://github.com/paritytech/parity/issues/5538
https://github.com/trufflesuite/truffle-migrate/issues/15
https://github.com/trufflesuite/truffle/issues/558