### PR TITLE
Stop JSON RPC errors from breaking websocket provider onmessage logic

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -110,7 +110,7 @@ var WebsocketProvider = function WebsocketProvider(url, options)  {
             }
 
             // notification
-            if(!id && result.method.indexOf('_subscription') !== -1) {
+            if(!id && result && result.method && result.method.indexOf('_subscription') !== -1) {
                 _this.notificationCallbacks.forEach(function(callback){
                     if(_.isFunction(callback))
                         callback(result);


### PR DESCRIPTION
JSON RPC errors do not include a `method` property so we had to add an additional check in the websocket provider to not cause unnecessary errors.