### PR TITLE
fix quorum timestamp

### DIFF
--- a/lib/web3/formatters.js
+++ b/lib/web3/formatters.js
@@ -182,7 +182,20 @@ var outputBlockFormatter = function(block) {
     block.gasLimit = utils.toDecimal(block.gasLimit);
     block.gasUsed = utils.toDecimal(block.gasUsed);
     block.size = utils.toDecimal(block.size);
-    block.timestamp = utils.toDecimal(block.timestamp);
+    
+    try {
+      block.timestamp = utils.hexToNumber(block.timestamp);
+    }
+    catch (err) {
+      // WARNING this implementation assumes RAFT timestamp (precision is nanoseconds)
+      // You should not simply assume RAFT if it is not successful rather take a consensus specific 
+      // action
+
+      // we are being extra cautious here and converting it back to the same format it was in after dropping
+      // the nanoseconds (i.e. a hex string prefixed with 0x)
+      block.timestamp = '0x' + Math.floor(block.timestamp / 1e6).toString(16);
+    }
+    
     if(block.number !== null)
         block.number = utils.toDecimal(block.number);
 


### PR DESCRIPTION
Quorum timestamp has nanoseconds. Make outputBlockFormatter possible to work with it.