### PR TITLE
[documentation]Adding information about gas parameters gasPrice and gasUsed

### DIFF
--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -50,7 +50,7 @@ Parameters
 2. ``address`` - ``String`` (optional): The address of the smart contract to call, can be added later using ``myContract.options.address = '0x1234..'``
 3. ``options`` - ``Object`` (optional): The options of the contract. Some are used as fallbacks for calls and transactions:
     * ``from`` - ``String``: The address transactions should be made from.
-    * ``gasPrice`` - ``String``: The gas price in wei to use for transactions.
+    * ``gasPrice`` - ``String``: The gas price in wei to use for transactions.It is the wei per unit of gas.
     * ``gas`` - ``Number``: The maximum gas provided for a transaction (gas limit).
     * ``data`` - ``String``: The byte code of the contract. Used when the contract gets :ref:`deployed <contract-deploy>`.
 
@@ -101,7 +101,7 @@ Properties
 - ``jsonInterface`` - ``Array``: The json interface of the contract. See :ref:`options.jsonInterface <contract-json-interface>`.
 - ``data`` - ``String``: The byte code of the contract. Used when the contract gets :ref:`deployed <contract-deploy>`.
 - ``from`` - ``String``: The address transactions should be made from.
-- ``gasPrice`` - ``String``: The gas price in wei to use for transactions.
+- ``gasPrice`` - ``String``: The gas price in wei to use for transactions.It is the wei per unit of gas.
 - ``gas`` - ``Number``: The maximum gas provided for a transaction (gas limit).
 
 
@@ -442,7 +442,7 @@ Parameters
 
 1. ``options`` - ``Object`` (optional): The options used for calling.
     * ``from`` - ``String`` (optional): The address the call "transaction" should be made from.
-    * ``gasPrice`` - ``String`` (optional): The gas price in wei to use for this call "transaction".
+    * ``gasPrice`` - ``String`` (optional): The gas price in wei to use for this call "transaction".It is the wei per unit of gas.
     * ``gas`` - ``Number`` (optional): The maximum gas provided for this call "transaction" (gas limit).
 2. ``callback`` - ``Function`` (optional): This callback will be fired with the result of the smart contract method execution as the second argument, or with an error object as the first argument.
 
@@ -529,7 +529,7 @@ Parameters
 
 1. ``options`` - ``Object``: The options used for sending.
     * ``from`` - ``String``: The address the transaction should be sent from.
-    * ``gasPrice`` - ``String`` (optional): The gas price in wei to use for this transaction.
+    * ``gasPrice`` - ``String`` (optional): The gas price in wei to use for this transaction.It is the wei per unit of gas.
     * ``gas`` - ``Number`` (optional): The maximum gas provided for this transaction (gas limit).
     * ``value`` - ``Number|String|BN|BigNumber``(optional): The value transferred for the transaction in wei.
 2. ``callback`` - ``Function`` (optional): This callback will be fired first with the "transactionHash", or with an error object as the first argument.

--- a/docs/web3-eth-subscribe.rst
+++ b/docs/web3-eth-subscribe.rst
@@ -206,7 +206,7 @@ The structure of a returned block header is as follows:
     - ``miner`` - ``String``: The address of the beneficiary to whom the mining rewards were given.
     - ``extraData`` - ``String``: The "extra data" field of this block.
     - ``gasLimit`` - ``Number``: The maximum gas allowed in this block.
-    - ``gasUsed`` - ``Number``: The total used gas by all transactions in this block.
+    - ``gasUsed`` - ``Number``: The total used gas by all transactions in this block. It can be multiplied to `gasPrice` to obtain total amount in wei.
     - ``timestamp`` - ``Number``: The unix timestamp for when the block was collated.
 
 ----------------

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -387,6 +387,7 @@ getGasPrice
 
 Returns the current gas price oracle.
 The gas price is determined by the last few blocks median gas price.
+GasPrice is the wei per unit of gas,.
 
 -------
 Returns
@@ -795,7 +796,7 @@ Returns
   - ``from`` - ``String``: Address of the sender.
   - ``to`` - ``String``: Address of the receiver. ``null`` when its a contract creation transaction.
   - ``value`` - ``String``: Value transferred in :ref:`wei <what-is-wei>`.
-  - ``gasPrice`` - ``String``: Gas price provided by the sender in :ref:`wei <what-is-wei>`.
+  - ``gasPrice`` - ``String``: The wei per unit of gas provided by the sender in :ref:`wei <what-is-wei>`.
   - ``gas`` - ``Number``: Gas provided by the sender.
   - ``input`` - ``String``: The data sent along with the transaction.
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/web3.js/issues/1686
Mentioned about gasPrice being wei per unit gas to several places.
Total amount spent on transactions is added along with gasUsed's definitions.

@nivida Perhaps we can also provide Total Amount Spent information on the web3.eth.getBlock() info section or web3.eth.Contract info page.