### PR TITLE
Web3 bzz types

### DIFF
--- a/packages/web3-bzz/package-lock.json
+++ b/packages/web3-bzz/package-lock.json
@@ -1,13 +1,21 @@
 {
-	"requires": true,
+	"name": "web3-bzz",
+	"version": "1.0.0-beta.36",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"@types/parsimmon": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
+			"integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ==",
+			"dev": true
+		},
 		"accepts": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"requires": {
-				"mime-types": "~2.1.18",
+				"mime-types": "2.1.21",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -16,10 +24,37 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
 			"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "2.0.1",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.4.1",
+				"uri-js": "4.2.2"
+			}
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"array-flatten": {
@@ -32,7 +67,7 @@
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"requires": {
-				"safer-buffer": "~2.1.0"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"assert-plus": {
@@ -60,6 +95,38 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
 			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
 		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
+					}
+				}
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
 		"base64-js": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
@@ -70,7 +137,7 @@
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"bl": {
@@ -78,8 +145,8 @@
 			"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
 			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"readable-stream": "2.3.6",
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"bluebird": {
@@ -98,15 +165,25 @@
 			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
 			"requires": {
 				"bytes": "3.0.0",
-				"content-type": "~1.0.4",
+				"content-type": "1.0.4",
 				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "~1.6.3",
+				"depd": "1.1.2",
+				"http-errors": "1.6.3",
 				"iconv-lite": "0.4.23",
-				"on-finished": "~2.3.0",
+				"on-finished": "2.3.0",
 				"qs": "6.5.2",
 				"raw-body": "2.3.3",
-				"type-is": "~1.6.16"
+				"type-is": "1.6.16"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "1.0.0",
+				"concat-map": "0.0.1"
 			}
 		},
 		"brorand": {
@@ -119,7 +196,7 @@
 			"resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
 			"integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
 			"requires": {
-				"js-sha3": "^0.3.1"
+				"js-sha3": "0.3.1"
 			}
 		},
 		"buffer": {
@@ -127,8 +204,8 @@
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
 			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
 			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4"
+				"base64-js": "1.3.0",
+				"ieee754": "1.1.12"
 			}
 		},
 		"buffer-alloc": {
@@ -136,8 +213,8 @@
 			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
 			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
 			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
+				"buffer-alloc-unsafe": "1.1.0",
+				"buffer-fill": "1.0.0"
 			}
 		},
 		"buffer-alloc-unsafe": {
@@ -160,6 +237,12 @@
 			"resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
 			"integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
 		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
+		},
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -170,17 +253,63 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
+		"chalk": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.5.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.3"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "3.0.0"
+					}
+				}
+			}
+		},
 		"chownr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
 			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
 		},
 		"combined-stream": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
 			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -188,8 +317,14 @@
 			"resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
 			"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
 			"requires": {
-				"graceful-readlink": ">= 1.0.0"
+				"graceful-readlink": "1.0.1"
 			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -221,8 +356,8 @@
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
 			"integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
 			"requires": {
-				"object-assign": "^4",
-				"vary": "^1"
+				"object-assign": "4.1.1",
+				"vary": "1.1.2"
 			}
 		},
 		"dashdash": {
@@ -230,7 +365,7 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"debug": {
@@ -251,14 +386,14 @@
 			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
 			"integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
 			"requires": {
-				"decompress-tar": "^4.0.0",
-				"decompress-tarbz2": "^4.0.0",
-				"decompress-targz": "^4.0.0",
-				"decompress-unzip": "^4.0.1",
-				"graceful-fs": "^4.1.10",
-				"make-dir": "^1.0.0",
-				"pify": "^2.3.0",
-				"strip-dirs": "^2.0.0"
+				"decompress-tar": "4.1.1",
+				"decompress-tarbz2": "4.1.1",
+				"decompress-targz": "4.1.1",
+				"decompress-unzip": "4.0.1",
+				"graceful-fs": "4.1.15",
+				"make-dir": "1.3.0",
+				"pify": "2.3.0",
+				"strip-dirs": "2.1.0"
 			}
 		},
 		"decompress-response": {
@@ -266,7 +401,7 @@
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "1.0.1"
 			}
 		},
 		"decompress-tar": {
@@ -274,9 +409,9 @@
 			"resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
 			"integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
 			"requires": {
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0",
-				"tar-stream": "^1.5.2"
+				"file-type": "5.2.0",
+				"is-stream": "1.1.0",
+				"tar-stream": "1.6.2"
 			}
 		},
 		"decompress-tarbz2": {
@@ -284,11 +419,11 @@
 			"resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
 			"integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
 			"requires": {
-				"decompress-tar": "^4.1.0",
-				"file-type": "^6.1.0",
-				"is-stream": "^1.1.0",
-				"seek-bzip": "^1.0.5",
-				"unbzip2-stream": "^1.0.9"
+				"decompress-tar": "4.1.1",
+				"file-type": "6.2.0",
+				"is-stream": "1.1.0",
+				"seek-bzip": "1.0.5",
+				"unbzip2-stream": "1.3.1"
 			},
 			"dependencies": {
 				"file-type": {
@@ -303,9 +438,9 @@
 			"resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
 			"integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
 			"requires": {
-				"decompress-tar": "^4.1.1",
-				"file-type": "^5.2.0",
-				"is-stream": "^1.1.0"
+				"decompress-tar": "4.1.1",
+				"file-type": "5.2.0",
+				"is-stream": "1.1.0"
 			}
 		},
 		"decompress-unzip": {
@@ -313,10 +448,10 @@
 			"resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
 			"integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
 			"requires": {
-				"file-type": "^3.8.0",
-				"get-stream": "^2.2.0",
-				"pify": "^2.3.0",
-				"yauzl": "^2.4.2"
+				"file-type": "3.9.0",
+				"get-stream": "2.3.1",
+				"pify": "2.3.0",
+				"yauzl": "2.10.0"
 			},
 			"dependencies": {
 				"file-type": {
@@ -324,6 +459,14 @@
 					"resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
 					"integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
 				}
+			}
+		},
+		"definitelytyped-header-parser": {
+			"version": "github:Microsoft/definitelytyped-header-parser#e0561530379dfa01324a89936b75d90b20df9bd2",
+			"dev": true,
+			"requires": {
+				"@types/parsimmon": "1.10.0",
+				"parsimmon": "1.12.0"
 			}
 		},
 		"delayed-stream": {
@@ -341,10 +484,29 @@
 			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
 		"dom-walk": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
 			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+		},
+		"dtslint": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.3.0.tgz",
+			"integrity": "sha512-3oWL8MD+2nKaxmNzrt8EAissP63hNSJ4OLr/itvNnPdAAl+7vxnjQ8p2Zdk0MNgdenqwk7GcaUDz7fQHaPgCyA==",
+			"dev": true,
+			"requires": {
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#e0561530379dfa01324a89936b75d90b20df9bd2",
+				"fs-promise": "2.0.3",
+				"strip-json-comments": "2.0.1",
+				"tslint": "5.11.0",
+				"typescript": "3.3.0-dev.20181214"
+			}
 		},
 		"duplexer3": {
 			"version": "0.1.4",
@@ -356,8 +518,8 @@
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"ee-first": {
@@ -370,13 +532,13 @@
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
 			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
 			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
+				"bn.js": "4.11.8",
+				"brorand": "1.1.0",
+				"hash.js": "1.1.5",
+				"hmac-drbg": "1.0.1",
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"encodeurl": {
@@ -389,13 +551,31 @@
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"requires": {
-				"once": "^1.4.0"
+				"once": "1.4.0"
 			}
 		},
 		"escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -407,13 +587,13 @@
 			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
 			"integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
 			"requires": {
-				"bn.js": "^4.11.6",
-				"elliptic": "^6.4.0",
-				"keccakjs": "^0.2.1",
-				"nano-json-stream-parser": "^0.1.2",
-				"servify": "^0.1.12",
-				"ws": "^3.0.0",
-				"xhr-request-promise": "^0.1.2"
+				"bn.js": "4.11.8",
+				"elliptic": "6.4.1",
+				"keccakjs": "0.2.1",
+				"nano-json-stream-parser": "0.1.2",
+				"servify": "0.1.12",
+				"ws": "3.3.3",
+				"xhr-request-promise": "0.1.2"
 			}
 		},
 		"express": {
@@ -421,36 +601,36 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
 			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
 			"requires": {
-				"accepts": "~1.3.5",
+				"accepts": "1.3.5",
 				"array-flatten": "1.1.1",
 				"body-parser": "1.18.3",
 				"content-disposition": "0.5.2",
-				"content-type": "~1.0.4",
+				"content-type": "1.0.4",
 				"cookie": "0.3.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
 				"finalhandler": "1.1.1",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.4",
+				"proxy-addr": "2.0.4",
 				"qs": "6.5.2",
-				"range-parser": "~1.2.0",
+				"range-parser": "1.2.0",
 				"safe-buffer": "5.1.2",
 				"send": "0.16.2",
 				"serve-static": "1.13.2",
 				"setprototypeof": "1.1.0",
-				"statuses": "~1.4.0",
-				"type-is": "~1.6.16",
+				"statuses": "1.4.0",
+				"type-is": "1.6.16",
 				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
+				"vary": "1.1.2"
 			},
 			"dependencies": {
 				"statuses": {
@@ -485,7 +665,7 @@
 			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
 			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"requires": {
-				"pend": "~1.2.0"
+				"pend": "1.2.0"
 			}
 		},
 		"file-type": {
@@ -499,12 +679,12 @@
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.2",
-				"statuses": "~1.4.0",
-				"unpipe": "~1.0.0"
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.4.0",
+				"unpipe": "1.0.0"
 			},
 			"dependencies": {
 				"statuses": {
@@ -519,7 +699,7 @@
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
 			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
 			"requires": {
-				"is-callable": "^1.1.3"
+				"is-callable": "1.1.4"
 			}
 		},
 		"forever-agent": {
@@ -532,9 +712,9 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.7",
+				"mime-types": "2.1.21"
 			}
 		},
 		"forwarded": {
@@ -557,9 +737,9 @@
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
 			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"graceful-fs": "4.1.15",
+				"jsonfile": "4.0.0",
+				"universalify": "0.1.2"
 			}
 		},
 		"fs-minipass": {
@@ -567,16 +747,55 @@
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 			"requires": {
-				"minipass": "^2.2.1"
+				"minipass": "2.3.5"
 			}
+		},
+		"fs-promise": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
+			"integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
+			"dev": true,
+			"requires": {
+				"any-promise": "1.3.0",
+				"fs-extra": "2.1.2",
+				"mz": "2.7.0",
+				"thenify-all": "1.6.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+					"integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.15",
+						"jsonfile": "2.4.0"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "4.1.15"
+					}
+				}
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"get-stream": {
 			"version": "2.3.1",
 			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
 			"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
 			"requires": {
-				"object-assign": "^4.0.1",
-				"pinkie-promise": "^2.0.0"
+				"object-assign": "4.1.1",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"getpass": {
@@ -584,7 +803,21 @@
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"global": {
@@ -592,8 +825,8 @@
 			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
 			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
 			"requires": {
-				"min-document": "^2.19.0",
-				"process": "~0.5.1"
+				"min-document": "2.19.0",
+				"process": "0.5.2"
 			}
 		},
 		"got": {
@@ -601,20 +834,20 @@
 			"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
 			"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
 			"requires": {
-				"decompress-response": "^3.2.0",
-				"duplexer3": "^0.1.4",
-				"get-stream": "^3.0.0",
-				"is-plain-obj": "^1.1.0",
-				"is-retry-allowed": "^1.0.0",
-				"is-stream": "^1.0.0",
-				"isurl": "^1.0.0-alpha5",
-				"lowercase-keys": "^1.0.0",
-				"p-cancelable": "^0.3.0",
-				"p-timeout": "^1.1.1",
-				"safe-buffer": "^5.0.1",
-				"timed-out": "^4.0.0",
-				"url-parse-lax": "^1.0.0",
-				"url-to-options": "^1.0.1"
+				"decompress-response": "3.3.0",
+				"duplexer3": "0.1.4",
+				"get-stream": "3.0.0",
+				"is-plain-obj": "1.1.0",
+				"is-retry-allowed": "1.1.0",
+				"is-stream": "1.1.0",
+				"isurl": "1.0.0",
+				"lowercase-keys": "1.0.1",
+				"p-cancelable": "0.3.0",
+				"p-timeout": "1.2.1",
+				"safe-buffer": "5.1.2",
+				"timed-out": "4.0.1",
+				"url-parse-lax": "1.0.0",
+				"url-to-options": "1.0.1"
 			},
 			"dependencies": {
 				"get-stream": {
@@ -644,9 +877,24 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
 			"requires": {
-				"ajv": "^6.5.5",
-				"har-schema": "^2.0.0"
+				"ajv": "6.5.5",
+				"har-schema": "2.0.0"
 			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
 		},
 		"has-symbol-support-x": {
 			"version": "1.4.2",
@@ -658,7 +906,7 @@
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
 			"requires": {
-				"has-symbol-support-x": "^1.4.1"
+				"has-symbol-support-x": "1.4.2"
 			}
 		},
 		"hash.js": {
@@ -666,8 +914,8 @@
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
 			"integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
 			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
+				"inherits": "2.0.3",
+				"minimalistic-assert": "1.0.1"
 			}
 		},
 		"hmac-drbg": {
@@ -675,9 +923,9 @@
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
+				"hash.js": "1.1.5",
+				"minimalistic-assert": "1.0.1",
+				"minimalistic-crypto-utils": "1.0.1"
 			}
 		},
 		"http-errors": {
@@ -685,10 +933,10 @@
 			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
-				"depd": "~1.1.2",
+				"depd": "1.1.2",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"statuses": "1.5.0"
 			}
 		},
 		"http-signature": {
@@ -696,9 +944,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.15.2"
 			}
 		},
 		"iconv-lite": {
@@ -706,13 +954,23 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
 			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"ieee754": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
 			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
+			}
 		},
 		"inherits": {
 			"version": "2.0.3",
@@ -779,14 +1037,30 @@
 			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
 			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
 			"requires": {
-				"has-to-string-tag-x": "^1.2.0",
-				"is-object": "^1.0.1"
+				"has-to-string-tag-x": "1.4.1",
+				"is-object": "1.0.1"
 			}
 		},
 		"js-sha3": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.3.1.tgz",
 			"integrity": "sha1-hhIoAhQvCChQKg0d7h2V4lO7AkM="
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.1"
+			}
 		},
 		"jsbn": {
 			"version": "0.1.1",
@@ -813,7 +1087,7 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"requires": {
-				"graceful-fs": "^4.1.6"
+				"graceful-fs": "4.1.15"
 			}
 		},
 		"jsprim": {
@@ -832,8 +1106,8 @@
 			"resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
 			"integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
 			"requires": {
-				"browserify-sha3": "^0.0.1",
-				"sha3": "^1.1.0"
+				"browserify-sha3": "0.0.1",
+				"sha3": "1.2.2"
 			}
 		},
 		"lowercase-keys": {
@@ -846,7 +1120,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -886,7 +1160,7 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
 			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.37.0"
 			}
 		},
 		"mimic-response": {
@@ -899,7 +1173,7 @@
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
 			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
 			"requires": {
-				"dom-walk": "^0.1.0"
+				"dom-walk": "0.1.1"
 			}
 		},
 		"minimalistic-assert": {
@@ -912,6 +1186,15 @@
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
 			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "1.1.11"
+			}
+		},
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -922,8 +1205,8 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
+				"safe-buffer": "5.1.2",
+				"yallist": "3.0.2"
 			}
 		},
 		"minizlib": {
@@ -931,7 +1214,7 @@
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
 			"integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
 			"requires": {
-				"minipass": "^2.2.1"
+				"minipass": "2.3.5"
 			}
 		},
 		"mkdirp": {
@@ -947,7 +1230,7 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
 			"integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
 			"requires": {
-				"mkdirp": "*"
+				"mkdirp": "0.5.1"
 			}
 		},
 		"mock-fs": {
@@ -959,6 +1242,17 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dev": true,
+			"requires": {
+				"any-promise": "1.3.0",
+				"object-assign": "4.1.1",
+				"thenify-all": "1.6.0"
+			}
 		},
 		"nan": {
 			"version": "2.10.0",
@@ -998,7 +1292,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"p-cancelable": {
@@ -1016,7 +1310,7 @@
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
 			"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
 			"requires": {
-				"p-finally": "^1.0.0"
+				"p-finally": "1.0.0"
 			}
 		},
 		"parse-headers": {
@@ -1024,7 +1318,7 @@
 			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
 			"integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
 			"requires": {
-				"for-each": "^0.3.2",
+				"for-each": "0.3.3",
 				"trim": "0.0.1"
 			}
 		},
@@ -1032,6 +1326,24 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
 			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+		},
+		"parsimmon": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.12.0.tgz",
+			"integrity": "sha512-uC/BjuSfb4jfaWajKCp1mVncXXq+V1twbcYChbTxN3GM7fn+8XoHwUdvUz+PTaFtDSCRQxU8+Rnh+iMhAkVwdw==",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -1063,7 +1375,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"prepend-http": {
@@ -1086,7 +1398,7 @@
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
 			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
 			"requires": {
-				"forwarded": "~0.1.2",
+				"forwarded": "0.1.2",
 				"ipaddr.js": "1.8.0"
 			}
 		},
@@ -1110,9 +1422,9 @@
 			"resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
 			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"requires": {
-				"decode-uri-component": "^0.2.0",
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
+				"decode-uri-component": "0.2.0",
+				"object-assign": "4.1.1",
+				"strict-uri-encode": "1.1.0"
 			}
 		},
 		"range-parser": {
@@ -1136,13 +1448,13 @@
 			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"request": {
@@ -1150,26 +1462,35 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.8.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.7",
+				"extend": "3.0.2",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.3",
+				"har-validator": "5.1.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.21",
+				"oauth-sign": "0.9.0",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"tough-cookie": "2.4.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.3.2"
+			}
+		},
+		"resolve": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"dev": true,
+			"requires": {
+				"path-parse": "1.0.6"
 			}
 		},
 		"safe-buffer": {
@@ -1187,8 +1508,14 @@
 			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
 			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
 			"requires": {
-				"commander": "~2.8.1"
+				"commander": "2.8.1"
 			}
+		},
+		"semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
 		},
 		"send": {
 			"version": "0.16.2",
@@ -1196,18 +1523,18 @@
 			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
 			"requires": {
 				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "~1.6.2",
+				"http-errors": "1.6.3",
 				"mime": "1.4.1",
 				"ms": "2.0.0",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.0",
-				"statuses": "~1.4.0"
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.4.0"
 			},
 			"dependencies": {
 				"statuses": {
@@ -1222,9 +1549,9 @@
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
 				"send": "0.16.2"
 			}
 		},
@@ -1233,11 +1560,11 @@
 			"resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
 			"integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
 			"requires": {
-				"body-parser": "^1.16.0",
-				"cors": "^2.8.1",
-				"express": "^4.14.0",
-				"request": "^2.79.0",
-				"xhr": "^2.3.3"
+				"body-parser": "1.18.3",
+				"cors": "2.8.5",
+				"express": "4.16.4",
+				"request": "2.88.0",
+				"xhr": "2.5.0"
 			}
 		},
 		"setimmediate": {
@@ -1268,25 +1595,31 @@
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
 			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
 			"requires": {
-				"decompress-response": "^3.3.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
+				"decompress-response": "3.3.0",
+				"once": "1.4.0",
+				"simple-concat": "1.0.0"
 			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
 		},
 		"sshpk": {
 			"version": "1.15.2",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
 			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.4",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.2",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.2",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"statuses": {
@@ -1304,7 +1637,16 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
+			}
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-dirs": {
@@ -1312,26 +1654,38 @@
 			"resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
 			"integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
 			"requires": {
-				"is-natural-number": "^4.0.1"
+				"is-natural-number": "4.0.1"
 			}
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
 		},
 		"swarm-js": {
 			"version": "0.1.39",
 			"resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
 			"integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
 			"requires": {
-				"bluebird": "^3.5.0",
-				"buffer": "^5.0.5",
-				"decompress": "^4.0.0",
-				"eth-lib": "^0.1.26",
-				"fs-extra": "^4.0.2",
-				"got": "^7.1.0",
-				"mime-types": "^2.1.16",
-				"mkdirp-promise": "^5.0.1",
-				"mock-fs": "^4.1.0",
-				"setimmediate": "^1.0.5",
-				"tar": "^4.0.2",
-				"xhr-request-promise": "^0.1.2"
+				"bluebird": "3.5.3",
+				"buffer": "5.2.1",
+				"decompress": "4.2.0",
+				"eth-lib": "0.1.27",
+				"fs-extra": "4.0.3",
+				"got": "7.1.0",
+				"mime-types": "2.1.21",
+				"mkdirp-promise": "5.0.1",
+				"mock-fs": "4.7.0",
+				"setimmediate": "1.0.5",
+				"tar": "4.4.8",
+				"xhr-request-promise": "0.1.2"
 			}
 		},
 		"tar": {
@@ -1339,13 +1693,13 @@
 			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
 			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 			"requires": {
-				"chownr": "^1.1.1",
-				"fs-minipass": "^1.2.5",
-				"minipass": "^2.3.4",
-				"minizlib": "^1.1.1",
-				"mkdirp": "^0.5.0",
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.2"
+				"chownr": "1.1.1",
+				"fs-minipass": "1.2.5",
+				"minipass": "2.3.5",
+				"minizlib": "1.1.1",
+				"mkdirp": "0.5.1",
+				"safe-buffer": "5.1.2",
+				"yallist": "3.0.2"
 			}
 		},
 		"tar-stream": {
@@ -1353,13 +1707,31 @@
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
 			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
 			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
+				"bl": "1.2.2",
+				"buffer-alloc": "1.2.0",
+				"end-of-stream": "1.4.1",
+				"fs-constants": "1.0.0",
+				"readable-stream": "2.3.6",
+				"to-buffer": "1.1.1",
+				"xtend": "4.0.1"
+			}
+		},
+		"thenify": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+			"integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+			"dev": true,
+			"requires": {
+				"any-promise": "1.3.0"
+			}
+		},
+		"thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+			"dev": true,
+			"requires": {
+				"thenify": "3.3.0"
 			}
 		},
 		"through": {
@@ -1382,8 +1754,8 @@
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
+				"psl": "1.1.29",
+				"punycode": "1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -1398,12 +1770,55 @@
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
 			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
 		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.11.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "6.26.0",
+				"builtin-modules": "1.1.1",
+				"chalk": "2.4.1",
+				"commander": "2.19.0",
+				"diff": "3.5.0",
+				"glob": "7.1.3",
+				"js-yaml": "3.12.0",
+				"minimatch": "3.0.4",
+				"resolve": "1.8.1",
+				"semver": "5.6.0",
+				"tslib": "1.9.3",
+				"tsutils": "2.29.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+					"dev": true
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "1.9.3"
+			}
+		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -1417,8 +1832,14 @@
 			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "~2.1.18"
+				"mime-types": "2.1.21"
 			}
+		},
+		"typescript": {
+			"version": "3.3.0-dev.20181214",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.0-dev.20181214.tgz",
+			"integrity": "sha512-dy3hilVp3gHsKEqj837gzo6YLn5IuX+5obTkdLJuvceYQ1B/fBnj4Y+FB44IQdmZ4oaeQd5+7u+uI6vDvp5FhQ==",
+			"dev": true
 		},
 		"ultron": {
 			"version": "1.1.1",
@@ -1430,8 +1851,8 @@
 			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
 			"integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
 			"requires": {
-				"buffer": "^3.0.1",
-				"through": "^2.3.6"
+				"buffer": "3.6.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"base64-js": {
@@ -1445,8 +1866,8 @@
 					"integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
 					"requires": {
 						"base64-js": "0.0.8",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
+						"ieee754": "1.1.12",
+						"isarray": "1.0.0"
 					}
 				}
 			}
@@ -1471,7 +1892,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			}
 		},
 		"url-parse-lax": {
@@ -1479,7 +1900,7 @@
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"requires": {
-				"prepend-http": "^1.0.1"
+				"prepend-http": "1.0.4"
 			}
 		},
 		"url-set-query": {
@@ -1517,9 +1938,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"wrappy": {
@@ -1532,9 +1953,9 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
 			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
 			"requires": {
-				"async-limiter": "~1.0.0",
-				"safe-buffer": "~5.1.0",
-				"ultron": "~1.1.0"
+				"async-limiter": "1.0.0",
+				"safe-buffer": "5.1.2",
+				"ultron": "1.1.1"
 			}
 		},
 		"xhr": {
@@ -1542,10 +1963,10 @@
 			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
 			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
 			"requires": {
-				"global": "~4.3.0",
-				"is-function": "^1.0.1",
-				"parse-headers": "^2.0.0",
-				"xtend": "^4.0.0"
+				"global": "4.3.2",
+				"is-function": "1.0.1",
+				"parse-headers": "2.0.1",
+				"xtend": "4.0.1"
 			}
 		},
 		"xhr-request": {
@@ -1553,13 +1974,13 @@
 			"resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
 			"integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
 			"requires": {
-				"buffer-to-arraybuffer": "^0.0.5",
-				"object-assign": "^4.1.1",
-				"query-string": "^5.0.1",
-				"simple-get": "^2.7.0",
-				"timed-out": "^4.0.1",
-				"url-set-query": "^1.0.0",
-				"xhr": "^2.0.4"
+				"buffer-to-arraybuffer": "0.0.5",
+				"object-assign": "4.1.1",
+				"query-string": "5.1.1",
+				"simple-get": "2.8.1",
+				"timed-out": "4.0.1",
+				"url-set-query": "1.0.0",
+				"xhr": "2.5.0"
 			}
 		},
 		"xhr-request-promise": {
@@ -1567,7 +1988,7 @@
 			"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
 			"integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
 			"requires": {
-				"xhr-request": "^1.0.1"
+				"xhr-request": "1.1.0"
 			}
 		},
 		"xtend": {
@@ -1585,8 +2006,8 @@
 			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
 			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
+				"buffer-crc32": "0.2.13",
+				"fd-slicer": "1.1.0"
 			}
 		}
 	}

--- a/packages/web3-bzz/package.json
+++ b/packages/web3-bzz/package.json
@@ -11,14 +11,18 @@
     "scripts": {
         "build": "rollup -c",
         "dev": "rollup -c -w",
-        "test": "jest"
+        "test": "jest",
+        "dtslint": "dtslint types"
     },
     "dependencies": {
         "swarm-js": "^0.1.39",
         "underscore-es": "^1.9.8"
     },
+    "devDependencies": {
+        "dtslint": "^0.3.0"
+    },
     "files": [
         "dist",
-        "index.d.ts"
+        "types/index.d.ts"
     ]
 }

--- a/packages/web3-bzz/types/index.d.ts
+++ b/packages/web3-bzz/types/index.d.ts
@@ -20,8 +20,8 @@
 // once dependency tree is sorted we can reuse web3-providers types here
 // for now we keep them loosely typed.
 export class Bzz {
-    constructor(provider: string);
-    setProvider(provider: string): boolean;
+    constructor(provider: string | {});
+    setProvider(provider: string | {}): boolean;
     givenProvider: {};
     currentProvider: string | null;
     upload(data: string | Buffer | Uint8Array | {}): Promise<string>;

--- a/packages/web3-bzz/types/index.d.ts
+++ b/packages/web3-bzz/types/index.d.ts
@@ -17,13 +17,20 @@
  * @date 2018
  */
 
-export declare class Bzz {
-    constructor(provider: Object | string);
-    pick(): Object | boolean;
-    download(bzzHash: string, localPath: string): Promise<Buffer|Object|string>;
-    upload(data: string | Buffer | Uint8Array | Object): Promise<string>;
-    isAvailable(): Promise<boolean>;
-    hasProvider(): boolean;
-    throwProviderError();
-    setProvider(provider: Object | string): boolean;
+// once dependency tree is sorted we can reuse web3-providers types here
+// for now we keep them loosely typed.
+export class Bzz {
+    constructor(provider: string);
+    setProvider(provider: string): boolean;
+    givenProvider: {};
+    currentProvider: string | null;
+    upload(data: string | Buffer | Uint8Array | {}): Promise<string>;
+    download(bzzHash: string, localPath?: string): Promise<Buffer | {} | string>;
+    pick: Pick;
+}
+
+export interface Pick {
+    file: () => Promise<any>;
+    directory: () => Promise<any>;
+    data: () => Promise<any>;
 }

--- a/packages/web3-bzz/types/index.d.ts
+++ b/packages/web3-bzz/types/index.d.ts
@@ -19,6 +19,8 @@
 
 // once dependency tree is sorted we can reuse web3-providers types here
 // for now we keep them loosely typed.
+// should really have a dependency on `web3-providers` as its using all
+// the providers objects within the class
 export class Bzz {
     constructor(provider: string | {});
     setProvider(provider: string | {}): boolean;
@@ -27,6 +29,7 @@ export class Bzz {
     upload(data: string | Buffer | Uint8Array | {}): Promise<string>;
     download(bzzHash: string, localPath?: string): Promise<Buffer | {} | string>;
     pick: Pick;
+    BatchRequest: new () => any;
 }
 
 export interface Pick {

--- a/packages/web3-bzz/types/index.d.ts
+++ b/packages/web3-bzz/types/index.d.ts
@@ -24,7 +24,7 @@
 export class Bzz {
     constructor(provider: string | {});
     setProvider(provider: string | {}): boolean;
-    givenProvider: {};
+    givenProvider: {} | string | null;
     currentProvider: string | null;
     upload(data: string | Buffer | Uint8Array | {}): Promise<string>;
     download(bzzHash: string, localPath?: string): Promise<Buffer | {} | string>;

--- a/packages/web3-bzz/types/tests/bzz-test.ts
+++ b/packages/web3-bzz/types/tests/bzz-test.ts
@@ -63,3 +63,6 @@ bzz.pick.directory();
 
 // $ExpectType Promise<any>
 bzz.pick.data();
+
+// $ExpectType any
+new bzz.BatchRequest();

--- a/packages/web3-bzz/types/tests/bzz-test.ts
+++ b/packages/web3-bzz/types/tests/bzz-test.ts
@@ -1,0 +1,62 @@
+/*
+    This file is part of web3.js.
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file bzz-tests.ts
+ * @author Josh Stevens <joshstevens19@hotmail.co.uk>
+ * @date 2018
+ */
+
+import {Bzz} from 'web3-bzz';
+
+const bzz = new Bzz('http://swarm-gateways.net');
+
+// $ExpectType boolean
+bzz.setProvider('test.com');
+
+// $ExpectType {}
+bzz.givenProvider;
+
+// $ExpectType string | null
+bzz.currentProvider;
+
+// $ExpectType Promise<string>
+bzz.upload('test file');
+
+const dir = {
+    '/foo.txt': {type: 'text/plain', data: 'sample file'},
+    '/bar.txt': {type: 'text/plain', data: 'another file'}
+};
+
+// $ExpectType Promise<string>
+bzz.upload(dir);
+// $ExpectType Promise<string>
+bzz.upload({
+    path: '/path/to/thing',
+    kind: 'directory',
+    defaultFile: '/index.html'
+});
+
+// $ExpectType Promise<string | {} | Buffer>
+bzz.download('a5c10851ef054c268a2438f10a21f6efe3dc3dcdcc2ea0e6a1a7a38bf8c91e23');
+// $ExpectType Promise<string | {} | Buffer>
+bzz.download('a5c1', '/target/dir');
+
+// $ExpectType Promise<any>
+bzz.pick.file();
+
+// $ExpectType Promise<any>
+bzz.pick.directory();
+
+// $ExpectType Promise<any>
+bzz.pick.data();

--- a/packages/web3-bzz/types/tests/bzz-test.ts
+++ b/packages/web3-bzz/types/tests/bzz-test.ts
@@ -27,7 +27,7 @@ bzz.setProvider('test.com');
 // $ExpectType boolean
 bzz.setProvider({});
 
-// $ExpectType {}
+// $ExpectType {} | string | null
 bzz.givenProvider;
 
 // $ExpectType string | null

--- a/packages/web3-bzz/types/tests/bzz-test.ts
+++ b/packages/web3-bzz/types/tests/bzz-test.ts
@@ -24,6 +24,9 @@ const bzz = new Bzz('http://swarm-gateways.net');
 // $ExpectType boolean
 bzz.setProvider('test.com');
 
+// $ExpectType boolean
+bzz.setProvider({});
+
 // $ExpectType {}
 bzz.givenProvider;
 

--- a/packages/web3-bzz/types/tsconfig.json
+++ b/packages/web3-bzz/types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+        "allowSyntheticDefaultImports": true,
+        "baseUrl": ".",
+        "paths": { 
+            "web3-bzz": ["."] 
+        }
+    }
+}

--- a/packages/web3-bzz/types/tslint.json
+++ b/packages/web3-bzz/types/tslint.json
@@ -1,0 +1,11 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "semicolon": false,
+        "no-import-default-of-export-equals": false,
+        "file-name-casing": [true, "kebab-case"],
+        "whitespace": false,
+        "no-unnecessary-class": false,
+        "unified-signatures": false
+    }
+}


### PR DESCRIPTION
web3-bzz types - as they have no dependencies on shared web3-core + web3-provider i have kept them loosely typed. 

This should really have a dependency on `web3-providers` if we could put that dependency on we could strongly type most of this without repeating typings? I think it should also inherit `AbstractWeb3Module` as well on the Bzz class. 

This is why i decided to keep it loosely typed, if we can have a discussion on the above to bring these dependencies in then that would be great.

👍 