### PR TITLE
Fixed the type for EventLog.returnValues

### DIFF
--- a/packages/web3/types.d.ts
+++ b/packages/web3/types.d.ts
@@ -88,7 +88,7 @@ export declare interface Transaction {
 export declare interface EventLog {
   event: string
   address: string
-  returnValues: object
+  returnValues: any
   logIndex: number
   transactionIndex: number
   transactionHash: string


### PR DESCRIPTION
Use `object` is inappropriate for `EventLog.returnValues` since reading any property of it will give "property doesn't exist" error. See http://www.typescriptlang.org/docs/handbook/basic-types.html .