### PR TITLE
Update the Documentation of methods.myMethod.send

### DIFF
--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -531,6 +531,7 @@ Parameters
     * ``from`` - ``String``: The address the transaction should be sent from.
     * ``gasPrice`` - ``String`` (optional): The gas price in wei to use for this transaction.
     * ``gas`` - ``Number`` (optional): The maximum gas provided for this transaction (gas limit).
+    * ``value`` - ``Number|String|BN|BigNumber``(optional): The value transferred for the transaction in wei.
 2. ``callback`` - ``Function`` (optional): This callback will be fired first with the "transactionHash", or with an error object as the first argument.
 
 -------


### PR DESCRIPTION
Add a value option, so its is clear that this function can also be used to send ether in conjunction with contract method calls.