### PR TITLE
ts definition file now contains a ctor that matches the docs

### DIFF
--- a/packages/web3/index.d.ts
+++ b/packages/web3/index.d.ts
@@ -10,7 +10,7 @@ declare class Web3 {
     Shh: new (provider: t.Provider) => t.Shh
     Bzz: new (provider: t.Provider) => t.Bzz
   }
-  constructor(provider: t.Provider | string)
+  constructor(provider?: t.Provider | string)
   version: string
   BatchRequest: new () => t.BatchRequest
   extend(methods: any): any // TODO


### PR DESCRIPTION
In the documentation you should be able to do:
```typescript
import Web3 = require('web3');
const web3 = new Web3();
```
But the compiler complains that:

> Expected 1 arguments, but got 0.

This PR fixes that.