### PR TITLE
Do not allow to publish the root repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "web3",
+  "private": true,
   "namespace": "ethereum",
   "version": "1.0.0-beta.35",
   "description": "Ethereum JavaScript API wrapper repository",


### PR DESCRIPTION
There is a [release tag](https://github.com/ethereum/web3.js/tree/v1.0.0-beta.36) and also an installable version for `web3@1.0.0-beta.36` but it appears to not have been published correctly. Instead of [packages/web3](https://github.com/ethereum/web3.js/tree/1.0/packages/web3), the root repository (whose `package.json` has the same `name`) was published to npm:

![screen shot 2018-08-29 at 11 29 31 am](https://user-images.githubusercontent.com/338316/44807597-d4d8b100-ab7e-11e8-8f31-74da6ebfa696.png)

This pull request sets the root repository `private` flag to `true` instructing Lerna to never publish it and also making it unpublishable running `npm publish` by accident and should allow publishing a working `1.0.0-beta.37`.