### PR TITLE
Add main file to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0-beta.30",
   "description": "Ethereum JavaScript API wrapper repository",
   "license": "LGPL-3.0",
+  "main": "./packages/web3/src/index.js",
   "directories": {
     "doc": "./doc",
     "test": "./test"


### PR DESCRIPTION
The `package.json` file doesn't have the main file, so is not possible to use this code directly from the repo (without npm). And that is useful especially when you are working with forks or testing functionality.