### PR TITLE
Fix bignumber.js dependency version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "./dist/web3.min.js"
   ],
   "dependencies": {
-    "bignumber.js": ">=2.0.0",
+    "bignumber.js": ">=2.0.0 <=5.0.0",
     "crypto-js": "~3.1.4"
   },
   "repository": {


### PR DESCRIPTION
Currently, bignumber.js version is 6.0.0.
Some functions are changed and removed in 6.0.0.

web3.js should use under bignumber.js v6.0.0.