### PR TITLE
Checks input type string to avoid confusing error

### DIFF
--- a/packages/web3-eth-abi/src/formatters.js
+++ b/packages/web3-eth-abi/src/formatters.js
@@ -103,6 +103,10 @@ var formatInputDynamicBytes = function (value) {
  * @returns {SolidityParam}
  */
 var formatInputString = function (value) {
+    if(!_.isString(value)) {
+        throw new Error('Given parameter is not a valid string: "'+ value + '"');
+    }
+
     var result = utils.utf8ToHex(value).replace(/^0x/i,'');
     var length = result.length / 2;
     var l = Math.floor((result.length + 63) / 64);

--- a/packages/web3-eth-abi/src/formatters.js
+++ b/packages/web3-eth-abi/src/formatters.js
@@ -104,7 +104,7 @@ var formatInputDynamicBytes = function (value) {
  */
 var formatInputString = function (value) {
     if(!_.isString(value)) {
-        throw new Error('Given parameter is not a valid string: "'+ value + '"');
+        throw new Error('Given parameter is not a valid string: ' + value);
     }
 
     var result = utils.utf8ToHex(value).replace(/^0x/i,'');


### PR DESCRIPTION
When the constructor is called with non-string values we get this confusing error:
```
// Tk.sol
function Tk(uint256 initialSupply, string tokenName, string tokenSymbol)

// app.js
let d = self.contract.deploy({data: "", arguments: [1000000000000000, null, "tk"]});
```


```
TypeError: Cannot read property 'length' of undefined
    at ucs2decode (/Users/samsonradu/Workspace/eth/node_modules/utf8/utf8.js:26:23)
    at Object.utf8encode [as encode] (/Users/samsonradu/Workspace/eth/node_modules/utf8/utf8.js:104:20)
    at Object.utf8ToHex (/Users/samsonradu/Workspace/eth/node_modules/web3-utils/src/utils.js:168:16)
    at SolidityTypeString.formatInputString [as _inputFormatter] (/Users/samsonradu/Workspace/eth/node_modules/web3-eth-abi/src/formatters.js:106
:24)
    at SolidityTypeString.SolidityType.encode (/Users/samsonradu/Workspace/eth/node_modules/web3-eth-abi/src/type.js:188:17)
    at /Users/samsonradu/Workspace/eth/node_modules/web3-eth-abi/src/index.js:255:29
    at Array.map (<anonymous>)
    at ABICoder.encodeParameters (/Users/samsonradu/Workspace/eth/node_modules/web3-eth-abi/src/index.js:254:34)
    at /Users/samsonradu/Workspace/eth/node_modules/web3-eth-contract/src/index.js:420:24
    at Array.map (<anonymous>)
    at Object._encodeMethodABI (/Users/samsonradu/Workspace/eth/node_modules/web3-eth-contract/src/index.js:419:12)
    at Object._processExecuteArguments (/Users/samsonradu/Workspace/eth/node_modules/web3-eth-contract/src/index.js:735:39)
    at Object._executeMethod (/Users/samsonradu/Workspace/eth/node_modules/web3-eth-contract/src/index.js:760:54)
    at Contract.deploy (/Users/samsonradu/Workspace/eth/lib/contract.js:37:18)
    at Object.<anonymous> (/Users/samsonradu/Workspace/eth/create.js:14:3)
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Function.Module.runMain (module.js:682:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:613:3
```

Checking for a valid string will at least output:

```
Error: Given parameter is not a valid string: undefined
    at SolidityTypeString.formatInputString [as _inputFormatter] (/Users/samsonradu/Workspace/eth/node_modules/web3-eth-abi/src/formatters.js:107:15)
...
```