### PR TITLE
WIP: web3-core-types submodule

### DIFF
--- a/packages/web3-tx/README.md
+++ b/packages/web3-tx/README.md
@@ -1,27 +1,7 @@
-# web3-eth-abi
+# web3-tx
 
 This is a sub package of [web3.js][repo]
 
-This is the abi package will be used in the `web3-eth` package.
+This is the transaction package that allows building of web3-valid transactions.
+.
 Please read the [documentation][docs] for more.
-
-## Installation
-
-```bash
-npm install web3-eth-abi
-```
-
-## Usage
-
-```js
-import {AbiCoder} from 'web3-eth-abi';
-
-new AbiCoder();
-```
-
-## Types 
-
-All the typescript typings are placed in the types folder. 
-
-[docs]: http://web3js.readthedocs.io/en/1.0/
-[repo]: https://github.com/ethereum/web3.js

--- a/packages/web3-tx/README.md
+++ b/packages/web3-tx/README.md
@@ -1,0 +1,27 @@
+# web3-eth-abi
+
+This is a sub package of [web3.js][repo]
+
+This is the abi package will be used in the `web3-eth` package.
+Please read the [documentation][docs] for more.
+
+## Installation
+
+```bash
+npm install web3-eth-abi
+```
+
+## Usage
+
+```js
+import {AbiCoder} from 'web3-eth-abi';
+
+new AbiCoder();
+```
+
+## Types 
+
+All the typescript typings are placed in the types folder. 
+
+[docs]: http://web3js.readthedocs.io/en/1.0/
+[repo]: https://github.com/ethereum/web3.js

--- a/packages/web3-tx/jest.config.js
+++ b/packages/web3-tx/jest.config.js
@@ -1,4 +1,4 @@
-const jestConfig = require('../../jest.config');
+const jestConfig  = require('../../jest.config');
 
 module.exports = jestConfig({
     Utils: 'web3-utils'

--- a/packages/web3-tx/jest.config.js
+++ b/packages/web3-tx/jest.config.js
@@ -1,0 +1,5 @@
+const jestConfig = require('../../jest.config');
+
+module.exports = jestConfig({
+    Utils: 'web3-utils'
+});

--- a/packages/web3-tx/package.json
+++ b/packages/web3-tx/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "build": "rollup -c",
         "dev": "rollup -c -w",
-        "test": "jest --config jest.config.js",
+        "test": "jest --verbose false",
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "types": "types",

--- a/packages/web3-tx/package.json
+++ b/packages/web3-tx/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "web3-tx",
+    "namespace": "ethereum",
+    "version": "1.0.0-beta.38",
+    "description": "Web3 module to build transactions.",
+    "repository": "https://github.com/ethereum/web3.js/tree/master/packages/web3-tx",
+    "license": "LGPL-3.0",
+    "main": "dist/web3-tx.cjs.js",
+    "module": "dist/web3-tx.esm.js",
+    "browser": "dist/web3-tx.umd.js",
+    "scripts": {
+        "build": "rollup -c",
+        "dev": "rollup -c -w",
+        "test": "jest",
+        "dtslint": "dtslint types --onlyTestTsNext"
+    },
+    "types": "types",
+    "dependencies": {
+        "ethers": "4.0.21",
+        "lodash": "^4.17.11",
+        "web3-utils": "1.0.0-beta.38"
+    },
+    "devDependencies": {
+        "dtslint": "^0.4.2"
+    },
+    "files": [
+        "dist",
+        "types/index.d.ts"
+    ]
+}

--- a/packages/web3-tx/package.json
+++ b/packages/web3-tx/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "build": "rollup -c",
         "dev": "rollup -c -w",
-        "test": "jest",
+        "test": "jest --config jest.config.js",
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "types": "types",

--- a/packages/web3-tx/rollup.config.js
+++ b/packages/web3-tx/rollup.config.js
@@ -1,0 +1,4 @@
+import pkg from './package.json';
+import rollupConfig from '../../rollup.config';
+
+export default rollupConfig('Web3Tx', pkg.name);

--- a/packages/web3-tx/src/Transaction.js
+++ b/packages/web3-tx/src/Transaction.js
@@ -15,14 +15,14 @@
     along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 /**
- * @file index.js
- * @author Marek Kotewicz <marek@parity.io>
- * @author Fabian Vogelsteller <fabian@frozeman.de>
- * @date 2018
+ * @file Transaction.js
+ * @author Oscar Fonseca <hiro@cehh.io>
+ * @date 2019
  */
 
-import {isAddress, isBN, isBigNumber, toBN, } from 'web3-utils';
-import {isObject, isArray} from 'lodash';
+import {formatters} from 'web3-core-helpers';
+import {isAddress, isBN, isBigNumber, toBN, isHex} from 'web3-utils';
+import {isObject, isArray, omit} from 'lodash';
 
 export default class Transaction {
     /**
@@ -43,96 +43,64 @@ export default class Transaction {
         gas,
         gasPrice,
         data,
-        nonce
+        nonce,
+        error,  /* from factory */
+        params  /* from factory */
     ) {
-      
-        /* Set the error messages */
-        this.error = {
-            from:     `The 'from' parameter needs to be an address or a wallet index number.`,
-            to:       `The 'to' parameter needs to be an address or 'deploy' when deploying code.`,
-            value:    `The 'value' parameter needs to be zero or positive, and in number, BN, BigNumber or string format.\n` +
-                      `Use 'auto' for 0 ether.`,
-            gas:      ``,
-            gasPrice: ``,
-            data:     `The 'data' parameter needs to be hex encoded.` +
-                      `Use 'auto' for no payload.`,
-            nonce:    `The 'nonce' parameter needs to be an integer.` +
-                      `Use 'auto' to set the RPC-calculated nonce.`
-        };
-
-
-        /* Initialise the params */
-        this.params = {
-            from: undefined,
-            to: undefined,
-            value: undefined,
-            gas: undefined,
-            gasPrice: undefined,
-            data: undefined,
-            nonce: undefined
-        };
-
+        this.error = error;
+        this.params = params;
 
         /* Check for type and format validity */
-        this.params.from = isAddress(from) || Number.isInteger(from)
-            ? from
-            : undefined;
-
-        this.params.to = isAddress(to) 
-            ? to
-            : undefined;
-
-        this.params.value =
-            (
-              !isNan(value) && Number.isInteger(value) && value >= 0 ||
-              isBN(value) ||
-              isBigNumber(value) ||
-              typeof value === 'string' && isBN(toBN(value))
+        this.params.from = (
+                isAddress(from) || Number.isInteger(from)
             )
-            ? value.toString()
+            ? from.replace(/(0x)([0-9a-fA-F]{40})/gm, '0x$2').toLowerCase()
             : undefined;
 
-        this.params.gas = Number.isInteger(gas)
-            ? gas
+        this.params.to = isAddress(to)
+            ? to.replace(/(0x)([0-9a-fA-F]{40})/gm, '0x$2').toLowerCase()
             : undefined;
 
-        this.params.gasPrice = 
-            (
-              !isNan(gasPrice) && Number.isInteger(gasPrice) && gasPrice >= 0 ||
-              isBN(gasPrice) ||
-              isBigNumber(gasPrice) ||
-              typeof gasPrice === 'string' && isBN(toBN(gasPrice))
+        this.params.value = (
+                !isNan(value) && Number.isInteger(value) && value >= 0) ||
+                isBN(value) ||
+                isBigNumber(value) ||
+                (typeof value === 'string' && isBN(toBN(value))
             )
-            ? gasPrice
+            ? toBN(value.toString())
             : undefined;
 
-        this.params.data = isHex(data)
-            ? data
+        this.params.gas = Number.isInteger(gas) ? gas : undefined;
+
+        this.params.gasPrice = (
+                (!isNan(gasPrice) && Number.isInteger(gasPrice) && gasPrice >= 0) ||
+                isBN(gasPrice) ||
+                isBigNumber(gasPrice) ||
+                (typeof gasPrice === 'string' && isBN(toBN(gasPrice)))
+            )
+            ? toBN(gasPrice.toString())
             : undefined;
 
-        this.params.nonce = Number.isInteger(nonce)
-            ? nonce
-            : undefined;
+        this.params.data = isHex(data) ? data : undefined;
 
+        this.params.nonce = Number.isInteger(nonce) && nonce > 0 ? nonce : undefined;
 
         /* Set the default values */
-        if(to === 'deploy');
+        if (value === 'empty') this.value = toBN(0);
 
-        if(value === 'auto')
-            this.value = toBN(0);
+        if (gas === 'auto');
+        // TODO
 
-        if(gas === 'auto');
-            // TODO
+        if (gasPrice === 'auto');
+        // this.gasPrice = web3.eth.gasPrice
 
-        if(gasPrice === 'auto');
-            // this.gasPrice = web3.eth.gasPrice
+        if (data === 'empty') this.params.data = '0x';
 
-        if(data === 'none')
-            this.params.data = "0x";
+        if (nonce === 'auto');
+        // default nonce
 
-        if(nonce === 'auto');
-            // default nonce
-
+        /* Allow empty 'to' field if code is being deployed */
+        if (to === 'deploy') this.params = omit(this.params, 'to');
 
         /* Throw if any parameter is still undefined */
         Object.keys(this.params).forEach((key) => {
@@ -144,4 +112,5 @@ export default class Transaction {
         throw message;
     }
 
+    toHex() {}
 }

--- a/packages/web3-tx/src/Transaction.js
+++ b/packages/web3-tx/src/Transaction.js
@@ -1,0 +1,136 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file index.js
+ * @author Marek Kotewicz <marek@parity.io>
+ * @author Fabian Vogelsteller <fabian@frozeman.de>
+ * @date 2018
+ */
+
+import {isAddress, isBN, isBigNumber, toBN, } from 'web3-utils';
+import {isObject, isArray} from 'lodash';
+
+export default class Transaction {
+    /**
+     * @param {String|Number}
+     * @param {String|"contractCreation"}
+     * @param {Number|BN|BigNumber|String|"auto"}
+     * @param {Number|"auto"}
+     * @param {Number|BN|BigNumber|String|"auto"}
+     * @param {String|"auto"}
+     * @param {Number|"auto"}
+     *
+     * @constructor
+     */
+    constructor(
+        from,
+        to,
+        value,
+        gas,
+        gasPrice,
+        data,
+        nonce
+    ) {
+        this.error = {
+            from: "",
+            to: "",
+            value: "",
+            gas: "",
+            gasPrice: "",
+            data: "",
+            nonce: ""
+        };
+
+        this.params = {
+            from: undefined,
+            to: undefined,
+            value: undefined,
+            gas: undefined,
+            gasPrice: undefined,
+            data: undefined,
+            nonce: undefined
+        };
+
+        this.params.from = isAddress(from) || Number.isInteger(from)
+            ? from
+            : undefined;
+
+        this.params.to = isAddress(to) 
+            ? to
+            : undefined;
+
+        this.params.value =
+            (
+              !isNan(value) && Number.isInteger(value) && value >= 0 ||
+              isBN(value) ||
+              isBigNumber(value) ||
+              typeof value === 'string' && isBN(toBN(value))
+            )
+            ? value.toString()
+            : undefined;
+
+        this.params.gas = Number.isInteger(gas)
+            ? gas
+            : undefined;
+
+        this.params.gasPrice = 
+            (
+              !isNan(gasPrice) && Number.isInteger(gasPrice) && gasPrice >= 0 ||
+              isBN(gasPrice) ||
+              isBigNumber(gasPrice) ||
+              typeof gasPrice === 'string' && isBN(toBN(gasPrice))
+            )
+            ? gasPrice
+            : undefined;
+
+        this.params.data = isHex(data)
+            ? data
+            : undefined;
+
+        this.params.nonce = Number.isInteger(nonce)
+            ? nonce
+            : undefined;
+
+
+        if(to === 'contractCreation');
+
+        if(value === 'auto')
+            this.value = toBN(0);
+
+        if(gas === 'auto');
+            // TODO
+
+        if(gasPrice === 'auto');
+            // this.gasPrice = web3.eth.gasPrice
+
+        if(data === 'none')
+            this.params.data = "0x";
+
+        if(nonce === 'auto');
+            // default nonce
+
+        
+        Object.keys(this.params).forEach((key) => {
+            this.params[key] && _throw(this.error[key]);
+        });
+    }
+
+    _throw(message) {
+        throw message;
+    }
+
+}

--- a/packages/web3-tx/src/Transaction.js
+++ b/packages/web3-tx/src/Transaction.js
@@ -46,13 +46,16 @@ export default class Transaction {
         nonce
     ) {
         this.error = {
-            from: "",
-            to: "",
-            value: "",
-            gas: "",
-            gasPrice: "",
-            data: "",
-            nonce: ""
+            from:     `The 'from' parameter needs to be an address or a wallet index number.`,
+            to:       `The 'to' parameter needs to be an address or 'deploy' when deploying code.`,
+            value:    `The 'value' parameter needs to be zero or positive, and in number, BN, BigNumber or string format.\n` +
+                      `Use 'auto' for 0 ether.`,
+            gas:      ``,
+            gasPrice: ``,
+            data:     `The 'data' parameter needs to be hex encoded.` +
+                      `Use 'auto' for no payload.`,
+            nonce:    `The 'nonce' parameter needs to be an integer.` +
+                      `Use 'auto' to set the RPC-calculated nonce.`
         };
 
         this.params = {

--- a/packages/web3-tx/src/Transaction.js
+++ b/packages/web3-tx/src/Transaction.js
@@ -45,6 +45,8 @@ export default class Transaction {
         data,
         nonce
     ) {
+      
+        /* Set the error messages */
         this.error = {
             from:     `The 'from' parameter needs to be an address or a wallet index number.`,
             to:       `The 'to' parameter needs to be an address or 'deploy' when deploying code.`,
@@ -58,6 +60,8 @@ export default class Transaction {
                       `Use 'auto' to set the RPC-calculated nonce.`
         };
 
+
+        /* Initialise the params */
         this.params = {
             from: undefined,
             to: undefined,
@@ -68,6 +72,8 @@ export default class Transaction {
             nonce: undefined
         };
 
+
+        /* Check for type and format validity */
         this.params.from = isAddress(from) || Number.isInteger(from)
             ? from
             : undefined;
@@ -109,7 +115,8 @@ export default class Transaction {
             : undefined;
 
 
-        if(to === 'contractCreation');
+        /* Set the default values */
+        if(to === 'deploy');
 
         if(value === 'auto')
             this.value = toBN(0);
@@ -126,7 +133,8 @@ export default class Transaction {
         if(nonce === 'auto');
             // default nonce
 
-        
+
+        /* Throw if any parameter is still undefined */
         Object.keys(this.params).forEach((key) => {
             this.params[key] && _throw(this.error[key]);
         });

--- a/packages/web3-tx/src/Transaction.js
+++ b/packages/web3-tx/src/Transaction.js
@@ -20,9 +20,8 @@
  * @date 2019
  */
 
-import {formatters} from 'web3-core-helpers';
 import {isAddress, isBN, isBigNumber, toBN, isHex} from 'web3-utils';
-import {isObject, isArray, omit} from 'lodash';
+import {isNan, omit} from 'lodash';
 
 export default class Transaction {
     /**
@@ -70,7 +69,9 @@ export default class Transaction {
             ? toBN(value.toString())
             : undefined;
 
-        this.params.gas = Number.isInteger(gas) ? gas : undefined;
+        this.params.gas = Number.isInteger(gas)
+            ? gas
+            : undefined;
 
         this.params.gasPrice = (
                 (!isNan(gasPrice) && Number.isInteger(gasPrice) && gasPrice >= 0) ||
@@ -81,9 +82,13 @@ export default class Transaction {
             ? toBN(gasPrice.toString())
             : undefined;
 
-        this.params.data = isHex(data) ? data : undefined;
+        this.params.data = isHex(data)
+            ? data
+            : undefined;
 
-        this.params.nonce = Number.isInteger(nonce) && nonce > 0 ? nonce : undefined;
+        this.params.nonce = Number.isInteger(nonce) && nonce > 0
+            ? nonce
+            : undefined;
 
         /* Set the default values */
         if (value === 'empty') this.value = toBN(0);
@@ -104,7 +109,7 @@ export default class Transaction {
 
         /* Throw if any parameter is still undefined */
         Object.keys(this.params).forEach((key) => {
-            this.params[key] && _throw(this.error[key]);
+            this.params[key] && this._throw(this.error[key]);
         });
     }
 
@@ -112,5 +117,4 @@ export default class Transaction {
         throw message;
     }
 
-    toHex() {}
 }

--- a/packages/web3-tx/src/factories/TransactionFactory.js
+++ b/packages/web3-tx/src/factories/TransactionFactory.js
@@ -20,7 +20,6 @@
  * @date 2018
  */
 
-import {isObject, isArray} from 'lodash';
 import Transaction from '../Transaction';
 
 export default class TransactionFactory {
@@ -38,11 +37,11 @@ export default class TransactionFactory {
             to: "The 'to' parameter needs to be an address or 'deploy' when deploying code.",
             value:
                 "The 'value' parameter needs to be zero or positive, and in number, BN, BigNumber or string format.\n" +
-                "Use 'auto' for 0 ether.",
+                "Use 'none' for 0 ether.",
             gas: '',
             gasPrice: '',
-            data: "The 'data' parameter needs to be hex encoded." + "Use 'auto' for no payload.",
-            nonce: "The 'nonce' parameter needs to be an integer." + "Use 'auto' to set the RPC-calculated nonce."
+            data: "The 'data' parameter needs to be hex encoded.\n" + "Use 'none' for no payload.",
+            nonce: "The 'nonce' parameter needs to be an integer.\n" + "Use 'auto' to set the RPC-calculated nonce."
         };
 
         /* Initialise the params */
@@ -56,6 +55,10 @@ export default class TransactionFactory {
             nonce: undefined
         };
 
-        return new Transaction(...txParams, error, params);
+        return new Transaction(
+            txParams,
+            error,
+            params
+        );
     }
 }

--- a/packages/web3-tx/src/factories/TransactionFactory.js
+++ b/packages/web3-tx/src/factories/TransactionFactory.js
@@ -16,8 +16,8 @@
 */
 /**
  * @file TransactionFactory.js
- * @author Samuel Furter <samuel@ethereum.org>
- * @date 2018
+ * @author Oscar Fonseca <hiro@cehh.org>
+ * @date 2019
  */
 
 import Transaction from '../Transaction';

--- a/packages/web3-tx/src/factories/TransactionFactory.js
+++ b/packages/web3-tx/src/factories/TransactionFactory.js
@@ -25,15 +25,37 @@ import Transaction from '../Transaction';
 
 export default class TransactionFactory {
     /**
-     * Returns an object of type Transaction 
+     * Returns an object of type Transaction
      *
      * @method createTransaction
      *
      * @returns {Transaction}
      */
-    createTransaction() {
-        return new Transaction(
-            
-        );
+    createTransaction(txParams) {
+        /* Set the error messages */
+        const error = {
+            from: "The 'from' parameter needs to be an address or a wallet index number.",
+            to: "The 'to' parameter needs to be an address or 'deploy' when deploying code.",
+            value:
+                "The 'value' parameter needs to be zero or positive, and in number, BN, BigNumber or string format.\n" +
+                "Use 'auto' for 0 ether.",
+            gas: '',
+            gasPrice: '',
+            data: "The 'data' parameter needs to be hex encoded." + "Use 'auto' for no payload.",
+            nonce: "The 'nonce' parameter needs to be an integer." + "Use 'auto' to set the RPC-calculated nonce."
+        };
+
+        /* Initialise the params */
+        const params = {
+            from: undefined,
+            to: undefined,
+            value: undefined,
+            gas: undefined,
+            gasPrice: undefined,
+            data: undefined,
+            nonce: undefined
+        };
+
+        return new Transaction(...txParams, error, params);
     }
 }

--- a/packages/web3-tx/src/factories/TransactionFactory.js
+++ b/packages/web3-tx/src/factories/TransactionFactory.js
@@ -1,0 +1,39 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file TransactionFactory.js
+ * @author Samuel Furter <samuel@ethereum.org>
+ * @date 2018
+ */
+
+import {isObject, isArray} from 'lodash';
+import Transaction from '../Transaction';
+
+export default class TransactionFactory {
+    /**
+     * Returns an object of type Transaction 
+     *
+     * @method createTransaction
+     *
+     * @returns {Transaction}
+     */
+    createTransaction() {
+        return new Transaction(
+            
+        );
+    }
+}

--- a/packages/web3-tx/src/index.js
+++ b/packages/web3-tx/src/index.js
@@ -1,0 +1,34 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file index.js
+ * @author Samuel Furter <samuel@ethereum.org>
+ * @date 2018
+ */
+
+import TransactionFactory from './factories/TransactionFactory';
+
+/**
+ * Returns an object of Transaction 
+ *
+ * @returns {Transaction}
+ *
+ * @constructor
+ */
+export const Transaction = () => {
+    return new TransactionFactory().createTransaction();
+};

--- a/packages/web3-tx/src/index.js
+++ b/packages/web3-tx/src/index.js
@@ -16,8 +16,8 @@
 */
 /**
  * @file index.js
- * @author Samuel Furter <samuel@ethereum.org>
- * @date 2018
+ * @author Oscar Fonseca <hiro@cehh.org>
+ * @date 2019
  */
 
 import TransactionFactory from './factories/TransactionFactory';

--- a/packages/web3-tx/src/index.js
+++ b/packages/web3-tx/src/index.js
@@ -23,12 +23,12 @@
 import TransactionFactory from './factories/TransactionFactory';
 
 /**
- * Returns an object of Transaction 
+ * Returns an object of Transaction
  *
  * @returns {Transaction}
  *
  * @constructor
  */
-export const Transaction = () => {
-    return new TransactionFactory().createTransaction();
+export const Transaction = (txParams) => {
+    return new TransactionFactory().createTransaction(txParams);
 };

--- a/packages/web3-tx/tests/TransactionTest.js
+++ b/packages/web3-tx/tests/TransactionTest.js
@@ -13,8 +13,6 @@ describe('TransactionTest', () => {
     beforeEach(() => {});
 
     it('constructor check', () => {
-        expect().toEqual();
-
-        expect().toEqual();
+        expect(1).toEqual(1);
     });
 });

--- a/packages/web3-tx/tests/TransactionTest.js
+++ b/packages/web3-tx/tests/TransactionTest.js
@@ -1,18 +1,149 @@
 import * as Utils from 'web3-utils';
+import {cloneDeep} from 'lodash';
 import Transaction from '../src/Transaction';
-
-// Mocks
-jest.mock('Utils');
 
 /**
  * Transaction test
  */
 describe('TransactionTest', () => {
     let transaction;
+    let txParamsTest;
 
-    beforeEach(() => {});
+    const txParams = {
+        from: '0xE247A45c287191d435A8a5D72A7C8dc030451E9F',
+        to: '0x4F38f4229924bfa28D58eeda496Cc85e8016bCCC',
+        value: Utils.toWei((1).toString(), 'ether'),
+        gas: 21000,
+        gasPrice: Utils.toWei((1).toString(), 'gwei'),
+        data: '0x0',
+        nonce: 0
+    };
+
+    const error = {
+        from: "The 'from' parameter needs to be an address or a wallet index number.",
+        to: "The 'to' parameter needs to be an address or 'deploy' when deploying code.",
+        value:
+            "The 'value' parameter needs to be zero or positive, and in number, BN, BigNumber or string format.\n" +
+            "Use 'none' for 0 ether.",
+        gas: '',
+        gasPrice: '',
+        data: "The 'data' parameter needs to be hex encoded.\n" + "Use 'none' for no payload.",
+        nonce: "The 'nonce' parameter needs to be an integer.\n" + "Use 'auto' to set the RPC-calculated nonce."
+    };
+
+    const params = {
+        from: undefined,
+        to: undefined,
+        value: undefined,
+        gas: undefined,
+        gasPrice: undefined,
+        data: undefined,
+        nonce: undefined
+    };
+
+    beforeEach(() => {
+        txParamsTest = cloneDeep(txParams);
+    });
 
     it('constructor check', () => {
-        expect(1).toEqual(1);
+        transaction = new Transaction(
+            txParamsTest,
+            error,
+            params
+        );
+
+        expect(transaction).toHaveProperty('error');
+        expect(transaction).toHaveProperty('params');
+    });
+    
+    it('accepts value types and parses to BN', () => {
+        const tests = [
+            {value: 101, is: Utils.toBN(101)},
+            {value: Utils.toBN(102), is: Utils.toBN(102)},
+            {value: "103", is: Utils.toBN(103)}
+        ];  
+     
+        tests.forEach((test) => {
+            txParamsTest.value = test.value;
+
+            transaction = new Transaction(
+                txParamsTest,
+                error,
+                params
+            );
+
+            expect(transaction).toHaveProperty('params');
+            expect(transaction.params.value).toEqual(test.is);
+        });
+    });
+    
+    it('accepts gas integer values', () => {
+        const tests = [
+            {value: 0},
+            {value: 10},
+        ];  
+     
+        tests.forEach((test) => {
+            txParamsTest.gas = test.value;
+
+            transaction = new Transaction(
+                txParamsTest,
+                error,
+                params
+            );
+
+            expect(transaction).toHaveProperty('params');
+            expect(transaction.params.gas).toEqual(test.value);
+        });
+    });
+    
+    it('removes "to" for code deployment', () => {
+        txParamsTest.to = 'deploy';
+        transaction = new Transaction(
+            txParamsTest,
+            error,
+            params
+        );
+
+        expect(transaction).toHaveProperty('params');
+        expect(transaction.params).not.toHaveProperty('to');
+    });
+    
+    it('sets 0 value for "none"', () => {
+        txParamsTest.value = 'none';
+        transaction = new Transaction(
+            txParamsTest,
+            error,
+            params
+        );
+
+        expect(transaction).toHaveProperty('params');
+        expect(transaction.params.value).toMatchObject(Utils.toBN(0));
+    });
+    
+    it('sets 0x data for "none"', () => {
+        txParamsTest.data = 'none';
+        transaction = new Transaction(
+            txParamsTest,
+            error,
+            params
+        );
+
+        expect(transaction).toHaveProperty('params');
+        expect(transaction.params.data).toEqual("0x");
     });
 });
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/packages/web3-tx/tests/TransactionTest.js
+++ b/packages/web3-tx/tests/TransactionTest.js
@@ -1,0 +1,21 @@
+import * as Utils from 'web3-utils';
+import Transaction from '../src/Transaction';
+
+// Mocks
+jest.mock('Utils');
+
+/**
+ * Transaction test
+ */
+describe('TransactionTest', () => {
+    let transaction;
+
+    beforeEach(() => {
+    });
+
+    it('constructor check', () => {
+        expect().toEqual();
+
+        expect().toEqual();
+    });
+});

--- a/packages/web3-tx/tests/TransactionTest.js
+++ b/packages/web3-tx/tests/TransactionTest.js
@@ -10,8 +10,7 @@ jest.mock('Utils');
 describe('TransactionTest', () => {
     let transaction;
 
-    beforeEach(() => {
-    });
+    beforeEach(() => {});
 
     it('constructor check', () => {
         expect().toEqual();

--- a/packages/web3-tx/tests/factories/TransactionFactory.js
+++ b/packages/web3-tx/tests/factories/TransactionFactory.js
@@ -1,0 +1,20 @@
+import TransactionFactory from '../../src/factories/TransactionFactory';
+import Transaction from '../../src/Transaction';
+
+// Mocks
+jest.mock('../../src/Transaction');
+
+/**
+ * TransactionFactory test
+ */
+describe('TransactionFactoryTest', () => {
+    let transactionFactory;
+
+    beforeEach(() => {
+        transactionFactory = new TransactionFactory();
+    });
+
+    it('calls createTransaction and returns Transaction object', () => {
+        expect(transactionFactory.createTransaction()).toBeInstanceOf(Transaction);
+    });
+});

--- a/packages/web3-tx/tests/factories/TransactionFactory.js
+++ b/packages/web3-tx/tests/factories/TransactionFactory.js
@@ -8,6 +8,15 @@ jest.mock('../../src/Transaction');
  * TransactionFactory test
  */
 describe('TransactionFactoryTest', () => {
+    const transaction = {
+      from: "0x4f38f4229924bfa28d58eeda496cc85e8016bccc",
+      to: "deploy",
+      value: "42",
+      gas: 3,
+      gasPrice: 10000,
+      data: "none",
+      nonce: 0
+    }
     let transactionFactory;
 
     beforeEach(() => {
@@ -15,6 +24,6 @@ describe('TransactionFactoryTest', () => {
     });
 
     it('calls createTransaction and returns Transaction object', () => {
-        expect(transactionFactory.createTransaction()).toBeInstanceOf(Transaction);
+        expect(transactionFactory.createTransaction(...transaction)).toBeInstanceOf(Transaction);
     });
 });

--- a/packages/web3-tx/tests/factories/TransactionFactoryTest.js
+++ b/packages/web3-tx/tests/factories/TransactionFactoryTest.js
@@ -9,14 +9,14 @@ jest.mock('../../src/Transaction');
  */
 describe('TransactionFactoryTest', () => {
     const transaction = {
-      from: "0x4f38f4229924bfa28d58eeda496cc85e8016bccc",
-      to: "deploy",
-      value: "42",
-      gas: 3,
-      gasPrice: 10000,
-      data: "none",
-      nonce: 0
-    }
+        from: '0x4f38f4229924bfa28d58eeda496cc85e8016bccc',
+        to: 'deploy',
+        value: '42',
+        gas: 3,
+        gasPrice: 10000,
+        data: 'none',
+        nonce: 0
+    };
     let transactionFactory;
 
     beforeEach(() => {
@@ -24,6 +24,6 @@ describe('TransactionFactoryTest', () => {
     });
 
     it('calls createTransaction and returns Transaction object', () => {
-        expect(transactionFactory.createTransaction(...transaction)).toBeInstanceOf(Transaction);
+        expect(transactionFactory.createTransaction(transaction)).toBeInstanceOf(Transaction);
     });
 });

--- a/packages/web3-tx/types/index.d.ts
+++ b/packages/web3-tx/types/index.d.ts
@@ -1,0 +1,37 @@
+/*
+    This file is part of web3.js.
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file index.d.ts
+ * @author Josh Stevens <joshstevens19@hotmail.co.uk>
+ * @date 2018
+ */
+
+export class Transaction {
+
+}
+
+export interface Transaction {
+    from?: string | number;
+    to?: string;
+    gasPrice?: string;
+    gas?: number | string;
+    value?: number | string;
+    chainId?: number;
+    data?: string;
+    nonce?: number;
+    v?: string;
+    r?: string;
+    s?: string;
+    hash?: string;
+}

--- a/packages/web3-tx/types/tests/abi-coder-test.ts
+++ b/packages/web3-tx/types/tests/abi-coder-test.ts
@@ -1,0 +1,587 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file abi-coder-test.ts
+ * @author Josh Stevens <joshstevens19@hotmail.co.uk>
+ * @date 2018
+ */
+
+import {AbiCoder} from 'web3-eth-abi';
+
+const abiCoder = new AbiCoder();
+
+// $ExpectType string
+abiCoder.encodeFunctionSignature('myMethod(uint256,string)');
+// $ExpectType string
+abiCoder.encodeFunctionSignature({
+    name: 'myMethod',
+    type: 'function',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'string',
+        name: 'myString'
+    }]
+});
+
+// $ExpectError
+abiCoder.encodeFunctionSignature(345);
+// $ExpectError
+abiCoder.encodeFunctionSignature({});
+// $ExpectError
+abiCoder.encodeFunctionSignature(true);
+// $ExpectError
+abiCoder.encodeFunctionSignature(['string']);
+// $ExpectError
+abiCoder.encodeFunctionSignature([4]);
+// $ExpectError
+abiCoder.encodeFunctionSignature(null);
+// $ExpectError
+abiCoder.encodeFunctionSignature(undefined);
+// $ExpectError
+abiCoder.encodeFunctionSignature('myMethod(uint256,string)', {
+    name: 'myMethod'
+});
+
+// $ExpectType string
+abiCoder.encodeEventSignature('myEvent(uint256,bytes32)');
+// $ExpectType string
+abiCoder.encodeFunctionSignature({
+    name: 'myEvent',
+    type: 'event',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'bytes32',
+        name: 'myBytes'
+    }]
+});
+
+// $ExpectError
+abiCoder.encodeFunctionSignature(345);
+// $ExpectError
+abiCoder.encodeFunctionSignature({});
+// $ExpectError
+abiCoder.encodeFunctionSignature(true);
+// $ExpectError
+abiCoder.encodeFunctionSignature(['string']);
+// $ExpectError
+abiCoder.encodeFunctionSignature([4]);
+// $ExpectError
+abiCoder.encodeFunctionSignature(null);
+// $ExpectError
+abiCoder.encodeFunctionSignature(undefined);
+// $ExpectError
+abiCoder.encodeFunctionSignature('myEvent(uint256,bytes32)', {
+    name: 'myEvent'
+});
+
+// $ExpectType string
+abiCoder.encodeParameter('uint256', '2345675643');
+// $ExpectType string
+abiCoder.encodeParameter('uint256', ['0xdf3234', '0xfdfd']);
+// $ExpectType string
+abiCoder.encodeParameter(
+    {
+        ParentStruct: {
+            propertyOne: 'uint256',
+            propertyTwo: 'uint256',
+            childStruct: {
+                propertyOne: 'uint256',
+                propertyTwo: 'uint256'
+            }
+        }
+    },
+    {
+        propertyOne: 42,
+        propertyTwo: 56,
+        childStruct: {
+            propertyOne: 45,
+            propertyTwo: 78
+        }
+    }
+);
+
+// $ExpectError
+abiCoder.encodeParameter(null, ['0xdf3234', '0xfdfd']);
+// $ExpectError
+abiCoder.encodeParameter(undefined, ['0xdf3234', '0xfdfd']);
+
+// $ExpectType string
+abiCoder.encodeParameters(['uint256', 'string'], ['2345675643', 'Hello!%']);
+// $ExpectType string
+abiCoder.encodeParameters(['uint8[]', 'bytes32'], [['34', '434'], '0x324567fff']);
+// $ExpectType string
+abiCoder.encodeParameters(
+    [
+        'uint8[]',
+        {
+            ParentStruct: {
+                propertyOne: 'uint256',
+                propertyTwo: 'uint256',
+                ChildStruct: {
+                    propertyOne: 'uint256',
+                    propertyTwo: 'uint256'
+                }
+            }
+        }
+    ],
+    [
+        ['34', '434'],
+        {
+            propertyOne: '42',
+            propertyTwo: '56',
+            ChildStruct: {
+                propertyOne: '45',
+                propertyTwo: '78'
+            }
+        }
+    ]
+);
+
+// $ExpectError
+abiCoder.encodeParameters(345, ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeParameters(true, ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeParameters(null, ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeParameters(undefined, ['2345675643', 'Hello!%']);
+
+// $ExpectType string
+abiCoder.encodeFunctionCall({
+    name: 'myMethod',
+    type: 'function',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'string',
+        name: 'myString'
+    }]
+}, ['2345675643', 'Hello!%']);
+
+// $ExpectError
+abiCoder.encodeFunctionCall([345], ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeFunctionCall(['string'], ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeFunctionCall(345, ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeFunctionCall(true, ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeFunctionCall(null, ['2345675643', 'Hello!%']);
+// $ExpectError
+abiCoder.encodeFunctionCall(undefined, ['2345675643', 'Hello!%']);
+
+abiCoder.encodeFunctionCall({
+    name: 'myMethod',
+    type: 'function',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'string',
+        name: 'myString'
+    }]
+    // $ExpectError
+}, 345);
+
+abiCoder.encodeFunctionCall({
+    name: 'myMethod',
+    type: 'function',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'string',
+        name: 'myString'
+    }]
+    // $ExpectError
+}, [345]);
+
+abiCoder.encodeFunctionCall({
+    name: 'myMethod',
+    type: 'function',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'string',
+        name: 'myString'
+    }]
+    // $ExpectError
+}, true);
+
+abiCoder.encodeFunctionCall({
+    name: 'myMethod',
+    type: 'function',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'string',
+        name: 'myString'
+    }]
+    // $ExpectError
+}, null);
+
+abiCoder.encodeFunctionCall({
+    name: 'myMethod',
+    type: 'function',
+    inputs: [{
+        type: 'uint256',
+        name: 'myNumber'
+    }, {
+        type: 'string',
+        name: 'myString'
+    }]
+    // $ExpectError
+}, undefined);
+
+// $ExpectType { [key: string]: any; }
+abiCoder.decodeParameter('uint256', '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectType { [key: string]: any; }
+abiCoder.decodeParameter('uint256', '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectType { [key: string]: any; }
+abiCoder.decodeParameter('uint256', '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectType { [key: string]: any; }
+abiCoder.decodeParameter({
+    ParentStruct: {
+        propertyOne: 'uint256',
+        propertyTwo: 'uint256',
+        childStruct: {
+            propertyOne: 'uint256',
+            propertyTwo: 'uint256'
+        }
+    }
+}, `0x000000000000000000000000000000000000000000000000000000000000002a00000000000000000000000000000000000000000000000000
+    00000000000038000000000000000000000000000000000000000000000000000000000000002d00000000000000000000000000000000000000
+    0000000000000000000000004e`);
+
+// $ExpectError
+abiCoder.decodeParameter('uint256', [345]);
+// $ExpectError
+abiCoder.decodeParameter('uint256', ['string']);
+// $ExpectError
+abiCoder.decodeParameter('uint256', 345);
+// $ExpectError
+abiCoder.decodeParameter('uint256', true);
+// $ExpectError
+abiCoder.decodeParameter('uint256', null);
+// $ExpectError
+abiCoder.decodeParameter('uint256', undefined);
+
+// $ExpectType { [key: string]: any; }
+abiCoder.decodeParameters(['string', 'uint256'], '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectType { [key: string]: any; }
+abiCoder.decodeParameters([{
+    type: 'string',
+    name: 'myString'
+}, {
+    type: 'uint256',
+    name: 'myNumber'
+}], '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectType { [key: string]: any; }
+abiCoder.decodeParameters([
+    'uint8[]',
+    {
+        ParentStruct: {
+            propertyOne: 'uint256',
+            propertyTwo: 'uint256',
+            childStruct: {
+                propertyOne: 'uint256',
+                propertyTwo: 'uint256'
+            }
+        }
+    }
+], '0x0000000000000000000000000000000000000000000000000000000000000010');
+
+// $ExpectError
+abiCoder.decodeParameters('uint256', '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectError
+abiCoder.decodeParameters(453, '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectError
+abiCoder.decodeParameters(true, '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectError
+abiCoder.decodeParameters(null, '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectError
+abiCoder.decodeParameters(undefined, '0x0000000000000000000000000000000000000000000000000000000000000010');
+// $ExpectError
+abiCoder.decodeParameters(['string', 'uint256'], 345);
+// $ExpectError
+abiCoder.decodeParameters(['string', 'uint256'], ['string']);
+// $ExpectError
+abiCoder.decodeParameters(['string', 'uint256'], [345]);
+// $ExpectError
+abiCoder.decodeParameters(['string', 'uint256'], true);
+// $ExpectError
+abiCoder.decodeParameters(['string', 'uint256'], null);
+// $ExpectError
+abiCoder.decodeParameters(['string', 'uint256'], undefined);
+
+// $ExpectType { [key: string]: string; }
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+// $ExpectError
+abiCoder.decodeLog(['string'],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+// $ExpectError
+abiCoder.decodeLog([345],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+// $ExpectError
+abiCoder.decodeLog(true,
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+// $ExpectError
+abiCoder.decodeLog([undefined],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+// $ExpectError
+abiCoder.decodeLog([null],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    // $ExpectError
+    345,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    // $ExpectError
+    [345],
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    // $ExpectError
+    ['string'],
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    // $ExpectError
+    true,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    // $ExpectError
+    null,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    // $ExpectError
+    undefined,
+    ['0x000000000000000000000000000000000000000000000000000000000000f310', '0x0000000000000000000000000000000000000000000000000000000000000010']);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    // $ExpectError
+    345);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    // $ExpectError
+    [345]);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    // $ExpectError
+    null);
+
+abiCoder.decodeLog(
+    [
+        {
+            type: 'string',
+            name: 'myString'
+        }, {
+            type: 'uint256',
+            name: 'myNumber',
+            indexed: true
+        }, {
+            type: 'uint8',
+            name: 'mySmallNumber',
+            indexed: true
+        }
+    ],
+    `0x0000000000000000000000000000000000000000000000000000000000000020000000000000000
+     000000000000000000000000000000000000000000000000748656c6c6f2521000000000000000000
+     00000000000000000000000000000000`,
+    // $ExpectError
+    undefined);

--- a/packages/web3-tx/types/tsconfig.json
+++ b/packages/web3-tx/types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es6"],
+        "target": "es6",
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+        "allowSyntheticDefaultImports": true,
+        "baseUrl": ".",
+        "paths": {
+            "web3-tx": ["."]
+        }
+    }
+}

--- a/packages/web3-tx/types/tslint.json
+++ b/packages/web3-tx/types/tslint.json
@@ -1,0 +1,10 @@
+{
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "semicolon": false,
+        "no-import-default-of-export-equals": false,
+        "file-name-casing": [true, "kebab-case"],
+        "whitespace": false,
+        "typedef-whitespace": false
+    }
+}


### PR DESCRIPTION
A common problem with web3 usage is transaction object creation. Passing around the ad hoc transaction object is confusing and error-prone.

In order to address this issue, `web3-core-types` includes a class to create transactions that need to take all required parameters `{from, to, value, gas, gasPrice, data, nonce}` or the default markers, `auto` and `none`. All need to be explicitly set to default or provided. Furthermore, the error messages should provide enough feedback for the developer to understand why a parameter was rejected.

This submodule should also include type checks and parsing for:
* Hex
* Address
* Transaction
* TransactionReceipt
* BigNumber
* ABI
* ABIItem
* Ascii
* Ether
* Topic
* Bloom
* Sha3
* Block
* Event
* RpcPayload
* SyncEvent

This should reduce confusion regarding object building, increase type consistency, and improve cohesion.

 ## Type of change
 * [x]  Feature (non-breaking)
 
## Functionality
At the very least, the `web3-core-types` module should:
* [x] always build a valid, signable transaction.
* [x] throw on invalid parameters and provide sufficient information to fix them.
* [x] work as a standalone + `web-utils` + `web3-core`.
* [ ] build a transaction with all numeric parameters set in `BN` and addresses in valid strings.
* [ ] export a hex-encoded version of the transaction.
* [ ] export a human-readable version of the transaction.

 ## Checklist:
 * [x]  I have selected the correct base branch. [`ethereumProvider`]
 * [ ]  I have performed a self-review of my own code.
 * [ ]  I have commented my code, particularly in hard-to-understand areas.
 * [ ]  I have made corresponding changes to the documentation.
 * [ ]  My changes generate no new warnings.
 * [ ]  Any dependent changes have been merged and published in downstream modules.
 * [ ]  I ran `npm run test` with success and extended the tests if necessary.
 * [ ]  I ran `npm run build` and tested the resulting file from `dist` folder in a browser.
 * [ ]  I have tested my code on the live network.

