### PR TITLE
prevent crash if browser is blocking 3rd party content

### DIFF
--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -525,7 +525,12 @@ Wallet.prototype.load = function (password, keyName) {
     return this.decrypt(keystore || [], password);
 };
 
-if (typeof localStorage === 'undefined') {
+try {
+    if (typeof localStorage === 'undefined') {
+        delete Wallet.prototype.save;
+        delete Wallet.prototype.load;
+    }
+} catch(e) {
     delete Wallet.prototype.save;
     delete Wallet.prototype.load;
 }


### PR DESCRIPTION
prevent crash if loaded in iframe and browser is blocking 3rd party content, which would give you an `Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Access is denied for this document.` if the localStorage is there, but not allowed to access.

Would be glad if you could merge my PR, so I don't need to frankenstein my own web3 module anymore and can get back to using npm :)