### PR TITLE
Add disconnect method to IpcProvider

### DIFF
--- a/packages/web3-providers-ipc/src/index.js
+++ b/packages/web3-providers-ipc/src/index.js
@@ -318,7 +318,7 @@ Disconnects from the IPC endpoint. This allows freeing the socket.
 */
 IpcProvider.prototype.disconnect = function () {
     if (this.connection) {
-        this.connection.close();
+        this.connection.endfix();
     }
 };
 

--- a/packages/web3-providers-ipc/src/index.js
+++ b/packages/web3-providers-ipc/src/index.js
@@ -311,5 +311,16 @@ IpcProvider.prototype.reset = function () {
     this.addDefaultEvents();
 };
 
+/**
+Disconnects from the IPC endpoint. This allows freeing the socket.
+
+@method disconnect
+*/
+IpcProvider.prototype.disconnect = function () {
+    if (this.connection) {
+        this.connection.close();
+    }
+};
+
 module.exports = IpcProvider;
 

--- a/packages/web3-providers-ipc/src/index.js
+++ b/packages/web3-providers-ipc/src/index.js
@@ -318,7 +318,7 @@ Disconnects from the IPC endpoint. This allows freeing the socket.
 */
 IpcProvider.prototype.disconnect = function () {
     if (this.connection) {
-        this.connection.endfix();
+        this.connection.end();
     }
 };
 


### PR DESCRIPTION
This makes the interface of `IpcProvider` more conform with other providers. This follows up on https://github.com/ethereum/web3.js/pull/1881 . This partially resolves https://github.com/ethereum/web3.js/issues/1850 .