### PR TITLE
fix: websocket authn with legacy URL parser

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -74,7 +74,11 @@ var WebsocketProvider = function WebsocketProvider(url, options)  {
     if (parsedURL.username && parsedURL.password) {
         headers.authorization = 'Basic ' + _btoa(parsedURL.username + ':' + parsedURL.password);
     }
-
+    // When all node core implementations that do not have the
+    // WHATWG compatible URL parser go out of service this line can be removed.
+    if (parsedURL.auth) {
+        headers.authorization = 'Basic ' + _btoa(parsedURL.auth);
+    }
     this.connection = new Ws(url, protocol, undefined, headers);
 
     this.addDefaultEvents();


### PR DESCRIPTION
Came across an issue on Stack Overflow where someone was having issues connecting to Kaleido using basic auth. Turns out their Node.js client was falling back to the legacy URL parser and we were missing it.

Seems 1.0.0-beta.34 is missing the check for the new parser, but when it's delivered this PR will be made obsolete on April 19, 2019 when Node 6 goes out of maintenance.