### PR TITLE
[1.0] Add Contract.destroy()

### DIFF
--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -663,6 +663,22 @@ Contract.prototype.getPastEvents = function(){
     return call(subOptions.params, subOptions.callback);
 };
 
+/**
+ * Destroy contract (unset all internal properties)
+ *
+ * @method destroy
+ * @return {Boolean} success
+ */
+Contract.prototype.destroy = function(){
+    core.packageDestroy(this);
+    delete this.methods;
+    delete this.events;
+    delete this._address;
+    delete this._jsonInterface;
+    delete this.options;
+    return true;
+};
+
 
 /**
  * returns the an object with call, send, estimate functions

--- a/test/contract.js
+++ b/test/contract.js
@@ -294,6 +294,36 @@ var runTests = function(contractFactory) {
         });
     });
 
+    describe('destroy', function() {
+        it('should unset internal properties', function() {
+            var provider = new FakeIpcProvider();
+
+            var contract = contractFactory(abi, address, provider);
+
+            contract.destroy();
+
+            assert.isTrue(contract.destroyed);
+            assert.isUndefined(contract.options);
+            assert.isUndefined(contract.methods);
+            assert.isUndefined(contract.events);
+            assert.isUndefined(contract._requestManager);
+        });
+        it('should destroy internal RequestManager', function() {
+            var provider = new FakeIpcProvider();
+
+            var contract = contractFactory(abi, address, provider);
+
+            var requestManager = contract._requestManager;
+
+            assert.isDefined(requestManager);
+
+            contract.destroy();
+
+            assert.isTrue(requestManager.destroyed);
+            assert.isUndefined(contract._requestManager);
+        });
+    });
+
     describe('provider assignment', function() {
         it('should assign a provider to a new instance without modifying old instance', function () {
             var provider1 = new FakeIpcProvider();

--- a/test/helpers/FakeHttpProvider.js
+++ b/test/helpers/FakeHttpProvider.js
@@ -29,6 +29,7 @@ var FakeHttpProvider = function HttpProvider() {
     this.response = [];
     this.error = [];
     this.validation = [];
+    this.listeners = {};
 };
 
 

--- a/test/helpers/FakeIpcProvider.js
+++ b/test/helpers/FakeIpcProvider.js
@@ -67,6 +67,20 @@ FakeIpcProvider.prototype.on = function (type, callback) {
     }
 };
 
+FakeIpcProvider.prototype.removeListener = function (type, callback) {
+    if(type === 'data'){
+        var idx = this.notificationCallbacks.indexOf(callback);
+        if(idx >= 0){
+            this.notificationCallbacks.splice(idx, 1);
+        }
+    }
+};
+
+FakeIpcProvider.prototype.listenerCount = function (type) {
+    return this.notificationCallbacks.length;
+};
+
+
 FakeIpcProvider.prototype.getResponseOrError = function (type, payload) {
     var _this = this;
     var response;

--- a/test/requestmanager.js
+++ b/test/requestmanager.js
@@ -24,5 +24,22 @@ describe('lib/web3/requestmanager', function () {
             });
         });
     });
+    describe('destroy', function() {
+        it('should unset internal properties', function() {
+            var provider = new FakeHttpProvider();
+            var manager = new requestManager.Manager(provider);
+            manager.destroy();
+            assert.isTrue(manager.destroyed);
+            assert.isUndefined(manager.provider);
+        });
+        it('should remove DATA listeners', function() {
+            var provider = new FakeHttpProvider();
+            var dataEventCount = provider.listenerCount('data');
+            var manager = new requestManager.Manager(provider);
+            assert.equal(provider.listenerCount('data'), dataEventCount + 1);
+            manager.destroy();
+            assert.equal(provider.listenerCount('data'), dataEventCount);
+        });
+    });
 });
 


### PR DESCRIPTION
Add `.destroy()` method to objects created via `packageInit`. It allows for proper destruction (and proper garbage collection) of an object. This is very useful when working with a large number of contracts where it isn't necessary to keep the instances in memory.

Calling `.destroy()` unsets the internal properties, removes event listeners and unlinks all underlying objects. It also defines a new getter `(bool) destroyed` which can be used to check whether the contract is destroyed.

```js
contract.destroy();
console.log(contract.destroyed) // prints `true`
```

The main motivation for this arises from the issue https://github.com/Giveth/giveth-dapp/issues/297. Because each instance of a contract binds new event listeners to the global provider, we encounter the warning 'possible EventEmitter memory leak detected'. In fact, these contracts and instances of `RequestManager` cannot be properly garbage collected due to the references between contracts and the global provider leading to the increased memory usage.