### PR TITLE
Allow keepAlive option when instantiating HttpProvider

### DIFF
--- a/packages/web3-providers-http/src/index.js
+++ b/packages/web3-providers-http/src/index.js
@@ -31,16 +31,18 @@ var https = require('https');
 /**
  * HttpProvider should be used to send rpc calls over http
  */
-var HttpProvider = function HttpProvider(host, options = {}) {
-    const keepAlive =
+var HttpProvider = function HttpProvider(host, options) {
+    options = options || {};
+
+    var keepAlive =
         (options.keepAlive === true || options.keepAlive !== false) ?
             true :
             false;
     this.host = host || 'http://localhost:8545';
     if (this.host.substring(0,5) === "https") {
-        this.httpsAgent = new https.Agent({ keepAlive });
+        this.httpsAgent = new https.Agent({ keepAlive: keepAlive });
     }else{
-        this.httpAgent = new http.Agent({ keepAlive });
+        this.httpAgent = new http.Agent({ keepAlive: keepAlive });
     }
     this.timeout = options.timeout || 0;
     this.headers = options.headers;

--- a/packages/web3-providers-http/src/index.js
+++ b/packages/web3-providers-http/src/index.js
@@ -31,13 +31,16 @@ var https = require('https');
 /**
  * HttpProvider should be used to send rpc calls over http
  */
-var HttpProvider = function HttpProvider(host, options) {
-    options = options || {};
+var HttpProvider = function HttpProvider(host, options = {}) {
+    const keepAlive =
+        (options.keepAlive === true || options.keepAlive !== false) ?
+            true :
+            false;
     this.host = host || 'http://localhost:8545';
-    if (this.host.substring(0,5) === "https"){
-        this.httpsAgent = new https.Agent({ keepAlive: true });
+    if (this.host.substring(0,5) === "https") {
+        this.httpsAgent = new https.Agent({ keepAlive });
     }else{
-        this.httpAgent = new http.Agent({ keepAlive: true });
+        this.httpAgent = new http.Agent({ keepAlive });
     }
     this.timeout = options.timeout || 0;
     this.headers = options.headers;


### PR DESCRIPTION
This PR proposes to make `keepAlive` an option for the HTTP Provider.

As mentioned in trufflesuite/truffle#1504, Truffle is not prepared to handle `keepAlive: true` in all cases.

Please also see @elenadimitrova's paper-trail at trufflesuite/truffle#1461, which identified the issue on Truffle's end.

Thanks to @eggplantzzz for pursuing and implementing the fix.