### PR TITLE
Don't try to parse non-indexed params if not expecting any

### DIFF
--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -280,7 +280,7 @@ ABICoder.prototype.decodeLog = function (inputs, data, topics) {
 
 
     var nonIndexedData = data;
-    var notIndexedParams = (nonIndexedData) ? this.decodeParameters(notIndexedInputs, nonIndexedData) : [];
+    var notIndexedParams = (notIndexedInputs.length > 0) ? this.decodeParameters(notIndexedInputs, nonIndexedData) : [];
 
     var returnValue = new Result();
     returnValue.__length__ = 0;


### PR DESCRIPTION
Problem manifests with ganache-cli 6.2.3, ganache-core 2.3.1.

Ganache returns transaction receipt with following attribute:
```
"logs": [
    {
      "logIndex": 0,
      "transactionIndex": 0,
      "transactionHash": "0xf010b9bd46c455b4969cfbf9f40d0a68d44ab1c6d4e572ae823c90b985b77da7",
      "blockHash": "0x28c20253994729717b0c9ede9e9e58a92fb0f5bfe837651c6eb83e5ada94f529",
      "blockNumber": 1,
      "address": "0xbAA81A0179015bE47Ad439566374F2Bae098686F",
      "data": "0x",
      "topics": [
        "0x6ae172837ea30b801fbfcdd4108aa1d5bf8ff775444fd70256b44e6bf3dfc3f6",
        "0x000000000000000000000000a3d1f77acff0060f7213d7bf3c7fec78df847de1"
      ],
      "type": "mined",
      "id": "log_1137f293"
    }
  ]
```

Notice the `"data": "0x"`. That is truthy, so decodeLog will try to decodeParameters([], "0x") which fails with `Error('Returned values aren\'t valid, did it run Out of Gas?')`. Pre-1.0 web3.js doesn't crash here, so probably 1.0 shouldn't either. It's not against the spec to denote "nothing" with a "0x".