### PR TITLE
Add ability to pass websocket protocol in via options.

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -70,11 +70,12 @@ var WebsocketProvider = function WebsocketProvider(url, options)  {
     // pass through with any additional headers supplied in constructor
     var parsedURL = parseURL(url);
     var headers = options.headers || {};
+    var protocol = options.protocol || undefined;
     if (parsedURL.username && parsedURL.password) {
         headers.authorization = 'Basic ' + _btoa(parsedURL.username + ':' + parsedURL.password);
     }
 
-    this.connection = new Ws(url, undefined, undefined, headers);
+    this.connection = new Ws(url, protocol, undefined, headers);
 
     this.addDefaultEvents();
 


### PR DESCRIPTION
# Secure WebSocket usage

This change will allow the `Sec-WebSocket-Protocol` header to be set when making a WebSocket connection.

This is important when connecting to Parity's WebSocket and need to provide a secure connection token, as Parity expects this token to be provided via the protocol header.

## Example usage:

The following code will allow connection to Parity more securely simply by specifying an allowed token and without needing to open up the `--ws-origins` or `--ws-hosts` to the entire world (only someone with the correct key may connect):

```javascript
const token = 'anAr-YZXi-wuzK-aJzL' // Generated with `parity signer new-token`

const epoch = parseInt(+(new Date)/1000, 10)
const sha3 = Web3.utils.keccak256(`${token.replace(/-/g, '')}:${epoch}`)
const hash = `${sha3.substr(2)}_${epoch}`

const provider = new Web3.providers.WebsocketProvider("ws://127.0.0.1:8546", {protocol: hash})
const web3 = new Web3(provider)
```
