### PR TITLE
[documentation] Clarify getAccounts and new Account

### DIFF
--- a/docs/web3-eth-accounts.rst
+++ b/docs/web3-eth-accounts.rst
@@ -34,7 +34,9 @@ create
 
     web3.eth.accounts.create([entropy]);
 
-Generates an account object with private key and public key.
+Generates an account object with private key and public key. It's different from
+:ref:`web3.eth.personal.newAccount() <personal-newaccount>` which creates an account
+over the network on the node via an RPC call.
 
 ----------
 Parameters

--- a/docs/web3-eth-personal.rst
+++ b/docs/web3-eth-personal.rst
@@ -261,6 +261,47 @@ Example
     .then(console.log('Account unlocked!'));
     > "Account unlocked!"
 
+------------------------------------------------------------------------------
+
+.. _personal-getaccounts:
+
+getAccounts
+=====================
+
+.. code-block:: javascript
+
+    web3.eth.personal.getAccounts([callback])
+
+Returns a list of accounts the node controls by using the provider and calling
+the RPC method ``personal_listAccounts``. Using :ref:`web3.eth.accounts.create() <accounts-create>`
+will not add accounts into this list. For that use
+:ref:`web3.eth.personal.newAccount() <personal-newaccount>`.
+
+The results are the same as :ref:`web3.eth.getAccounts() <eth-getaccounts>` except that calls
+the RPC method ``eth_accounts``.
+
+-------
+Returns
+-------
+
+
+``Promise`` returns ``Array`` - An array of addresses controlled by node.
+
+-------
+Example
+-------
+
+
+.. code-block:: javascript
+
+    web3.eth.getAccounts()
+    .then(console.log);
+    > ["0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", "0xDCc6960376d6C6dEa93647383FfB245CfCed97Cf"]
+
+
+------------------------------------------------------------------------------
+
+
 // TODO
 
-getAccounts, lockAccount, sendTransaction
+lockAccount, sendTransaction

--- a/docs/web3-eth-personal.rst
+++ b/docs/web3-eth-personal.rst
@@ -294,7 +294,7 @@ Example
 
 .. code-block:: javascript
 
-    web3.eth.getAccounts()
+    web3.eth.personal.getAccounts()
     .then(console.log);
     > ["0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", "0xDCc6960376d6C6dEa93647383FfB245CfCed97Cf"]
 

--- a/docs/web3-eth-personal.rst
+++ b/docs/web3-eth-personal.rst
@@ -37,7 +37,7 @@ The ``web3-eth-personal`` package allows you to interact with the Ethereum node'
 
 ------------------------------------------------------------------------------
 
-
+.. _personal-newaccount:
 
 newAccount
 =========
@@ -46,7 +46,10 @@ newAccount
 
     web3.eth.personal.newAccount(password, [callback])
 
-Creates a new account.
+Create a new account on the node that Web3 is connected to with its provider.
+The RPC method used is ``personal_newAccount``. It differs from
+:ref:`web3.eth.accounts.create() <accounts-create>` where the key pair is
+created only on client and it's up to the developer to manage it.
 
 .. note:: Never call this function over a unsecured Websocket or HTTP provider, as your password will be send in plain text!
 

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -424,6 +424,9 @@ the RPC method ``eth_accounts``. Using :ref:`web3.eth.accounts.create() <account
 will not add accounts into this list. For that use
 :ref:`web3.eth.personal.newAccount() <personal-newaccount>`.
 
+The results are the same as :ref:`web3.eth.personal.getAccounts() <personal-getaccounts>` except that calls
+the RPC method ``personal_listAccounts``.
+
 -------
 Returns
 -------

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -410,6 +410,7 @@ Example
 
 ------------------------------------------------------------------------------
 
+.. _eth-getaccounts:
 
 getAccounts
 =====================
@@ -418,7 +419,10 @@ getAccounts
 
     web3.eth.getAccounts([callback])
 
-Returns a list of accounts the node controls.
+Returns a list of accounts the node controls by using the provider and calling
+the RPC method ``eth_accounts``. Using :ref:`web3.eth.accounts.create() <accounts-create>`
+will not add accounts into this list. For that use
+:ref:`web3.eth.personal.newAccount() <personal-newaccount>`.
 
 -------
 Returns


### PR DESCRIPTION
## What does it do?

#1154 pointed out that it's not clear what `web3.eth.getAccounts` is doing. This PR tells how `web3.eth.personal.newAccount` and `web3.eth.getAccounts` work together and which RPC methods they call. It describes how it's different than `web3.eth.accounts.create()`.

The missing documentation for `web3.eth.personal.getAccounts` was added.

Related bounty: #2081

## Does it work?

This how it's rendered locally. It will look a little different when it gets deployed.

 *change* `web3.eth.getAccounts()`

<img width="834" alt="screen shot 2018-12-14 at 1 33 33 pm" src="https://user-images.githubusercontent.com/1634015/50026284-9b00ae80-ffa5-11e8-9404-01e0a1ee5a2b.png">

---

*create* `web3.eth.personal.getAccounts()`

<img width="833" alt="screen shot 2018-12-14 at 1 38 25 pm" src="https://user-images.githubusercontent.com/1634015/50026316-bbc90400-ffa5-11e8-9be6-474949b57f79.png">

---

*change* `web3.eth.personal.newAccount()`

<img width="836" alt="screen shot 2018-12-14 at 1 38 36 pm" src="https://user-images.githubusercontent.com/1634015/50026334-d0a59780-ffa5-11e8-8c10-4feba105af3f.png">

---

*change* `web3.eth.accounts.create()`

<img width="831" alt="screen shot 2018-12-14 at 1 38 50 pm" src="https://user-images.githubusercontent.com/1634015/50026354-e31fd100-ffa5-11e8-90d1-d86b0b346c2e.png">
