### PR TITLE
TypeScript definition CommonJS compatibility

### DIFF
--- a/packages/web3/index.d.ts
+++ b/packages/web3/index.d.ts
@@ -25,3 +25,5 @@ declare class Web3 {
 }
 
 export default Web3;
+
+export = Web3;


### PR DESCRIPTION
TypeScript compiler generates "web3.default" to access  the `export default` value. However the underlying CommonJS module does not have a "default" property. 

TypeScript has supports the CommonJS module export pattern with this syntax:

```
// module.exports = foo
export = foo
```

