### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ meteor add ethereum:web3
 ```
 
 ### As Browser module
+
+CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/web3@0.20.6/dist/web3.min.js"></script>
+```
+
 Bower
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ meteor add ethereum:web3
 CDN
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/web3@0.20.6/dist/web3.min.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/ethereum/web3.js/dist/web3.min.js"></script>
 ```
 
 Bower

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Ethereum JavaScript API, middleware to talk to a ethereum node over RPC",
   "main": "./index.js",
   "directories": {
-    "lib": "./lib"
+    "lib": "./lib",
+    "dist": "./dist"
   },
   "dependencies": {
     "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "description": "Ethereum JavaScript API, middleware to talk to a ethereum node over RPC",
   "main": "./index.js",
   "directories": {
-    "lib": "./lib",
-    "dist": "./dist"
+    "lib": "./lib"
   },
   "dependencies": {
     "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",


### PR DESCRIPTION
I added a [jsDelivr CDN](https://www.jsdelivr.com/package/npm/web3) link to your readme, so that people can use it directly without bower or component. jsDelivr is the fastest open-source CDN and updates automatically from npm. 

I also added dist folder to npm so that this continues to work after v1.0.0 is released.