### PR TITLE
Extend filter options for EIP-234

### DIFF
--- a/lib/web3/filter.js
+++ b/lib/web3/filter.js
@@ -50,7 +50,7 @@ var toTopic = function(value){
 /// @param should be string or object
 /// @returns options string or object
 var getOptions = function (options, type) {
-    /*jshint maxcomplexity: 6 */
+    /*jshint maxcomplexity: 7 */
 
     if (utils.isString(options)) {
         return options;
@@ -68,14 +68,17 @@ var getOptions = function (options, type) {
                 return (utils.isArray(topic)) ? topic.map(toTopic) : toTopic(topic);
             });
 
-            return {
+            return Object.assign({
                 topics: options.topics,
                 from: options.from,
                 to: options.to,
-                address: options.address,
-                fromBlock: formatters.inputBlockNumberFormatter(options.fromBlock),
-                toBlock: formatters.inputBlockNumberFormatter(options.toBlock)
-            };
+                address: options.address
+                },
+                options.blockHash ? { blockHash: options.blockHash }
+                  : { fromBlock: formatters.inputBlockNumberFormatter(options.fromBlock),
+                      toBlock: formatters.inputBlockNumberFormatter(options.toBlock)
+                  }
+            );
         case 'shh':
             return options;
     }

--- a/test/web3.eth.filter.js
+++ b/test/web3.eth.filter.js
@@ -38,6 +38,19 @@ var tests = [{
     formattedResult: '0xf',
     call: 'eth_newFilter'
 },{
+    args: [{
+        blockHash: '0x4932a21c2d34f941498532310b205aa7b98451d91e33a1e9abcf75e888b3241e',
+        address: '0x47d33b27bb249a2dbab4c0612bf9caf4c1950855'
+    }],
+    formattedArgs: [{
+        blockHash: '0x4932a21c2d34f941498532310b205aa7b98451d91e33a1e9abcf75e888b3241e',
+        address: '0x47d33b27bb249a2dbab4c0612bf9caf4c1950855',
+        topics: []
+    }],
+    result: '0xf',
+    formattedResult: '0xf',
+    call: 'eth_newFilter'
+},{
     args: ['latest'],
     formattedArgs: [],
     result: '0xf',


### PR DESCRIPTION
Querying/filtering logs by blockHash is supported per [EIP-234](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-234.md) and is convenient in various situations. Would be great to have this in web3.js.