### PR TITLE
Add support for multiple events in subscriptions

### DIFF
--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -254,20 +254,25 @@ Subscription.prototype.subscribe = function() {
             // call callback on notifications
             _this.options.requestManager.addSubscription(_this.id, payload.params[0] , _this.options.type, function(err, result) {
 
-                // TODO remove once its fixed in geth
-                if(_.isArray(result))
-                    result = result[0];
-
-                var output = _this._formatOutput(result);
-
                 if (!err) {
-
-                    if(_.isFunction(_this.options.subscription.subscriptionHandler)) {
-                        return _this.options.subscription.subscriptionHandler.call(_this, output);
-                    } else {
-                        _this.emit('data', output);
+                    if (!_.isArray(result)) {
+                        result = [result];
                     }
 
+                    result.forEach(function(resultItem) {
+                        var output = _this._formatOutput(resultItem);
+
+                        if (_.isFunction(_this.options.subscription.subscriptionHandler)) {
+                            return _this.options.subscription.subscriptionHandler.call(_this, output);
+                        } else {
+                            _this.emit('data', output);
+                        }
+
+                        // call the callback, last so that unsubscribe there won't affect the emit above
+                        if (_.isFunction(_this.callback)) {
+                            _this.callback(null, output, _this);
+                        }
+                    });
                 } else {
                     // unsubscribe, but keep listeners
                     _this.options.requestManager.removeSubscription(_this.id);
@@ -287,11 +292,11 @@ Subscription.prototype.subscribe = function() {
                         });
                     }
                     _this.emit('error', err);
-                }
 
-                // call the callback, last so that unsubscribe there won't affect the emit above
-                if (_.isFunction(_this.callback)) {
-                    _this.callback(err, output, _this);
+                     // call the callback, last so that unsubscribe there won't affect the emit above
+                     if (_.isFunction(_this.callback)) {
+                        _this.callback(err, null, _this);
+                    }
                 }
             });
         } else if (_.isFunction(_this.callback)) {


### PR DESCRIPTION
The subscription handler was forcing the response to be a unique result, even when the result was an array of multiple objects (due multiple events).

This PR allows the handler to manage an array of responses. So any time multiple events were registered, the subscription will be able to handle all of them properly and emit the corresponding events.