### PR TITLE
Use fromUtf8 in web3.toHex

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -269,7 +269,7 @@ var toHex = function (val) {
         else if(val.indexOf('0x') === 0)
             return val;
         else if (!isFinite(val))
-            return fromAscii(val);
+            return fromUtf8(val);
     }
 
     return fromDecimal(val);

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -145,18 +145,24 @@ var toAscii = function(hex) {
  *
  * @method fromUtf8
  * @param {String} string
- * @param {Number} optional padding
+ * @param {Boolean} allowZero to convert code point zero to 00 instead of end of string
  * @returns {String} hex representation of input string
  */
-var fromUtf8 = function(str) {
+var fromUtf8 = function(str, allowZero) {
     str = utf8.encode(str);
     var hex = "";
     for(var i = 0; i < str.length; i++) {
         var code = str.charCodeAt(i);
-        if (code === 0)
-            break;
-        var n = code.toString(16);
-        hex += n.length < 2 ? '0' + n : n;
+        if (code === 0) {
+            if (allowZero) {
+                hex += '00';
+            } else {
+                break;
+            }
+        } else {
+            var n = code.toString(16);
+            hex += n.length < 2 ? '0' + n : n;
+        }
     }
 
     return "0x" + hex;
@@ -269,7 +275,7 @@ var toHex = function (val) {
         else if(val.indexOf('0x') === 0)
             return val;
         else if (!isFinite(val))
-            return fromUtf8(val);
+            return fromUtf8(val,1);
     }
 
     return fromDecimal(val);

--- a/test/utils.fromUtf8.js
+++ b/test/utils.fromUtf8.js
@@ -6,6 +6,8 @@ var assert = chai.assert;
 var tests = [
     { value: 'myString', expected: '0x6d79537472696e67'},
     { value: 'myString\x00', expected: '0x6d79537472696e67'},
+    { value: '我能吞下玻璃而不伤身体。', expected: '0xe68891e883bde5909ee4b88be78ebbe79283e8808ce4b88de4bca4e8baabe4bd93e38082'},
+    { value: '나는 유리를 먹을 수 있어요. 그래도 아프지 않아요', expected: '0xeb8298eb8a9420ec9ca0eba6aceba5bc20eba8b9ec9d8420ec889820ec9e88ec96b4ec9a942e20eab7b8eb9e98eb8f8420ec9584ed9484eca78020ec958aec9584ec9a94' },
     { value: 'expected value\u0000\u0000\u0000', expected: '0x65787065637465642076616c7565'}
 ];
 

--- a/test/utils.toHex.js
+++ b/test/utils.toHex.js
@@ -33,7 +33,7 @@ var tests = [
     { value: true, expected: '0x1'},
     { value: false, expected: '0x0'},
     { value: '\u0003\u0000\u0000\u00005èÆÕL]\u0012|Î¾\u001a7«\u00052\u0011(ÐY\n<\u0010\u0000\u0000\u0000\u0000\u0000\u0000e!ßd/ñõì\f:z¦Î¦±ç·÷Í¢Ëß\u00076*\bñùC1ÉUÀé2\u001aÓB',
-      expected: '0x0300000035e8c6d54c5d127c9dcebe9e1a37ab9b05321128d097590a3c100000000000006521df642ff1f5ec0c3a7aa6cea6b1e7b7f7cda2cbdf07362a85088e97f19ef94331c955c0e9321ad386428c'}
+      expected: '0x0300000035c3a8c386c3954c5d127cc29dc38ec2bec29e1a37c2abc29b05321128c390c297590a3c100000000000006521c39f642fc3b1c3b5c3ac0c3a7ac2a6c38ec2a6c2b1c3a7c2b7c3b7c38dc2a2c38bc39f07362ac28508c28ec297c3b1c29ec3b94331c38955c380c3a9321ac393c28642c28c'}
 ];
 
 describe('lib/utils/utils', function () {

--- a/test/utils.toHex.js
+++ b/test/utils.toHex.js
@@ -28,6 +28,7 @@ var tests = [
     { value: {test: 'test'}, expected: '0x7b2274657374223a2274657374227d'},
     { value: '{"test": "test"}', expected: '0x7b2274657374223a202274657374227d'},
     { value: 'myString', expected: '0x6d79537472696e67'},
+    { value: '내가 제일 잘 나가', expected:'0xeb82b4eab08020eca09cec9dbc20ec9e9820eb8298eab080'},
     { value: new BigNumber(15), expected: '0xf'},
     { value: true, expected: '0x1'},
     { value: false, expected: '0x0'},


### PR DESCRIPTION
Fixes: https://github.com/ethereum/web3.js/issues/1179

This fixes an issue I am having where if I submit Korean `bytes` parameters through web3.js it sends garbage. It likely fixes other utf8 issues as well.

Before:
```
web3.toHex('내가 제일 잘 나가')
"0xb0b4ac0020c81cc77c20c79820b098ac00"
web3.toUtf8(web3.toHex('내가 제일 잘 나가'))
inpage.js:14308 Uncaught Error: Invalid UTF-8 detected
    at c (inpage.js:14308)
    at Object.decode (inpage.js:14308)
    at Proxy.toUtf8 (inpage.js:14308)
    at <anonymous>:1:6
```
After:
```
web3.toHex('내가 제일 잘 나가')
"0xeb82b4eab08020eca09cec9dbc20ec9e9820eb8298eab080"
web3.toUtf8(web3.toHex('내가 제일 잘 나가'))
"내가 제일 잘 나가"
```