### PR TITLE
Add 'txHash' field to the result of 'accounts.signTransaction'

### DIFF
--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -194,13 +194,16 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
 
             var rawTransaction = RLP.encode(rawTx);
 
+            const txHash = Hash.keccak256(rawTransaction)
+
             var values = RLP.decode(rawTransaction);
             result = {
                 messageHash: hash,
                 v: trimLeadingZero(values[6]),
                 r: trimLeadingZero(values[7]),
                 s: trimLeadingZero(values[8]),
-                rawTransaction: rawTransaction
+                rawTransaction: rawTransaction,
+                txHash: txHash,
             };
 
         } catch(e) {


### PR DESCRIPTION
Sometimes, a user wants to know transaction hash before sending a `eth_sendRawTransaction`.

Of course, if the user send a transaction with `eth_sendTransaction` rpc call, user should wait for the response of the rpc call to receive transaction hash from Ethereum node. (It assumes the user doesn't use private key for signing, he uses unlockedAccount instead.)

On the otherhand, if the user send a transaction with `eth_sendRawTransaction` rpc call, user can know the transaction hash before sending the rpc call. (It assumes the user uses private key for signing directly.)

According to go-ethereum/src/internal/api.go, there are 2 steps to return `txHash` for a response of the rpc call.

Step 1: call `SendRawTransaction` function.

It accepts rlp-encoded transaction as an argument which is the the value `rawTransaction` of the result of calling `web3.eth.accounts.signTransaction(tx, privateKey)`.

After getting the encoded `rawTransaction`, this function decodes the encoded one. (rlp decode)
Then stores the decoded value to `tx` variable.

At last, call `submitTransaction()` function with `tx` variable which is decoded raw transaction.

```go
func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encodedTx hexutil.Bytes) (common.Hash, error) {
	tx := new(types.Transaction)
	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
		return common.Hash{}, err
	}
	return submitTransaction(ctx, s.b, tx)
}
```

Step 2: call `submitTransaction`, return `tx.Hash()`

It returns `tx.Hash()` which is the payload for the response of `sendRawTransaction`.

```go
func submitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (common.Hash, error) {
	if err := b.SendTx(ctx, tx); err != nil {
		return common.Hash{}, err
	}
	if tx.To() == nil {
		signer := types.MakeSigner(b.ChainConfig(), b.CurrentBlock().Number())
		from, err := types.Sender(signer, tx)
		if err != nil {
			return common.Hash{}, err
		}
		addr := crypto.CreateAddress(from, tx.Nonce())
		log.Info("Submitted contract creation", "fullhash", tx.Hash().Hex(), "contract", addr.Hex())
	} else {
		log.Info("Submitted transaction", "fullhash", tx.Hash().Hex(), "recipient", tx.To())
	}
	return tx.Hash(), nil
}
```

How `tx.Hash()` works?

Following code is the internal code of `tx.Hash`.

`go-ethereum/blockchain/types/transaction.go`
```go
func (tx *Transaction) Hash() common.Hash {
	if hash := tx.hash.Load(); hash != nil {
		return hash.(common.Hash)
	}
	v := rlpHash(tx)
	tx.hash.Store(v)
	return v
}
```

`go-ethereum/blockchain/types/block.go`
```go
func rlpHash(x interface{}) (h common.Hash) {
	hw := sha3.NewKeccak256()
	rlp.Encode(hw, x)
	hw.Sum(h[:0])
	return h
}
```

What it does is simple: do `keccak256` hash for the encoded transaction(rawTransaction.)

That's it. 

It means that if you already know encoded raw transaction (with signature, of course), you can achieve `txHash` before sending `eth_sendRawTransaction` rpc call, by `keccak256(rawTransaction)`.

It would be better if we add `txHash` field for the result of `web3.eth.accounts.signTransaction()`.

@nivida @frozeman @joshstevens19  Please take a look :)
