### PR TITLE
Update index.js in WebSocket provider

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -30,7 +30,11 @@ var _btoa = null;
 var parseURL = null;
 if (typeof window !== 'undefined' && typeof window.WebSocket !== 'undefined') {
     Ws = function(url, protocols) {
-      return new window.WebSocket(url, protocols);
+      if (protocols) {
+        return new window.WebSocket(url, protocols);
+      } else {
+        return new window.WebSocket(url); 
+      }
     };
     _btoa = btoa;
     parseURL = function(url) {


### PR DESCRIPTION
Related to: https://github.com/ethereum/web3.js/issues/1559
WebSocket implementation in older browsers still pass "Sec-WebSocket-Protocol: undefined" if protocols is passed as undefined or null.

This solution will prevent it.