### PR TITLE
remove `web3.bzz` from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,6 @@ Contents:
     web3-eth-iban
     web3-eth-abi
     web3-net
-    web3-bzz
     web3-shh
     web3-utils
     web3-admin


### PR DESCRIPTION
Currently, Swarm implementation in `web3.js` is broken and the documentation is very much misleading. 
This PR removes the `web3.bzz` documentation from the TOC in order to reduce clutter and confusion among users till we sort this out.