### PR TITLE
[documentation] Removing ambiguity of transaction object

### DIFF
--- a/docs/web3-eth-accounts.rst
+++ b/docs/web3-eth-accounts.rst
@@ -146,7 +146,7 @@ Signs an Ethereum transaction with a given private key.
 Parameters
 ----------
 
-1. ``tx`` - ``Object``: The transaction object as follows:
+1. ``tx`` - ``Object``: The transaction's properties object as follows:
     - ``nonce`` - ``String``: (optional) The nonce to use when signing this transaction. Default will use :ref:`web3.eth.getTransactionCount() <eth-gettransactioncount>`.
     - ``chainId`` - ``String``: (optional) The chain id to use when signing this transaction. Default will use :ref:`web3.eth.net.getId() <net-getid>`.
     - ``to`` - ``String``: (optional) The recevier of the transaction, can be empty when deploying a contract.

--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -379,7 +379,7 @@ Parameters of any method depend on the smart contracts methods, defined in the :
 Returns
 -------
 
-``Object``: The transaction object:
+``Object``: The Transaction Object:
 
 - ``Array`` - arguments: The arguments passed to the method before. They can be changed.
 - ``Function`` - :ref:`call <contract-call>`: Will call the "constant" method and execute its smart contract method in the EVM without sending a transaction (Can't alter the smart contract state).


### PR DESCRIPTION
Fixes #1716  
Function `myContract.methods.myMethod` returns a transaction object as output, according to the [docs](https://web3js.readthedocs.io/en/1.0/web3-eth-contract.html#id13).
Function `web3.eth.accounts.signTransaction` takes a transaction object as input, according to the [docs](https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#id4).
At both places instead of using same term `transaction object` we can use `transaction's properties object` for `web3.eth.accounts.signTransaction`. 