### PR TITLE
Bubble up tx signing errors

### DIFF
--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -533,7 +533,14 @@ Method.prototype.buildCall = function() {
 
                     // If wallet was found, sign tx, and send using sendRawTransaction
                     if (wallet && wallet.privateKey) {
-                        return method.accounts.signTransaction(_.omit(tx, 'from'), wallet.privateKey).then(sendSignedTx);
+                        return method.accounts.signTransaction(_.omit(tx, 'from'), wallet.privateKey)
+                            .then(sendSignedTx)
+                            .catch(function (err) {
+                                if (defer.eventEmitter.emit) {
+                                    defer.eventEmitter.emit('error', err);
+                                }
+                                defer.reject(err);
+                            });
                     }
 
                     // ETH_SIGN

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -536,8 +536,10 @@ Method.prototype.buildCall = function() {
                         return method.accounts.signTransaction(_.omit(tx, 'from'), wallet.privateKey)
                             .then(sendSignedTx)
                             .catch(function (err) {
-                                if (defer.eventEmitter.emit) {
+                                if (_.isFunction(defer.eventEmitter.listeners) && defer.eventEmitter.listeners('error').length) {
                                     defer.eventEmitter.emit('error', err);
+                                    defer.eventEmitter.removeAllListeners();
+                                    defer.eventEmitter.catch(function () {});
                                 }
                                 defer.reject(err);
                             });


### PR DESCRIPTION
This is a proposal to solve the `Unhandled Promise Rejection` reported in #2062.

If for any reason the call to `signTransaction` fails, the `promiEvent` created during the contract method call will emit an `error` message -if working as an event emitter- and will also be rejected.