### PR TITLE
fixed the signature of the decodeParameters functions

### DIFF
--- a/packages/web3/types.d.ts
+++ b/packages/web3/types.d.ts
@@ -370,7 +370,7 @@ export declare class Eth {
     encodeFunctionCall(jsonInterface: object, parameters: any[]): string
     encodeFunctionSignature(name: string | object): string
     decodeParameter(type: string, hex: string): any
-    decodeParameters(types: string[], hex: string): any
+    decodeParameters(types: string[] | { name: string; type: string; }[], hex: string): any
   }
   accounts: {
     'new'(entropy?: string): Account


### PR DESCRIPTION
According to the docs this function can be called with either:
```javascript
web3.eth.abi.decodeParameters(['string', 'uint256'], ...
```
Or:
```javascript
web3.eth.abi.decodeParameters([{
    type: 'string',
    name: 'myString'
},{
    type: 'uint256',
    name: 'myNumber'
}], ...
```

But doing this latter in ts results in:

 > Argument of type '{ type: string; name: string; }[]' is not assignable to parameter of type 'string[]'.
 >    Type '{ type: string; name: string; }' is not assignable to type 'string'.

This PR fixes that.