### PR TITLE
Add Parity trace_*/parity_* methods

### DIFF
--- a/lib/web3.js
+++ b/lib/web3.js
@@ -39,6 +39,7 @@ var Shh = require('./web3/methods/shh');
 var Net = require('./web3/methods/net');
 var Personal = require('./web3/methods/personal');
 var Swarm = require('./web3/methods/swarm');
+var Trace = require('./web3/methods/trace');
 var Settings = require('./web3/settings');
 var version = require('./version.json');
 var utils = require('./utils/utils');
@@ -60,6 +61,7 @@ function Web3 (provider) {
     this.shh = new Shh(this);
     this.net = new Net(this);
     this.personal = new Personal(this);
+    this.trace = new Trace(this);
     this.bzz = new Swarm(this);
     this.settings = new Settings();
     this.version = {

--- a/lib/web3.js
+++ b/lib/web3.js
@@ -40,6 +40,7 @@ var Net = require('./web3/methods/net');
 var Personal = require('./web3/methods/personal');
 var Swarm = require('./web3/methods/swarm');
 var Trace = require('./web3/methods/trace');
+var Parity = require('./web3/methods/parity');
 var Settings = require('./web3/settings');
 var version = require('./version.json');
 var utils = require('./utils/utils');
@@ -62,6 +63,7 @@ function Web3 (provider) {
     this.net = new Net(this);
     this.personal = new Personal(this);
     this.trace = new Trace(this);
+    this.parity = new Parity(this);
     this.bzz = new Swarm(this);
     this.settings = new Settings();
     this.version = {

--- a/lib/web3/formatters.js
+++ b/lib/web3/formatters.js
@@ -132,6 +132,29 @@ var outputTransactionFormatter = function (tx){
 };
 
 /**
+ * Formats the output of an array of transactions to its proper values
+ *
+ * @method outputTransactionArrayFormatter
+ * @param {Object} tx
+ * @returns {Object}
+*/
+var outputTransactionArrayFormatter = function (txs){
+  
+  txs.forEach(function(tx) {
+    if(tx.blockNumber !== null)
+        tx.blockNumber = utils.toDecimal(tx.blockNumber);
+    if(tx.transactionIndex !== null)
+        tx.transactionIndex = utils.toDecimal(tx.transactionIndex);
+    tx.nonce = utils.toDecimal(tx.nonce);
+    tx.gas = utils.toDecimal(tx.gas);
+    tx.gasPrice = utils.toBigNumber(tx.gasPrice);
+    tx.value = utils.toBigNumber(tx.value);
+  });
+  
+  return txs;
+};
+
+/**
  * Formats the output of a transaction receipt to its proper values
  *
  * @method outputTransactionReceiptFormatter
@@ -300,6 +323,7 @@ module.exports = {
     inputPostFormatter: inputPostFormatter,
     outputBigNumberFormatter: outputBigNumberFormatter,
     outputTransactionFormatter: outputTransactionFormatter,
+    outputTransactionArrayFormatter: outputTransactionArrayFormatter,
     outputTransactionReceiptFormatter: outputTransactionReceiptFormatter,
     outputBlockFormatter: outputBlockFormatter,
     outputLogFormatter: outputLogFormatter,

--- a/lib/web3/methods/parity.js
+++ b/lib/web3/methods/parity.js
@@ -43,9 +43,30 @@ var methods = function () {
         params: 0,
         outputFormatter: formatters.outputTransactionFormatter
     });
+    
+    var pendingTransactionsStats = new Method({
+        name: 'pendingTransactionsStats',
+        call: 'parity_pendingTransactionsStats',
+        params: 0
+    });
+    
+    var listAccounts = new Method({
+        name: 'listAccounts',
+        call: 'parity_listAccounts',
+        params: 2
+    });
+    
+    var phraseToAddress = new Method({
+        name: 'phraseToAddress',
+        call: 'parity_phraseToAddress',
+        params: 1
+    });
 
     return [
-        pendingTransactions
+        pendingTransactions,
+        pendingTransactionsStats,
+        listAccounts,
+        phraseToAddress
     ];
 };
 

--- a/lib/web3/methods/parity.js
+++ b/lib/web3/methods/parity.js
@@ -1,0 +1,52 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file parity.js
+ * @author Peter Pratscher <peter@bitfly.at>
+ * @date 2017
+ */
+
+"use strict";
+
+var Method = require('../method');
+var formatters = require('../formatters');
+
+function Parity(web3) {
+    this._requestManager = web3._requestManager;
+
+    var self = this;
+
+    methods().forEach(function(method) {
+        method.attachToObject(self);
+        method.setRequestManager(self._requestManager);
+    });
+}
+
+var methods = function () {
+    var pendingTransactions = new Method({
+        name: 'pendingTransactions',
+        call: 'parity_pendingTransactions',
+        params: 0,
+        outputFormatter: formatters.outputTransactionFormatter
+    });
+
+    return [
+        pendingTransactions
+    ];
+};
+
+module.exports = Parity;

--- a/lib/web3/methods/trace.js
+++ b/lib/web3/methods/trace.js
@@ -1,0 +1,95 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file trace.js
+ * @author Alexis Roussel <alexis@bity.com>
+ * @date 2017
+ */
+
+"use strict";
+
+var Method = require('../method');
+var formatters = require('../formatters');
+
+function Trace(web3) {
+    this._requestManager = web3._requestManager;
+
+    var self = this;
+
+    methods().forEach(function(method) {
+        method.attachToObject(self);
+        method.setRequestManager(self._requestManager);
+    });
+}
+
+var methods = function () {
+    var call = new Method({
+        name: 'call',
+        call: 'trace_call',
+        params: 3,
+        inputFormatter: [formatters.inputCallFormatter, null, formatters.inputDefaultBlockNumberFormatter]
+    });
+
+    var rawTransaction = new Method({
+        name: 'rawTransaction',
+        call: 'trace_rawTransaction',
+        params: 2
+    });
+
+    var replayTransaction = new Method({
+        name: 'replayTransaction',
+        call: 'trace_replayTransaction',
+        params: 2
+    });
+
+    var block = new Method({
+        name: 'block',
+        call: 'trace_block',
+        params: 1,
+        inputFormatter: [formatters.inputDefaultBlockNumberFormatter]
+    });
+
+    var filter = new Method({
+        name: 'filter',
+        call: 'trace_filter',
+        params: 1
+    });
+
+    var get = new Method({
+        name: 'get',
+        call: 'trace_get',
+        params: 2
+    });
+
+    var transaction = new Method({
+        name: 'transaction',
+        call: 'trace_transaction',
+        params: 1
+    });
+
+    return [
+        call,
+        rawTransaction,
+        replayTransaction,
+        block,
+        filter,
+        get,
+        transaction
+    ];
+};
+
+module.exports = Trace;


### PR DESCRIPTION
These are commits from https://github.com/gobitfly/web3.js made by @ppratscher and @digithinksa.

These are used by https://github.com/gobitfly/etherchain-light and we are trying to use it for the ewasm testnet (fork: https://github.com/ewasm/etherchain-light).

cc @cdetrio 