### PR TITLE
Updates _confirmTransaction to make receipt available in error handlers if a transaction fails

### DIFF
--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -545,7 +545,7 @@ The **callback** will return the 32 bytes transaction hash.
 - ``"transactionHash"`` returns ``String``: is fired right after the transaction is sent and a transaction hash is available.
 - ``"receipt"`` returns ``Object``: is fired when the transaction *receipt* is available. Receipts from contracts will have no ``logs`` property, but instead an ``events`` property with event names as keys and events as properties. See :ref:`getPastEvents return values <contract-events-return>` for details about the returned event object.
 - ``"confirmation"`` returns ``Number``, ``Object``: is fired for every confirmation up to the 24th confirmation. Receives the confirmation number as the first and the receipt as the second argument. Fired from confirmation 1 on, which is the block where it's minded.
-- ``"error"`` returns ``Error``: is fired if an error occurs during sending. If a out of gas error, the second parameter is the receipt.
+- ``"error"`` returns ``Error``: is fired if an error occurs during sending. If an out of gas error, the receipt will be available as ``error.data``.
 
 
 -------
@@ -612,7 +612,7 @@ Example
             }
         }
     })
-    .on('error', console.error); // If there's an out of gas error the second parameter is the receipt.
+    .on('error', console.error); // If an out of gas error, the receipt will be available as error.data
 
 
 ------------------------------------------------------------------------------

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -1012,7 +1012,7 @@ The **callback** will return the 32 bytes transaction hash.
 - ``"transactionHash"`` returns ``String``: Is fired right after the transaction is sent and a transaction hash is available.
 - ``"receipt"`` returns ``Object``: Is fired when the transaction receipt is available.
 - ``"confirmation"`` returns ``Number``, ``Object``: Is fired for every confirmation up to the 12th confirmation. Receives the confirmation number as the first and the :ref:`receipt <eth-gettransactionreceipt-return>` as the second argument. Fired from confirmation 0 on, which is the block where its minded.
-- ``"error"`` returns ``Error``: Is fired if an error occurs during sending. If a out of gas error, the second parameter is the receipt.
+- ``"error"`` returns ``Error``: Is fired if an error occurs during sending. If an out of gas error, the receipt will be available as ``error.data``.
 
 
 -------
@@ -1057,7 +1057,7 @@ Example
         ...
     })
     .on('confirmation', function(confirmationNumber, receipt){ ... })
-    .on('error', console.error); // If a out of gas error, the second parameter is the receipt.
+    .on('error', console.error); // If an out of gas error, the receipt will be available as error.data.
 
 
 ------------------------------------------------------------------------------

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -199,6 +199,7 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
         confirmationCount = 0,
         intervalId = null,
         receiptJSON = '',
+        receiptError = {},
         gasProvided = (_.isObject(payload.params[0]) && payload.params[0].gas) ? payload.params[0].gas : null,
         isContractDeployment = _.isObject(payload.params[0]) &&
             payload.params[0].data &&
@@ -359,15 +360,14 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
                         }
 
                     } else {
+                        receiptError.data = receipt;
                         receiptJSON = JSON.stringify(receipt, null, 2);
                         if (receipt.status === false || receipt.status === '0x0') {
-                            utils._fireError(new Error("Transaction has been reverted by the EVM:\n" + receiptJSON),
-                                defer.eventEmitter, defer.reject);
+                            receiptError.message = "Transaction has been reverted by the EVM:";
                         } else {
-                            utils._fireError(
-                                new Error("Transaction ran out of gas. Please provide more gas:\n" + receiptJSON),
-                                defer.eventEmitter, defer.reject);
+                            receiptError.message = "Transaction ran out of gas. Please provide more gas:";
                         }
+                        utils._fireError(receiptError, defer.eventEmitter, defer.reject);
                     }
 
                     if (canUnsubscribe) {

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -43,13 +43,17 @@ var randomHex = require('randomhex');
 var _fireError = function (error, emitter, reject, callback) {
     /*jshint maxcomplexity: 10 */
 
-    // add data if given
-    if(_.isObject(error) && !(error instanceof Error) &&  error.data) {
-        if(_.isObject(error.data) || _.isArray(error.data)) {
-            error.data = JSON.stringify(error.data, null, 2);
-        }
+    var errorData;
 
-        error = error.message +"\n"+ error.data;
+    // add data if given
+    if(_.isObject(error) && !(error instanceof Error) && error.data) {
+        errorData = error.data;
+        if(_.isObject(errorData) || _.isArray(errorData)) {
+            error = new Error(error.message + "\n" + JSON.stringify(errorData, null, 2));
+        } else {
+            error = new Error(error.message + "\n" + errorData);
+        }
+        error.data = errorData;
     }
 
     if(_.isString(error)) {


### PR DESCRIPTION
This PR provides a fix for issue #1941. If a transaction fails, the receipt will now be available on `error.data`. As a bonus, any other method that calls `utils._fireError()` with the `{ message, data }` object will also have the `data` value preserved on `error.data` when passed to the callback / event.

Some example code:

```javascript
// specify a gasLimit you know will be too low for the contract method you're
//  calling so that the transaction will fail
web3.eth.sendTransaction(transactionData)
  .on('error', (error) => {

    // error.data is the raw receipt object, i.e error.data.gasUsed === 240358

    // error.message is still:
    //
    // Transaction has been reverted by the EVM:
    // {
    //   "transactionHash": "0xa2ac91c7affd59a761dd088230008082a0bcd3c43e46dd70a70e79db9c5df993",
    //   "transactionIndex": 0,
    //   "blockHash": "0x8efa4a788fd29ccc0d25a893635c4c37ebe9ddc452df83f7c249181451f8c0e0",
    //   "blockNumber": 267,
    //   "gasUsed": 240358,
    //   "cumulativeGasUsed": 240358,
    //   "contractAddress": null,
    //   "logs": [],
    //   "status": false,
    //   "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
    // }

  })
```