### PR TITLE
Replace the to-be-removed ABI field ``constant`` with ``stateMutability``

### DIFF
--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -37,7 +37,7 @@ var SolidityFunction = function (eth, json, address) {
     this._outputTypes = json.outputs.map(function (i) {
         return i.type;
     });
-    this._constant = json.constant;
+    this._constant = (json.stateMutability === "view" || json.stateMutability === "pure" || json.constant);
     this._payable = json.payable;
     this._name = utils.transformToFullName(json);
     this._address = address;

--- a/lib/web3/function.js
+++ b/lib/web3/function.js
@@ -38,7 +38,7 @@ var SolidityFunction = function (eth, json, address) {
         return i.type;
     });
     this._constant = (json.stateMutability === "view" || json.stateMutability === "pure" || json.constant);
-    this._payable = json.payable;
+    this._payable = (json.stateMutability === "payable" || json.payable);
     this._name = utils.transformToFullName(json);
     this._address = address;
 };


### PR DESCRIPTION
(and fall back to ``constant`` for backwards compatibility with older compiler versions).

With solidity version 0.5.0 the ``constant`` field will be removed from the JSON ABI, since it duplicates the information in ``stateMutability``. I'm part of the solidity team and currently working on this change, but we want to make sure that everything that depends on the old ABI is updated first.

The change in this PR should make web3 robust against this change in the ABI while maintaining backwards compatibility.

I don't have much experience with the web3 codebase, though, so any help would be appreciated. Thanks!