### PR TITLE
[documentation] Clarify privateKeyToAccount private string is hex

### DIFF
--- a/docs/web3-eth-accounts.rst
+++ b/docs/web3-eth-accounts.rst
@@ -104,7 +104,7 @@ Creates an account object from a private key.
 Parameters
 ----------
 
-1. ``privateKey`` - ``String``: The private key to convert.
+1. ``privateKey`` - ``String``: The private key hex string beginning with ``0x``.
 
 -------
 Returns


### PR DESCRIPTION
## What does it do?

#1267 brought up a good point that `web3.eth.accounts.privateKeyToAccount` `privateKey` does not specify that it's a hex string. This PR fixes that in the documentation.

## Does it work?

<img width="533" alt="screen shot 2018-12-15 at 4 50 09 pm" src="https://user-images.githubusercontent.com/1634015/50048441-8c8bc300-0089-11e9-87d4-b66c1b1ca0be.png">
