### PR TITLE
Use Node.js 6 API where possible for WSS URL

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -39,8 +39,18 @@ if (typeof window !== 'undefined') {
     _btoa = function(str) {
       return Buffer(str).toString('base64');
     };
-    // Web3 supports Node.js 5, so we need to use the legacy URL API
-    parseURL = require('url').parse;
+    var url = require('url');
+    if (url.URL) {
+        // Use the new Node 6+ API for parsing URLs that supports username/password
+        var URL = url.URL;
+        parseURL = function(url) {
+            return new URL(url);
+        };
+    }
+    else {
+        // Web3 supports Node.js 5, so fall back to the legacy URL API if necessary
+        parseURL = require('url').parse;
+    }
 }
 // Default connection ws://localhost:8546
 


### PR DESCRIPTION
Sorry @frozeman - the very last change in https://github.com/ethereum/web3.js/pull/1541 to allow the build to run with Node 5, broke the fix.
It seems that the legacy `parse()` API in Node 5 does not support username/password, so we need to use the `new URL()` API wherever it is available