### PR TITLE
Updated getGasPrice documentation to fix link

### DIFF
--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -394,7 +394,7 @@ Returns
 
 ``Promise`` returns ``String`` - Number string of the current gas price in :ref:`wei <what-is-wei>`.
 
-See the :ref:`A note on dealing with big numbers in JavaScript <big-numbers-in-javascript>`.
+See the :ref:`A note on dealing with big numbers in JavaScript <utils-bn>`.
 
 -------
 Example


### PR DESCRIPTION
Fixed a link under getGasPrice to redirect it to big numbers documentation in utils