### PR TITLE
Add Basic Auth support in wss:// Websocket URL

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -27,17 +27,20 @@ var errors = require('web3-core-helpers').errors;
 
 var Ws = null;
 var _btoa = null;
-var _URL = null;
+var parseURL = null;
 if (typeof window !== 'undefined') {
     Ws = window.WebSocket;
     _btoa = btoa;
-    _URL = URL;
+    parseURL = function(url) {
+        return new URL(url);
+    };
 } else {
     Ws = require('websocket').w3cwebsocket;
     _btoa = function(str) {
       return Buffer(str).toString('base64');
     };
-    _URL = require('url').URL;
+    // Web3 supports Node.js 5, so we need to use the legacy URL API
+    parseURL = require('url').parse;
 }
 // Default connection ws://localhost:8546
 
@@ -51,7 +54,7 @@ var WebsocketProvider = function WebsocketProvider(url, headers)  {
     // The w3cwebsocket implementation does not support Basic Auth
     // username/password in the URL. So generate the basic auth header, and
     // pass through with any additional headers supplied in constructor
-    var parsedURL = new _URL(url);
+    var parsedURL = parseURL(url);
     headers = headers || {};
     if (parsedURL.username && parsedURL.password) {
         headers.authorization = 'Basic ' + _btoa(parsedURL.username + ':' + parsedURL.password);

--- a/test/provider.js
+++ b/test/provider.js
@@ -25,6 +25,10 @@ var tests = [{
     providerType: 'WebsocketProvider',
     package: Web3
 },{
+    providerParams: ['wss://user1:passw0rd@localhost:8546'],
+    providerType: 'WebsocketProvider',
+    package: Web3
+},{
     providerParams: ['/.ethereum/my/path/geth.ipc', net],
     providerType: 'IpcProvider',
     package: Web3


### PR DESCRIPTION
Basic Auth is not currently supported for the WebsocketProvider in Node.js (it works fine in HttpProvider).

I can see the Node.js package used does not support providing the Basic Auth within the URL syntax, so this PR parses the URL and adds an `Authorization` header explicitly.