### PR TITLE
Fix sha3 to take BN type

### DIFF
--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -425,12 +425,12 @@ var isTopic = function (topic) {
 var SHA3_NULL_S = '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
 
 var sha3 = function (value) {
-    if (isHexStrict(value) && /^0x/i.test((value).toString())) {
-        value = hexToBytes(value);
+    if (isBN(value)) {
+        value = value.toString();
     }
 
-    if (isBN(value)) {
-        value = value.toString(10);
+    if (isHexStrict(value) && /^0x/i.test((value).toString())) {
+        value = hexToBytes(value);
     }
 
     var returnValue = Hash.keccak256(value); // jshint ignore:line

--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -429,6 +429,10 @@ var sha3 = function (value) {
         value = hexToBytes(value);
     }
 
+    if (isBN(value)) {
+        value = value.toString(10);
+    }
+
     var returnValue = Hash.keccak256(value); // jshint ignore:line
 
     if(returnValue === SHA3_NULL_S) {


### PR DESCRIPTION
Tryting to fix 
#2093 issue.

Currently, sha3 can't take an BN type argument. However, there is an example in https://web3js.readthedocs.io/en/1.0/web3-utils.html#sha3 which takes an BN instance as an argument.

@joshstevens19 Thank you :)

