### PR TITLE
ERC-147: process.env.ETHEREUM_SOCKET default provider

### DIFF
--- a/lib/web3.js
+++ b/lib/web3.js
@@ -44,9 +44,8 @@ var HttpProvider = require('./web3/httpprovider');
 var IpcProvider = require('./web3/ipcprovider');
 var BigNumber = require('bignumber.js');
 
-
-
 function Web3 (provider) {
+    provider = provider || process.env.ETHEREUM_SOCKET;
     this._requestManager = new RequestManager(provider);
     this.currentProvider = provider;
     this.eth = new Eth(this);

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -1,0 +1,14 @@
+const chai = require('chai');
+const assert = chai.assert;
+const Web3 = require('../index');
+
+describe('lib/web3#constructor', () => {
+    it('should use ETHEREUM_SOCKET environment variable', () => {
+        const existingProvider = process.env.ETHEREUM_SOCKET;
+        const testProvider = 'ws://localhost:1337';
+        process.env.ETHEREUM_SOCKET = testProvider;
+        const web3 = new Web3();
+        assert.strictEqual(web3.currentProvider, testProvider);
+        process.env.ETHEREUM_SOCKET = existingProvider;
+    });
+});


### PR DESCRIPTION
This PR implements [ERC-147](https://github.com/ethereum/EIPs/issues/147) from [Milestone 1.0](https://github.com/ethereum/web3.js/milestone/3) and adds associated tests. Specifically, creating a new `Web3` instance uses `process.env.ETHEREUM_SOCKET` as a provider if no value is explicitly passed into the constructor.

Resolves #492 