### PR TITLE
Fix overly strict function validation requirements for decoding parameters

### DIFF
--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -222,7 +222,7 @@ ABICoder.prototype.decodeParameter = function (type, bytes) {
  * @return {Array} array of plain params
  */
 ABICoder.prototype.decodeParameters = function (outputs, bytes) {
-    if (!bytes || bytes === '0x' || bytes === '0X') {
+    if (outputs.length > 0 && (!bytes || bytes === '0x' || bytes === '0X')) {
         throw new Error('Returned values aren\'t valid, did it run Out of Gas?');
     }
 


### PR DESCRIPTION
This should fix #1916 and #2065. 
Arises from trufflesuite/truffle#1487. Also being tracked on Truffle's end at trufflesuite/truffle#1504.

There is a bit of history here, in that empty bytes arrays have been variously represented as:
- `"0x"` (correct value, others malformed)
- `"0X"`
- `"0x0"`
- `""`
- who knows what else

Anyway, Ganache was passing `"0x0"` for awhile, and now that's stopped, exposing this conditional that asserts `bytes` must contain data. In the case where `outputs` equals `[]`, an empty value for `bytes` is really all that makes sense.

This PR thus loosens the conditional a bit, to throw the exception only if `bytes` is empty and `outputs` is non-empty.