### PR TITLE
Emit error if subscription fails to start

### DIFF
--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -296,6 +296,7 @@ Subscription.prototype.subscribe = function() {
             _this.callback(err, null, _this);
             _this.emit('error', err);
         } else {
+            // emit the event even if no callback was provided
             _this.emit('error', err);
         }
     });

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -295,6 +295,8 @@ Subscription.prototype.subscribe = function() {
         } else if (_.isFunction(_this.callback)) {
             _this.callback(err, null, _this);
             _this.emit('error', err);
+        } else {
+            _this.emit('error', err);
         }
     });
 


### PR DESCRIPTION
When `web3.eth.subscription` is called but for some reason the subscription cannot be established, i.e. `web3`was given a websocket provider with a wrong address or the node is down, the error should be sent to the caller either through the callback or the `error` event. But if no callback is given, the `error` event is not event emitted. 

The following code shows how to reproduce the issue mentioned:

```js
const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://invalidaddress'))

web3.eth.subscribe('newBlockHeaders', function (err) {
    console.log('Error will be captured here')
})

web3.eth.subscribe('newBlockHeaders', function (err) {
    console.log('Error will be captured here too')
}).on('error', function (err) {
    console.log('Error will not be captured here as a callback was given')
})

web3.eth.subscribe('newBlockHeaders').on('error', function (err) {
    console.log('Error will not be captured here')
})
```

With the change proposed in this PR, the `error` handler properly receives the subscription error even when no callback is provided.