### PR TITLE
updating example code to 1.0 syntax (capital C)

### DIFF
--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -481,7 +481,7 @@ Example
     }
 
     // web3.js
-    var MyContract = new web3.eth.contract(abi, address);
+    var MyContract = new web3.eth.Contract(abi, address);
     MyContract.methods.myFunction().call()
     .then(console.log);
     > Result {
@@ -502,7 +502,7 @@ Example
     }
 
     // web3.js
-    var MyContract = new web3.eth.contract(abi, address);
+    var MyContract = new web3.eth.Contract(abi, address);
     MyContract.methods.myFunction().call()
     .then(console.log);
     > "Hello!%"


### PR DESCRIPTION
Two instances of the example in the "methods.myMethod.call" section were still showing the instantiation of the contract with a lower c.