### PR TITLE
treat RLP 'r' and 's' fields as quantity, not string

### DIFF
--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -151,15 +151,15 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
         var rawTx = RLP.decode(rlpEncoded).slice(0, 6).concat(Account.decodeSignature(signature));
 
         var trimLeadingZero = function (hex) {
-            while (hex && hex.startsWith('0x0')) {
-                hex = '0x' + hex.slice(3);
+            while (hex && hex.startsWith('0x00')) {
+                hex = '0x' + hex.slice(4);
             }
             return hex;
-        };
+        }
         rawTx[7] = trimLeadingZero(rawTx[7]);
         rawTx[8] = trimLeadingZero(rawTx[8]);
 
-        var rawTransaction = RLP.encode(rawTx);
+        var rawTransaction = RLP.encode(rawTx)
 
         var values = RLP.decode(rawTransaction);
         var result = {

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -146,10 +146,20 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
 
         var hash = Hash.keccak256(rlpEncoded);
 
-
         var signature = Account.makeSigner(Nat.toNumber(transaction.chainId || "0x1") * 2 + 35)(Hash.keccak256(rlpEncoded), privateKey);
-        var rawTx = RLP.decode(rlpEncoded).slice(0,6).concat(Account.decodeSignature(signature));
-        var rawTransaction = RLP.encode(rawTx);
+
+        var rawTx = RLP.decode(rlpEncoded).slice(0, 6).concat(Account.decodeSignature(signature));
+
+        var trimLeadingZero = function (hex) {
+            while (hex && hex.startsWith('0x00')) {
+                hex = '0x' + hex.slice(4);
+            }
+            return hex;
+        }
+        rawTx[7] = trimLeadingZero(rawTx[7]);
+        rawTx[8] = trimLeadingZero(rawTx[8]);
+
+        var rawTransaction = RLP.encode(rawTx)
 
         var values = RLP.decode(rawTransaction);
         var result = {

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -151,15 +151,15 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
         var rawTx = RLP.decode(rlpEncoded).slice(0, 6).concat(Account.decodeSignature(signature));
 
         var trimLeadingZero = function (hex) {
-            while (hex && hex.startsWith('0x00')) {
-                hex = '0x' + hex.slice(4);
+            while (hex && hex.startsWith('0x0')) {
+                hex = '0x' + hex.slice(3);
             }
             return hex;
-        }
+        };
         rawTx[7] = trimLeadingZero(rawTx[7]);
         rawTx[8] = trimLeadingZero(rawTx[8]);
 
-        var rawTransaction = RLP.encode(rawTx)
+        var rawTransaction = RLP.encode(rawTx);
 
         var values = RLP.decode(rawTransaction);
         var result = {


### PR DESCRIPTION
This fixes #1170 by using the patch provided by @ldn0x7dc in that issue
