### PR TITLE
return XMLHttpRequest as a result of sendAsync

### DIFF
--- a/lib/web3/httpprovider.js
+++ b/lib/web3/httpprovider.js
@@ -110,6 +110,7 @@ HttpProvider.prototype.send = function (payload) {
  * @method sendAsync
  * @param {Object} payload
  * @param {Function} callback triggered on end with (err, result)
+ * @return {XMLHttpRequest} object
  */
 HttpProvider.prototype.sendAsync = function (payload, callback) {
   var request = this.prepareRequest(true);
@@ -138,6 +139,7 @@ HttpProvider.prototype.sendAsync = function (payload, callback) {
   } catch (error) {
     callback(errors.InvalidConnection(this.host));
   }
+  return request;
 };
 
 /**


### PR DESCRIPTION
without this change, it's impossible to cancel running request