### PR TITLE
checking that window is defined is not always enough, we also need to…

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -28,7 +28,7 @@ var errors = require('web3-core-helpers').errors;
 var Ws = null;
 var _btoa = null;
 var parseURL = null;
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && typeof window.WebSocket !== 'undefined') {
     Ws = window.WebSocket;
     _btoa = btoa;
     parseURL = function(url) {


### PR DESCRIPTION
… check that window.WebSocket is actually a thing

I am using jsdom in our test env and `window` is defined in that context, without a `WebSocket`. Adding this check means that we revert to the node module if that is the case.