### PR TITLE
fixed bytes[] decode logic

### DIFF
--- a/lib/solidity/type.js
+++ b/lib/solidity/type.js
@@ -197,7 +197,7 @@ SolidityType.prototype.encode = function (value, name) {
  * @param {String} name type name
  * @returns {Object} decoded value
  */
-SolidityType.prototype.decode = function (bytes, offset, name) {
+SolidityType.prototype.decode = function (bytes, offset, name, memberOffset = 0) {
     var self = this;
 
     if (this.isDynamicArray(name)) {
@@ -213,7 +213,7 @@ SolidityType.prototype.decode = function (bytes, offset, name) {
             var result = [];
 
             for (var i = 0; i < length * roundedNestedStaticPartLength; i += roundedNestedStaticPartLength) {
-                result.push(self.decode(bytes, arrayStart + i, nestedName));
+                result.push(self.decode(bytes, arrayStart + i, nestedName, i));
             }
 
             return result;
@@ -241,6 +241,8 @@ SolidityType.prototype.decode = function (bytes, offset, name) {
         return (function () {
             var dynamicOffset = parseInt('0x' + bytes.substr(offset * 2, 64));      // in bytes
             var length = parseInt('0x' + bytes.substr(dynamicOffset * 2, 64));      // in bytes
+            //in the case of bytes[], offset is not 0x0, need to add this offset to dynamicOffset
+            if(name == "bytes") dynamicOffset = dynamicOffset + offset - memberOffset;
             var roundedLength = Math.floor((length + 31) / 32);                     // in int
             var param = new SolidityParam(bytes.substr(dynamicOffset * 2, ( 1 + roundedLength) * 64), 0);
             return self._outputFormatter(param, name);


### PR DESCRIPTION
dynamicOffset needs to consider the basic offset. If type is bytes[], the basic offset is not 0x0