### PR TITLE
Fix: invalid params error while batch execution for contract methods.

### DIFF
--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -765,11 +765,12 @@ Contract.prototype._executeMethod = function _executeMethod(){
     if(args.generateRequest) {
 
         var payload = {
-            params: [formatters.inputCallFormatter.call(this._parent, args.options), formatters.inputDefaultBlockNumberFormatter.call(this._parent, args.defaultBlock)],
+            params: [formatters.inputCallFormatter.call(this._parent, args.options)],
             callback: args.callback
         };
 
         if(args.type === 'call') {
+            payload.params.push(formatters.inputDefaultBlockNumberFormatter.call(this._parent, args.defaultBlock));
             payload.method = 'eth_call';
             payload.format = this._parent._decodeMethodReturn.bind(null, this._method.outputs);
         } else {


### PR DESCRIPTION
[Root Cause]
While sending transaction to contract methods will always occurred
error: 'Invalid params: invalid length 2, expected fewer elements in
array.'

The problem is method 'eth_sendTransaction' only accepts one parameter,
however , it will get two parameters while making a batch request payload.