### PR TITLE
fix: install `@types/node` so you do not need to add types > node in …

### DIFF
--- a/packages/web3-bzz/package-lock.json
+++ b/packages/web3-bzz/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "web3-bzz",
+    "version": "1.0.0-beta.38",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "10.12.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+            "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+    }
+}

--- a/packages/web3-bzz/package.json
+++ b/packages/web3-bzz/package.json
@@ -16,6 +16,7 @@
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "dependencies": {
+        "@types/node": "^10.12.18",
         "lodash": "^4.17.11",
         "swarm-js": "^0.1.39"
     },

--- a/packages/web3-core/package-lock.json
+++ b/packages/web3-core/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "web3-core",
+    "version": "1.0.0-beta.38",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "10.12.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+            "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+    }
+}

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -16,6 +16,7 @@
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "dependencies": {
+        "@types/node": "^10.12.18",
         "lodash": "^4.17.11",
         "web3-utils": "1.0.0-beta.38"
     },

--- a/packages/web3-providers/package-lock.json
+++ b/packages/web3-providers/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "web3-providers",
+    "version": "1.0.0-beta.38",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "10.12.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+            "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+    }
+}

--- a/packages/web3-providers/package.json
+++ b/packages/web3-providers/package.json
@@ -16,6 +16,7 @@
     },
     "types": "types",
     "dependencies": {
+        "@types/node": "^10.12.18",
         "eventemitter3": "3.1.0",
         "lodash": "^4.17.11",
         "oboe": "2.1.4",

--- a/packages/web3-utils/package-lock.json
+++ b/packages/web3-utils/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "web3-utils",
+    "version": "1.0.0-beta.38",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "10.12.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+            "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+    }
+}

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -16,6 +16,7 @@
     },
     "types": "types",
     "dependencies": {
+        "@types/node": "^10.12.18",
         "bn.js": "4.11.8",
         "eth-lib": "0.2.8",
         "ethjs-unit": "^0.1.6",

--- a/packages/web3/package-lock.json
+++ b/packages/web3/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "web3",
+    "version": "1.0.0-beta.38",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/node": {
+            "version": "10.12.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+            "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+    }
+}

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -56,6 +56,7 @@
     },
     "types": "types",
     "dependencies": {
+        "@types/node": "^10.12.18",
         "web3-bzz": "1.0.0-beta.38",
         "web3-core": "1.0.0-beta.38",
         "web3-core-helpers": "1.0.0-beta.38",


### PR DESCRIPTION
…`tsconfig.json`

## Description

When you use the typings on a ts project which isnt a node project you have to manually go into your tsconfig > types and add `node`. Importing node types itself in the dependencies of the packages which use them will solve that. 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
