### PR TITLE
remove Swarm from package exports

### DIFF
--- a/lib/web3.js
+++ b/lib/web3.js
@@ -38,6 +38,7 @@ var DB = require('./web3/methods/db');
 var Shh = require('./web3/methods/shh');
 var Net = require('./web3/methods/net');
 var Personal = require('./web3/methods/personal');
+var Swarm = require('./web3/methods/swarm');
 var Debug = require('./web3/methods/debug');
 var Settings = require('./web3/settings');
 var version = require('./version.json');
@@ -61,6 +62,7 @@ function Web3 (provider) {
     this.net = new Net(this);
     this.personal = new Personal(this);
     this.debug = new Debug(this);
+    this.bzz = new Swarm(this);
     this.settings = new Settings();
     this.version = {
         api: version.version

--- a/lib/web3.js
+++ b/lib/web3.js
@@ -38,7 +38,6 @@ var DB = require('./web3/methods/db');
 var Shh = require('./web3/methods/shh');
 var Net = require('./web3/methods/net');
 var Personal = require('./web3/methods/personal');
-var Swarm = require('./web3/methods/swarm');
 var Debug = require('./web3/methods/debug');
 var Settings = require('./web3/settings');
 var version = require('./version.json');
@@ -62,7 +61,6 @@ function Web3 (provider) {
     this.net = new Net(this);
     this.personal = new Personal(this);
     this.debug = new Debug(this);
-    this.bzz = new Swarm(this);
     this.settings = new Settings();
     this.version = {
         api: version.version

--- a/lib/web3/methods/swarm.js
+++ b/lib/web3/methods/swarm.js
@@ -24,7 +24,6 @@
 
 "use strict";
 
-var Method = require('../method');
 var Property = require('../property');
 
 function Swarm(web3) {
@@ -44,88 +43,7 @@ function Swarm(web3) {
 }
 
 var methods = function () {
-    var blockNetworkRead = new Method({
-        name: 'blockNetworkRead',
-        call: 'bzz_blockNetworkRead',
-        params: 1,
-        inputFormatter: [null]
-    });
-
-    var syncEnabled = new Method({
-        name: 'syncEnabled',
-        call: 'bzz_syncEnabled',
-        params: 1,
-        inputFormatter: [null]
-    });
-
-    var swapEnabled = new Method({
-        name: 'swapEnabled',
-        call: 'bzz_swapEnabled',
-        params: 1,
-        inputFormatter: [null]
-    });
-
-    var download = new Method({
-        name: 'download',
-        call: 'bzz_download',
-        params: 2,
-        inputFormatter: [null, null]
-    });
-
-    var upload = new Method({
-        name: 'upload',
-        call: 'bzz_upload',
-        params: 2,
-        inputFormatter: [null, null]
-    });
-
-    var retrieve = new Method({
-        name: 'retrieve',
-        call: 'bzz_retrieve',
-        params: 1,
-        inputFormatter: [null]
-    });
-
-    var store = new Method({
-        name: 'store',
-        call: 'bzz_store',
-        params: 2,
-        inputFormatter: [null, null]
-    });
-
-    var get = new Method({
-        name: 'get',
-        call: 'bzz_get',
-        params: 1,
-        inputFormatter: [null]
-    });
-
-    var put = new Method({
-        name: 'put',
-        call: 'bzz_put',
-        params: 2,
-        inputFormatter: [null, null]
-    });
-
-    var modify = new Method({
-        name: 'modify',
-        call: 'bzz_modify',
-        params: 4,
-        inputFormatter: [null, null, null, null]
-    });
-
-    return [
-        blockNetworkRead,
-        syncEnabled,
-        swapEnabled,
-        download,
-        upload,
-        retrieve,
-        store,
-        get,
-        put,
-        modify
-    ];
+    return [];
 };
 
 var properties = function () {


### PR DESCRIPTION
Currently, Swarm implementation in `web3.js` is broken. This PR removes the problematic references from the main `Web3` object until we sort this issue out.

If someone could point out how and where `web3-bzz` is maintained since the npm repo link is broken.