### PR TITLE
[documentation]  Fixing `fromWei` and `toWei`  

### DIFF
--- a/docs/web3-utils.rst
+++ b/docs/web3-utils.rst
@@ -977,7 +977,7 @@ Converts any `ether value <http://ethdocs.org/en/latest/ether.html>`_ value into
 Parameters
 ----------
 
-1. ``number`` - ``String|Number|BN``: The value.
+1. ``number`` - ``String|BN``: The value.
 2. ``unit`` - ``String`` (optional, defaults to ``"ether"``): The ether to convert from. Possible units are:
     - ``noether``: '0'
     - ``wei``: '1'
@@ -1011,7 +1011,7 @@ Parameters
 Returns
 -------
 
-``String|BN``: If a number, or string is given it returns a number string, otherwise a `BN.js <https://github.com/indutny/bn.js/>`_ instance.
+``String|BN``: If a string is given it returns a number string, otherwise a `BN.js <https://github.com/indutny/bn.js/>`_ instance.
 
 -------
 Example
@@ -1051,7 +1051,7 @@ Converts any `wei <http://ethereum.stackexchange.com/questions/253/the-ether-den
 Parameters
 ----------
 
-1. ``number`` - ``String|Number|BN``: The value in wei.
+1. ``number`` - ``String|BN``: The value in wei.
 2. ``unit`` - ``String`` (optional, defaults to ``"ether"``): The ether to convert to. Possible units are:
     - ``noether``: '0'
     - ``wei``: '1'
@@ -1085,7 +1085,7 @@ Parameters
 Returns
 -------
 
-``String|BN``: If a number, or string is given it returns a number string, otherwise a `BN.js <https://github.com/indutny/bn.js/>`_ instance.
+``String``: It always returns a string number.
 
 -------
 Example


### PR DESCRIPTION
As https://github.com/ethereum/web3.js/issues/1874 pointed out
`web3.utils.toWei` and `web3.utils.fromWei` 's docs are poorly written and input parameters, return types are given are incorrect.
