### PR TITLE
Add Missing err param onmessage function (ws provider)

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -68,7 +68,7 @@ var WebsocketProvider = function WebsocketProvider(url)  {
             if(!id && result.method.indexOf('_subscription') !== -1) {
                 _this.notificationCallbacks.forEach(function(callback){
                     if(_.isFunction(callback))
-                        callback(result);
+                        callback(null, result);
                 });
 
                 // fire the callback


### PR DESCRIPTION
During the `onmessage` function of ws provider, a callback is called with a success result but the err param (`null`) is missing. So the success result is treated as an error. 