### PR TITLE
Introduce raw return type

### DIFF
--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -226,9 +226,16 @@ ABICoder.prototype.decodeParameters = function (outputs, bytes) {
         throw new Error('Returned values aren\'t valid, did it run Out of Gas?');
     }
 
-    var res = ethersAbiCoder.decode(this.mapTypes(outputs), '0x' + bytes.replace(/0x/i, ''));
     var returnValue = new Result();
     returnValue.__length__ = 0;
+
+    if (outputs.length == 1 && outputs[0] == "raw") {
+        returnValue[0] = bytes;
+        returnValue.__length__++;
+        return returnValue;
+    }
+
+    var res = ethersAbiCoder.decode(this.mapTypes(outputs), '0x' + bytes.replace(/0x/i, ''));
 
     outputs.forEach(function (output, i) {
         var decodedValue = res[returnValue.__length__];


### PR DESCRIPTION
Propose use `raw` return type to parse node result manually for handling different return types.

Questions:
- https://ethereum.stackexchange.com/questions/37165/web3js-1-0-0-beta-24-the-returned-value-is-not-a-convertible-string
- https://ethereum.stackexchange.com/questions/58945/how-to-handle-both-string-and-bytes32-method-returns

Issues:
- https://github.com/ethereum/web3.js/issues/1035
- https://github.com/ethereum/web3.js/issues/1954