### PR TITLE
Ability to sign hex string

### DIFF
--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -216,13 +216,15 @@ Accounts.prototype.recoverTransaction = function recoverTransaction(rawTx) {
 /* jshint ignore:end */
 
 Accounts.prototype.hashMessage = function hashMessage(data) {
-    var message = utils.isHexStrict(data) ? utils.hexToUtf8(data) : data;
-    var ethMessage = "\x19Ethereum Signed Message:\n" + message.length + message;
+    var message = utils.isHexStrict(data) ? utils.hexToBytes(data) : data;
+    var messageBuffer = Buffer.from(message);
+    var preamble = "\x19Ethereum Signed Message:\n" + message.length;
+    var preambleBuffer = Buffer.from(preamble);
+    var ethMessage = Buffer.concat([preambleBuffer, messageBuffer]);
     return Hash.keccak256s(ethMessage);
 };
 
 Accounts.prototype.sign = function sign(data, privateKey) {
-
     var hash = this.hashMessage(data);
     var signature = Account.sign(hash, privateKey);
     var vrs = Account.decodeSignature(signature);
@@ -242,9 +244,8 @@ Accounts.prototype.recover = function recover(hash, signature) {
         return this.recover(hash.messageHash, Account.encodeSignature([hash.v, hash.r, hash.s]));
     }
 
-    if (!utils.isHexStrict(hash)) {
-        hash = this.hashMessage(hash);
-    }
+    if (!utils.isHexStrict(hash))
+        throw new Error('The parameter "'+ hash +'" must be a valid HEX string.');
 
     if (arguments.length === 4) {
         return this.recover(hash, Account.encodeSignature([].slice.call(arguments, 1, 4))); // v, r, s

--- a/test/eth.accounts.sign.js
+++ b/test/eth.accounts.sign.js
@@ -17,6 +17,12 @@ var tests = [
         data: 'Some data!%$$%&@*',
         // signature done with personal_sign
         signature: '0x05252412b097c5d080c994d1ea12abcee6f1cae23feb225517a0b691a66e12866b3f54292f9cfef98f390670b4d010fc4af7fcd46e41d72870602c117b14921c1c'
+    }, {
+        address: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+        privateKey: '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728',
+        data: '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+        // signature done with personal_sign
+        signature: '0xddd493679d80c9c74e0e5abd256a496dfb31b51cd39ea2c7c9e8a2a07de94a90257107a00d9cb631bacb85b208d66bfa7a80c639536b34884505eff352677dd01c'
     }
 ];
 
@@ -36,7 +42,8 @@ describe("eth", function () {
             it("sign data using a utf8 encoded hex string", function() {
                 var ethAccounts = new Accounts();
 
-                var data = ethAccounts.sign(web3.utils.utf8ToHex(test.data), test.privateKey);
+                var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
+                var data = ethAccounts.sign(data, test.privateKey);
 
                 assert.equal(data.signature, test.signature);
             });
@@ -45,7 +52,7 @@ describe("eth", function () {
             it("recover signature using a string", function() {
                 var ethAccounts = new Accounts();
 
-                var address = ethAccounts.recover(test.data, test.signature);
+                var address = ethAccounts.recover(ethAccounts.hashMessage(test.data), test.signature);
 
                 assert.equal(address, test.address);
             });
@@ -61,7 +68,8 @@ describe("eth", function () {
             it("recover signature (pre encoded) using a signature object", function() {
                 var ethAccounts = new Accounts();
 
-                var sig = ethAccounts.sign(web3.utils.utf8ToHex(test.data), test.privateKey);
+                var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
+                var sig = ethAccounts.sign(data, test.privateKey);
                 var address = ethAccounts.recover(sig);
 
                 assert.equal(address, test.address);
@@ -79,8 +87,9 @@ describe("eth", function () {
             it("recover signature (pre encoded) using a hash and r s v values", function() {
                 var ethAccounts = new Accounts();
 
-                var sig = ethAccounts.sign(web3.utils.utf8ToHex(test.data), test.privateKey);
-                var address = ethAccounts.recover(test.data, sig.v, sig.r, sig.s);
+                var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
+                var sig = ethAccounts.sign(data, test.privateKey);
+                var address = ethAccounts.recover(ethAccounts.hashMessage(test.data), sig.v, sig.r, sig.s);
 
                 assert.equal(address, test.address);
             });
@@ -89,7 +98,7 @@ describe("eth", function () {
                 var ethAccounts = new Accounts();
 
                 var sig = ethAccounts.sign(test.data, test.privateKey);
-                var address = ethAccounts.recover(test.data, sig.v, sig.r, sig.s);
+                var address = ethAccounts.recover(ethAccounts.hashMessage(test.data), sig.v, sig.r, sig.s);
 
                 assert.equal(address, test.address);
             });


### PR DESCRIPTION
**What was broken:**
Referencing #1168. Trying to sign a raw hex string (results of a keccak256 hash for example) with `web3.eth.accounts.sign` will throw an `Invalid continuation byte` error. This is because of this line: https://github.com/ethereum/web3.js/blob/dd55daa6cd54a3907457169425bcd5e29bf32ec4/packages/web3-eth-accounts/src/index.js#L219 The above line assumes that any hex string passed to the `hashMessage` function is utf8 encodable. The results of a keccak256 hash are not utf8 encodable (Maybe the number is too large or something. I'm not an expert on bytes and encodings so I may not be saying this correctly!). 

However, the ability to sign a hex string (specifically the results of a keccak256 hash) is important functionality. Say I have a state-channel contract and I want to hash some pre-image values, and then sign the resulting hash. Attempting this with the current implementation throws an error since `msg` is not a utf8 encodable hex string.

```javascript
var msg = web3.utils.soliditySha3(
      {type: 'address', value: some.address}
      {type: 'uint256', value: some.value},
);
var sig = web3.eth.accounts.sign(msg, some.privateKey);
``` 

**How it was fixed:**
Two fixes were made in this PR. 
(1) `web3.eth.accounts.hashMessage` will now break data into Buffers and performs a keccak256 hash on on the Buffer data.
(2) The existing implementation of`web3.eth.accounts.recover` allows users to pass in either the pre-image message or the hashed-message. This is incompatible with allowing hex strings that are not utf8 encodable to be pre-image values. This method was changed to only allow hashed-messages to be passed as arguments. This can be seen as the mirror image of the `web3.eth.accounts.sign` method, which only allows pre-images to be passed as arguments.
To sum up, users should pass pre-images to `sign` and message-hashes to `recover`. I believe that This is in line with how `web3.py` works.
