### PR TITLE
Full support for websocket reconnection/resubscription 

### DIFF
--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -205,17 +205,20 @@ RequestManager.prototype.addSubscription = function (id, name, type, callback) {
  * @param {Function} callback   fired once the subscription is removed
  */
 RequestManager.prototype.removeSubscription = function (id, callback) {
-    var _this = this;
-
     if(this.subscriptions[id]) {
+        var type = this.subscriptions[id].type;
 
+        // remove subscription first to avoid reentry
+        delete this.subscriptions[id];
+
+        // then, try to actually unsubscribe
         this.send({
-            method: this.subscriptions[id].type + '_unsubscribe',
+            method: type + '_unsubscribe',
             params: [id]
         }, callback);
-
-        // remove subscription
-        delete _this.subscriptions[id];
+    } else if (typeof callback === 'function') {
+        // call the callback if the subscription was already removed
+        callback(null);
     }
 };
 

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -103,13 +103,16 @@ RequestManager.prototype.setProvider = function (p, net) {
                 _this.subscriptions[result.params.subscription].callback(null, result.params.result);
             }
         });
-        // TODO add error, end, timeout, connect??
-        // this.provider.on('error', function requestManagerNotification(result){
-        //     Object.keys(_this.subscriptions).forEach(function(id){
-        //         if(_this.subscriptions[id].callback)
-        //             _this.subscriptions[id].callback(err);
-        //     });
-        // }
+
+        // notify all subscriptions about the error condition
+        this.provider.on('error', function (event) {
+            Object.keys(_this.subscriptions).forEach(function(id){
+                if(_this.subscriptions[id] && _this.subscriptions[id].callback)
+                _this.subscriptions[id].callback(event.code || new Error('Provider error'));
+            });
+        });
+
+        // TODO add end, timeout, connect??
     }
 };
 

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -271,37 +271,44 @@ Subscription.prototype.subscribe = function() {
                         _this.callback(null, output, _this);
                     });
                 } else {
-                    // unsubscribe, but keep listeners
-                    _this.options.requestManager.removeSubscription(_this.id);
+                    _this._resubscribe(err);
+                }
+            });
+        } else {
+            _this._resubscribe(err);
+        }
+    });
+
+    // return an object to cancel the subscription
+    return this;
+};
+
+Subscription.prototype._resubscribe = function (err) {
+    var _this = this;
+
+    // unsubscribe
+    this.options.requestManager.removeSubscription(this.id);
 
                     // re-subscribe, if connection fails
-                    if(_this.options.requestManager.provider.once) {
-                        _this._reconnectIntervalId = setInterval(function () {
+    if(this.options.requestManager.provider.once && !_this._reconnectIntervalId) {
+        this._reconnectIntervalId = setInterval(function () {
                             // TODO check if that makes sense!
                             if (_this.options.requestManager.provider.reconnect) {
                                 _this.options.requestManager.provider.reconnect();
                             }
                         }, 500);
 
-                        _this.options.requestManager.provider.once('connect', function () {
+        this.options.requestManager.provider.once('connect', function () {
                             clearInterval(_this._reconnectIntervalId);
+            _this._reconnectIntervalId = null;
                             _this.subscribe(_this.callback);
                         });
                     }
-                    _this.emit('error', err);
+
+    this.emit('error', err);
 
                      // call the callback, last so that unsubscribe there won't affect the emit above
-                    _this.callback(err, null, _this);
-                }
-            });
-        } else {
-          _this.callback(err, null, _this);
-          _this.emit('error', err);
-        }
-    });
-
-    // return an object to cancel the subscription
-    return this;
+    this.callback(err, null, this);
 };
 
 module.exports = Subscription;

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -289,25 +289,29 @@ Subscription.prototype._resubscribe = function (err) {
     // unsubscribe
     this.options.requestManager.removeSubscription(this.id);
 
-                    // re-subscribe, if connection fails
+    // re-subscribe, if connection fails
     if(this.options.requestManager.provider.once && !_this._reconnectIntervalId) {
         this._reconnectIntervalId = setInterval(function () {
-                            // TODO check if that makes sense!
-                            if (_this.options.requestManager.provider.reconnect) {
-                                _this.options.requestManager.provider.reconnect();
-                            }
-                        }, 500);
+            // TODO check if that makes sense!
+            if (_this.options.requestManager.provider.reconnect) {
+                _this.options.requestManager.provider.reconnect();
+            }
+        }, 500);
 
         this.options.requestManager.provider.once('connect', function () {
-                            clearInterval(_this._reconnectIntervalId);
+            clearInterval(_this._reconnectIntervalId);
             _this._reconnectIntervalId = null;
-                            _this.subscribe(_this.callback);
-                        });
-                    }
+
+            // delete id to keep the listeners on subscribe
+            _this.id = null;
+
+            _this.subscribe(_this.callback);
+        });
+    }
 
     this.emit('error', err);
 
-                     // call the callback, last so that unsubscribe there won't affect the emit above
+    // call the callback, last so that unsubscribe there won't affect the emit above
     this.callback(err, null, this);
 };
 

--- a/packages/web3-providers-ws/README.md
+++ b/packages/web3-providers-ws/README.md
@@ -31,7 +31,15 @@ This will expose the `Web3WsProvider` object on the window object.
 // in node.js
 var Web3WsProvider = require('web3-providers-ws');
 
-var options = { timeout: 30000, headers: {authorization: 'Basic username:password'} } // set a custom timeout at 30 seconds, and credentials (you can also add the credentials to the URL: ws://username:password@localhost:8546)
+var options = { 
+    // set credentials (you can also add the credentials to the URL: 
+    // ws://username:password@localhost:8546)
+    headers: {authorization: 'Basic username:password'},
+    // set a custom timeout at 30 seconds
+    timeout: 30000,
+    // enable WebSocket auto-reconnection
+    autoReconnect: true
+}
 var ws = new Web3WsProvider('ws://localhost:8546', options);
 ```
 

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -48,6 +48,11 @@
 				"yaeti": "^0.0.6"
 			}
 		},
+		"websocket-reconnector": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/websocket-reconnector/-/websocket-reconnector-1.0.0.tgz",
+			"integrity": "sha512-n6fzSqtR2qfScJSFx8ePnWn9WQCAT7As0WPlMADuMBthfwrkFfmkONStRWw4hoqwawdYDoZgL+HQITWuDY6oyw=="
+		},
 		"yaeti": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.36",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+        "websocket-reconnector": "1.1.1"
     }
 }

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -299,15 +299,15 @@ WebsocketProvider.prototype.on = function (type, callback) {
             break;
 
         case 'connect':
-            this.connection.onopen = callback;
+            this.connection.addEventListener('open', callback);
             break;
 
         case 'end':
-            this.connection.onclose = callback;
+            this.connection.addEventListener('close', callback);
             break;
 
         case 'error':
-            this.connection.onerror = callback;
+            this.connection.addEventListener('error', callback);
             break;
 
         // default:
@@ -336,7 +336,17 @@ WebsocketProvider.prototype.removeListener = function (type, callback) {
             });
             break;
 
-        // TODO remvoving connect missing
+        case 'connect':
+            this.connection.removeEventListener('open', callback);
+            break;
+
+        case 'end':
+            this.connection.removeEventListener('close', callback);
+            break;
+
+        case 'error':
+            this.connection.removeEventListener('error', callback);
+            break;
 
         // default:
         //     this.connection.removeListener(type, callback);

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -239,7 +239,13 @@ WebsocketProvider.prototype._addResponseCallback = function(payload, callback) {
         setTimeout(function () {
             if (_this.responseCallbacks[id]) {
                 _this.responseCallbacks[id](errors.ConnectionTimeout(_this._customTimeout));
+
                 delete _this.responseCallbacks[id];
+
+                // try to reconnect
+                if (_this.connection.reconnect) {
+                    _this.connection.reconnect();
+            }
             }
         }, this._customTimeout);
     }

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -316,7 +316,24 @@ WebsocketProvider.prototype.on = function (type, callback) {
     }
 };
 
-// TODO add once
+/**
+ Subscribes to provider only once
+
+ @method once
+ @param {String} type    'notifcation', 'connect', 'error', 'end' or 'data'
+ @param {Function} callback   the callback to call
+ */
+WebsocketProvider.prototype.once = function (type, callback) {
+    var _this = this;
+
+    function onceCallback(event) {
+        _this.removeListener(type, onceCallback);
+
+        callback(event);
+    }
+
+    this.on(type, onceCallback);
+};
 
 /**
  Removes event listener

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -25,6 +25,8 @@
 var _ = require('underscore');
 var errors = require('web3-core-helpers').errors;
 
+var WsReconnector = require('websocket-reconnector');
+
 var Ws = null;
 var _btoa = null;
 var parseURL = null;
@@ -79,6 +81,11 @@ var WebsocketProvider = function WebsocketProvider(url, options)  {
 
     // Allow a custom client configuration
     var clientConfig = options.clientConfig || undefined;
+
+    // Enable automatic reconnection wrapping `Ws` with reconnector
+    if (options.autoReconnect) {
+        Ws = WsReconnector(Ws);
+    }
 
     // When all node core implementations that do not have the
     // WHATWG compatible URL parser go out of service this line can be removed.


### PR DESCRIPTION
## Description

Websocket disconnection is a long standing issue in the 1.0 branch of this library and is the source of many issues when developing applications that for any reason use a not-so-reliable connection to the nodes.

Solving the disconnection and reconnection means basically resolving several major problems:
- Reconnecting the transport layer, this is the websocket connection itself.
- Reattaching client's event listeners that handle the different websocket connection states.
- Resubscribing to higher-level events like incoming blocks, events.

This PR addresses these problems by:
- Updating the events management functions of the websocket provider, adding `once` and updating `on` to use `addEventListener` instead of just overwriting the default event listener. That was needed to properly manage the error events that needed to be sent to every `RequestManager`s using the provider and later allow them to listen for the new `connect` events.
- Update the `RequestManager`'s error handling logic so it does the same steps when the connection was already established and an error occurs or when the connection cannot be established on start due to a recoverable cause. This was needed to resubscribe in all scenarios. In addition there was two small bugs that was fixed so the resubscriptions can actually be processed and issues are avoided in the case several resubscriptions are tried simultaneously (no function reentry).
- Once errors are sent by the websocker provider, those have to be properly broadcasted and handled by all subscriptions to trigger unsubscription/resubscription logic.
- In order to avoid extensive changes to the websocket provider, the websocket object used was -optionally- replaced by a wrapper object exposing the W3C Websocket API that automatically handles the reconnection on recoverable error conditions.
- On Node.js environments, the websocket package used has the ability to send keepalive packets and detect a zombie connection (connection was lost but since no packages are sent, no errors are triggered). In this scenarios, the reconnection is also triggered. Unfortunately, browser implementations do not have keepalive options so client's code will need to detect zombie connections and force a restart.

The changes were extensively tested and work as expected, reconnecting and resubscribing under several different circumstances.

The commits of this PR have extensive comments explaining the rationale behind each one.

Fixes #1085
Fixes #1391
Fixes #1558
Fixes #1852 
Fixes #1933

And possibly addresses others issues as well.

@nivida @frozeman Please review and evaluate this PR. I will be happy to address any comment you might have on it.

Thanks!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` with success and extended the tests if necessary.
- [x] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [x] I have tested my code on the live network.