### PR TITLE
Fix eth.accounts types

### DIFF
--- a/packages/web3/types.d.ts
+++ b/packages/web3/types.d.ts
@@ -379,7 +379,7 @@ export declare class Eth {
     decodeParameters(types: EthAbiDecodeParametersType[], hex: string): EthAbiDecodeParametersResultObject
   }
   accounts: {
-    'new'(entropy?: string): Account
+    create(entropy?: string): Account
     privateKeyToAccount(privKey: string): Account
     publicToAddress(key: string): string
     signTransaction(tx: Tx, privateKey: string, returnSignature?: boolean, cb?: (err: Error, result: string | Signature) => void): Promise<string> | Signature
@@ -389,7 +389,7 @@ export declare class Eth {
     encrypt(privateKey: string, password: string): PrivateKey
     decrypt(privateKey: PrivateKey, password: string): Account
     wallet: {
-      'new'(numberOfAccounts: number, entropy: string): Account[]
+      create(numberOfAccounts: number, entropy: string): Account[]
       add(account: string | Account): any
       remove(account: string | number): any
       save(password: string, keyname?: string): string


### PR DESCRIPTION
Deference of method name between types file and original javascript code.

**JavaScript code**

https://github.com/ethereum/web3.js/blob/3c333f11cd2740188e24e8cebc431ca8019848e3/packages/web3-eth-accounts/src/index.js#L124-L126

https://github.com/ethereum/web3.js/blob/3c333f11cd2740188e24e8cebc431ca8019848e3/packages/web3-eth-accounts/src/index.js#L419-L424

**Types files**

https://github.com/ethereum/web3.js/blob/84781da85d30ae1cdc3dd45e78477cdb713dbd75/packages/web3/types.d.ts#L381-L399