### PR TITLE
Run tests on NodeJS 5, 6, 7 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
   - "4.1"
   - "4.0"
+  - "5"
+  - "6"
+  - "7"
+  - "8"
 before_script:
   - npm install
   - npm install jshint


### PR DESCRIPTION
Run TravisCI tests on NodeJS version 5, 6, 7, and 8.