### PR TITLE
Fixes #1559: Remove `Sec-WebSocket-Protocol: undefined` …

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -29,7 +29,9 @@ var Ws = null;
 var _btoa = null;
 var parseURL = null;
 if (typeof window !== 'undefined' && typeof window.WebSocket !== 'undefined') {
-    Ws = window.WebSocket;
+    Ws = function(url, protocols) {
+      return new window.WebSocket(url, protocols);
+    };
     _btoa = btoa;
     parseURL = function(url) {
         return new URL(url);


### PR DESCRIPTION
...from WebSocket headers

The WebSocket constructor in a browser based environment [only takes two
arguments](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket).
Before we were passing it extra arguments which was causing it to send
invalid headers. This commit ignores all arguments except for the first two.