### PR TITLE
fix: `signTransaction` should return `Promise<SignedTransaction>`

### DIFF
--- a/packages/web3-eth-accounts/types/index.d.ts
+++ b/packages/web3-eth-accounts/types/index.d.ts
@@ -30,7 +30,7 @@ export class Accounts extends AbstractWeb3Module {
 
     privateKeyToAccount(privateKey: string): Account;
 
-    signTransaction(tx: Transaction, privateKey: string, callback?: () => void): SignedTransaction;
+    signTransaction(tx: Transaction, privateKey: string, callback?: () => void): Promise<SignedTransaction>;
 
     recoverTransaction(signature: string): string;
 

--- a/packages/web3-eth-accounts/types/tests/accounts-tests.ts
+++ b/packages/web3-eth-accounts/types/tests/accounts-tests.ts
@@ -28,14 +28,14 @@ accounts.create('2435@#@#@±±±±!!!!678543213456764321§3456754321345678543213
 // $ExpectType Account
 accounts.privateKeyToAccount('0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709');
 
-// $ExpectType SignedTransaction
+// $ExpectType Promise<SignedTransaction>
 accounts.signTransaction({
     to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
     value: '1000000000',
     gas: 2000000
 }, '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318');
 
-// $ExpectType SignedTransaction
+// $ExpectType Promise<SignedTransaction>
 accounts.signTransaction({
     to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
     value: '1000000000',


### PR DESCRIPTION
## Description

`signTransaction` should return `Promise<SignedTransaction>` in typings

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [] I have tested my code on the live network.
