### PR TITLE
Return r, s, and v without leading 0's

### DIFF
--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -42,14 +42,14 @@ var isNot = function(value) {
 };
 
 var trimLeadingZero = function (hex) {
-    while (hex && hex.startsWith('0x00')) {
-        hex = '0x' + hex.slice(4);
+    while (hex && hex.startsWith('0x0')) {
+        hex = '0x' + hex.slice(3);
     }
     return hex;
 };
 
 var makeEven = function (hex) {
-    if(hex % 2 === 1) {
+    if(hex.length % 2 === 1) {
         hex = hex.replace('0x', '0x0');
     }
     return hex;
@@ -165,17 +165,17 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
 
         var rawTx = RLP.decode(rlpEncoded).slice(0, 6).concat(Account.decodeSignature(signature));
 
-        rawTx[7] = trimLeadingZero(rawTx[7]);
-        rawTx[8] = trimLeadingZero(rawTx[8]);
+        rawTx[7] = makeEven(trimLeadingZero(rawTx[7]));
+        rawTx[8] = makeEven(trimLeadingZero(rawTx[8]));
 
         var rawTransaction = RLP.encode(rawTx);
 
         var values = RLP.decode(rawTransaction);
         var result = {
             messageHash: hash,
-            v: makeEven(values[6]),
-            r: makeEven(values[7]),
-            s: makeEven(values[8]),
+            v: trimLeadingZero(values[6]),
+            r: trimLeadingZero(values[7]),
+            s: trimLeadingZero(values[8]),
             rawTransaction: rawTransaction
         };
         if (_.isFunction(callback)) {

--- a/test/eth.accounts.signTransaction.js
+++ b/test/eth.accounts.signTransaction.js
@@ -27,6 +27,27 @@ var tests = [
         oldSignature: "0xf868808504a817c80082520894f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008026a0afa02d193471bb974081585daabf8a751d4decbb519604ac7df612cc11e9226da04bf1bd55e82cebb2b09ed39bbffe35107ea611fa212c2d9a1f1ada4952077118"
     },
     {
+        address: '0x2c7536E3605D9C16a7a3D7b1898e529396a65c23',
+        iban: 'XE0556YCRTEZ9JALZBSCXOK4UJ5F3HN03DV',
+        privateKey: '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
+        transaction: {
+            chainId: 1,
+            nonce: 0,
+            gasPrice: "234567897654321",
+            gas: 2000000,
+            to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
+            toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
+            value: "1000000000",
+            data: ""
+        },
+        // expected r and s values from signature
+        r: "0x9ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c",
+        s: "0x440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428",
+        // signature from eth_signTransaction
+        rawTransaction: "0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428",
+        oldSignature: "0xf86a8086d55698372431831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a009ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9ca0440ffd775ce91a833ab410777204d5341a6f9fa91216a6f3ee2c051fea6a0428"
+    },
+    {
         address: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
         iban: 'XE25RG8S3H5TX5RD7QTL5UPVW90AHN2VYDC',
         privateKey: '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728',
@@ -79,6 +100,20 @@ describe("eth", function () {
                 
 
                 assert.equal(tx.rawTransaction, test.rawTransaction);
+            });
+        });
+
+        tests.forEach(function (test, i) {
+            it("signTransaction must produce r and s as quantities, not data", function() {
+                if (!('r' in test)) {
+                    return ;
+                }
+                var ethAccounts = new Accounts();
+
+                var signature = ethAccounts.signTransaction(test.transaction, test.privateKey);
+
+                assert.equal(signature.r, test.r);
+                assert.equal(signature.s, test.s);
             });
         });
 


### PR DESCRIPTION
These values are [quantities, not data](https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding). Other nodes return r, s, and v as hex-encoded quantites.

See #1170 