### PR TITLE
Replace external github reference with internal

### DIFF
--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -1060,7 +1060,7 @@ sendSignedTransaction
 
     web3.eth.sendSignedTransaction(signedTransactionData [, callback])
 
-Sends an already signed transaction. For example can be signed using: `ethereumjs-accounts <https://github.com/SilentCicero/ethereumjs-accounts>`_
+Sends an already signed transaction, generated for example using :ref:`web3.eth.accounts.signTransaction <eth-accounts-signtransaction>`.
 
 ----------
 Parameters


### PR DESCRIPTION
Since web3 1.0 has a function for that, why link outside?