### PR TITLE
fix: incorrect removal of tests + static methods in types

### DIFF
--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -25,7 +25,9 @@ import {
     provider,
     ProvidersModuleFactory,
     WebsocketProvider,
-    BatchRequest
+    BatchRequest,
+    HttpProviderOptions,
+    WebsocketProviderOptions
 } from 'web3-providers';
 
 export class AbstractWeb3Module {
@@ -44,10 +46,13 @@ export class AbstractWeb3Module {
     transactionPollingTimeout: number;
     defaultGasPrice: string;
     defaultGas: number;
+    static readonly providers: Providers;
     readonly providers: Providers;
     defaultAccount: string | null;
     readonly currentProvider: EthereumProvider | HttpProvider | IpcProvider | WebsocketProvider;
+    static readonly currentProvider: EthereumProvider | HttpProvider | IpcProvider | WebsocketProvider;
     readonly givenProvider: provider | null;
+    static readonly givenProvider: provider | null;
 
     setProvider(provider: provider, net?: net.Socket): boolean;
 
@@ -67,31 +72,37 @@ export interface Web3ModuleOptions {
 }
 
 export interface Providers {
-    HttpProvider: HttpProvider;
-    WebsocketProvider: WebsocketProvider;
-    IpcProvider: IpcProvider;
+    HttpProvider: new (host: string, options?: HttpProviderOptions) => HttpProvider;
+    WebsocketProvider: new (host: string, options?: WebsocketProviderOptions) => WebsocketProvider;
+    IpcProvider: new (path: string, net: any) => IpcProvider;
 }
 
 export interface PromiEvent<T> extends Promise<T> {
-    once(type: 'transactionHash', handler: (receipt: string) => void): PromiEvent<T>
+    once(type: 'transactionHash', handler: (receipt: string) => void): PromiEvent<T>;
 
-    once(type: 'receipt', handler: (receipt: TransactionReceipt) => void): PromiEvent<T>
+    once(type: 'receipt', handler: (receipt: TransactionReceipt) => void): PromiEvent<T>;
 
-    once(type: 'confirmation', handler: (confNumber: number, receipt: TransactionReceipt) => void): PromiEvent<T>
+    once(type: 'confirmation', handler: (confNumber: number, receipt: TransactionReceipt) => void): PromiEvent<T>;
 
-    once(type: 'error', handler: (error: Error) => void): PromiEvent<T>
+    once(type: 'error', handler: (error: Error) => void): PromiEvent<T>;
 
-    once(type: 'error' | 'confirmation' | 'receipt' | 'transactionHash', handler: (error: Error | TransactionReceipt | string) => void): PromiEvent<T>
+    once(
+        type: 'error' | 'confirmation' | 'receipt' | 'transactionHash',
+        handler: (error: Error | TransactionReceipt | string) => void
+    ): PromiEvent<T>;
 
-    on(type: 'transactionHash', handler: (receipt: string) => void): PromiEvent<T>
+    on(type: 'transactionHash', handler: (receipt: string) => void): PromiEvent<T>;
 
-    on(type: 'receipt', handler: (receipt: TransactionReceipt) => void): PromiEvent<T>
+    on(type: 'receipt', handler: (receipt: TransactionReceipt) => void): PromiEvent<T>;
 
-    on(type: 'confirmation', handler: (confNumber: number, receipt: TransactionReceipt) => void): PromiEvent<T>
+    on(type: 'confirmation', handler: (confNumber: number, receipt: TransactionReceipt) => void): PromiEvent<T>;
 
-    on(type: 'error', handler: (error: Error) => void): PromiEvent<T>
+    on(type: 'error', handler: (error: Error) => void): PromiEvent<T>;
 
-    on(type: 'error' | 'confirmation' | 'receipt' | 'transactionHash', handler: (error: Error | TransactionReceipt | string) => void): PromiEvent<T>
+    on(
+        type: 'error' | 'confirmation' | 'receipt' | 'transactionHash',
+        handler: (error: Error | TransactionReceipt | string) => void
+    ): PromiEvent<T>;
 }
 
 export interface Transaction {
@@ -110,36 +121,36 @@ export interface Transaction {
 }
 
 export interface RLPEncodedTransaction {
-    raw: string,
-    tx: Transaction
+    raw: string;
+    tx: Transaction;
 }
 
 export interface TransactionReceipt {
-    transactionHash: string
-    transactionIndex: number
-    blockHash: string
-    blockNumber: number
-    from: string
-    to: string
-    contractAddress: string
-    cumulativeGasUsed: number
-    gasUsed: number
-    logs?: Log[]
+    transactionHash: string;
+    transactionIndex: number;
+    blockHash: string;
+    blockNumber: number;
+    from: string;
+    to: string;
+    contractAddress: string;
+    cumulativeGasUsed: number;
+    gasUsed: number;
+    logs?: Log[];
     events?: {
-        [eventName: string]: EventLog
-    }
+        [eventName: string]: EventLog;
+    };
 }
 
 export interface EventLog {
-    event: string
-    address: string
-    returnValues: object
-    logIndex: number
-    transactionIndex: number
-    transactionHash: string
-    blockHash: string
-    blockNumber: number
-    raw?: {data: string, topics: any[]}
+    event: string;
+    address: string;
+    returnValues: object;
+    logIndex: number;
+    transactionIndex: number;
+    transactionHash: string;
+    blockHash: string;
+    blockNumber: number;
+    raw?: {data: string; topics: any[]};
 }
 
 export interface Log {

--- a/packages/web3-core/types/tests/abstract-web3-module-test.ts
+++ b/packages/web3-core/types/tests/abstract-web3-module-test.ts
@@ -80,9 +80,9 @@ abstractWeb3Module.currentProvider;
 // $ExpectType HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider
 AbstractWeb3Module.currentProvider;
 
-// $ExpectType provider | null
+// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider | null
 abstractWeb3Module.givenProvider;
-// $ExpectType provider | null
+// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider | null
 AbstractWeb3Module.givenProvider;
 
 // $ExpectType boolean

--- a/packages/web3-core/types/tests/abstract-web3-module-test.ts
+++ b/packages/web3-core/types/tests/abstract-web3-module-test.ts
@@ -24,7 +24,8 @@ const options = {
     timeout: 20000,
     headers: [
         {
-            name: 'Access-Control-Allow-Origin', value: '*'
+            name: 'Access-Control-Allow-Origin',
+            value: '*'
         }
     ]
 };
@@ -67,13 +68,22 @@ abstractWeb3Module.defaultGasPrice;
 abstractWeb3Module.defaultGas;
 
 // $ExpectType Providers
-abstractWeb3Module.providers
+abstractWeb3Module.providers;
+// $ExpectType Providers
+AbstractWeb3Module.providers;
 
 // $ExpectType string | null
 abstractWeb3Module.defaultAccount;
 
 // $ExpectType HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider
 abstractWeb3Module.currentProvider;
+// $ExpectType HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider
+AbstractWeb3Module.currentProvider;
+
+// $ExpectType provider | null
+abstractWeb3Module.givenProvider;
+// $ExpectType provider | null
+AbstractWeb3Module.givenProvider;
 
 // $ExpectType boolean
 abstractWeb3Module.setProvider(httpProvider);

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -71,6 +71,21 @@ eth.subscribe('pendingTransactions');
 // $ExpectType Promise<Subscribe<Transaction>>
 eth.subscribe('pendingTransactions', (error: Error, result: Subscribe<Transaction>) => {});
 
+// $ExpectType Providers
+eth.providers;
+
+// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | null
+eth.givenProvider;
+
+// $ExpectType BatchRequest
+new eth.BatchRequest();
+
+// $ExpectType string | null
+eth.defaultAccount;
+
+// $ExpectType string | number
+eth.defaultBlock;
+
 // $ExpectType Promise<string>
 eth.getProtocolVersion();
 // $ExpectType Promise<string>
@@ -172,11 +187,17 @@ eth.getBlock('0x407d73d8a49eeb85d32cf465507dd71d507100c1', true, (error: Error, 
 eth.getBlock('0x407d73d8a49eeb85d32cf465507dd71d507100c1', false, (error: Error, block: Block) => {});
 
 // $ExpectType Promise<number>
-eth.getBlockTransactionCount('0x407d73d8a49eeb85d32cf465507dd71d507100c1', (error: Error, numberOfTransactions: number) => {});
+eth.getBlockTransactionCount(
+    '0x407d73d8a49eeb85d32cf465507dd71d507100c1',
+    (error: Error, numberOfTransactions: number) => {}
+);
 // $ExpectType Promise<number>
 eth.getBlockTransactionCount(345);
 // $ExpectType Promise<number>
-eth.getBlockTransactionCount('0x407d73d8a49eeb85d32cf465507dd71d507100c1', (error: Error, numberOfTransactions: number) => {});
+eth.getBlockTransactionCount(
+    '0x407d73d8a49eeb85d32cf465507dd71d507100c1',
+    (error: Error, numberOfTransactions: number) => {}
+);
 // $ExpectType Promise<number>
 eth.getBlockTransactionCount(345);
 
@@ -215,14 +236,21 @@ eth.getTransactionFromBlock('0x407d73d8a49eeb85d32cf465507dd71d507100c1', 2);
 // $ExpectType Promise<Transaction>
 eth.getTransactionFromBlock(345, 2);
 // $ExpectType Promise<Transaction>
-eth.getTransactionFromBlock('0x407d73d8a49eeb85d32cf465507dd71d507100c1', 2, (error: Error, transaction: Transaction) => {});
+eth.getTransactionFromBlock(
+    '0x407d73d8a49eeb85d32cf465507dd71d507100c1',
+    2,
+    (error: Error, transaction: Transaction) => {}
+);
 // $ExpectType Promise<Transaction>
 eth.getTransactionFromBlock(345, 2, (error: Error, transaction: Transaction) => {});
 
 // $ExpectType Promise<TransactionReceipt>
 eth.getTransactionReceipt('0x407d73d8a49eeb85d32cf465507dd71d507100c1');
 // $ExpectType Promise<TransactionReceipt>
-eth.getTransactionReceipt('0x407d73d8a49eeb85d32cf465507dd71d507100c1', (error: Error, transactionReceipt: TransactionReceipt) => {});
+eth.getTransactionReceipt(
+    '0x407d73d8a49eeb85d32cf465507dd71d507100c1',
+    (error: Error, transactionReceipt: TransactionReceipt) => {}
+);
 
 // $ExpectType Promise<number>
 eth.getTransactionCount('0x407d73d8a49eeb85d32cf465507dd71d507100c1');
@@ -247,10 +275,13 @@ eth.sendTransaction({
     data: 'code'
 });
 // $ExpectType PromiEvent<TransactionReceipt>
-eth.sendTransaction({
-    from: '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe',
-    data: 'code'
-}, (error: Error, hash: string) => {});
+eth.sendTransaction(
+    {
+        from: '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe',
+        data: 'code'
+    },
+    (error: Error, hash: string) => {}
+);
 
 // $ExpectType PromiEvent<TransactionReceipt>
 eth.sendSignedTransaction('0xf889808609184e72a0008227109');
@@ -276,91 +307,128 @@ eth.signTransaction({
     data: ''
 });
 // $ExpectType Promise<RLPEncodedTransaction>
-eth.signTransaction({
-    from: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
-    gasPrice: '20000000000',
-    gas: '21000',
-    to: '0x3535353535353535353535353535353535353535',
-    value: '1000000000000000000',
-    data: ''
-}, '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0');
+eth.signTransaction(
+    {
+        from: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+        gasPrice: '20000000000',
+        gas: '21000',
+        to: '0x3535353535353535353535353535353535353535',
+        value: '1000000000000000000',
+        data: ''
+    },
+    '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0'
+);
 // $ExpectType Promise<RLPEncodedTransaction>
-eth.signTransaction({
-    from: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
-    gasPrice: '20000000000',
-    gas: '21000',
-    to: '0x3535353535353535353535353535353535353535',
-    value: '1000000000000000000',
-    data: ''
-}, (error: Error, signedTransaction: RLPEncodedTransaction) => {});
+eth.signTransaction(
+    {
+        from: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+        gasPrice: '20000000000',
+        gas: '21000',
+        to: '0x3535353535353535353535353535353535353535',
+        value: '1000000000000000000',
+        data: ''
+    },
+    (error: Error, signedTransaction: RLPEncodedTransaction) => {}
+);
 // $ExpectType Promise<RLPEncodedTransaction>
-eth.signTransaction({
-    from: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
-    gasPrice: '20000000000',
-    gas: '21000',
-    to: '0x3535353535353535353535353535353535353535',
-    value: '1000000000000000000',
-    data: ''
-}, '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0', (error: Error, signedTransaction: RLPEncodedTransaction) => {});
+eth.signTransaction(
+    {
+        from: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+        gasPrice: '20000000000',
+        gas: '21000',
+        to: '0x3535353535353535353535353535353535353535',
+        value: '1000000000000000000',
+        data: ''
+    },
+    '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+    (error: Error, signedTransaction: RLPEncodedTransaction) => {}
+);
 
 // $ExpectType Promise<string>
 eth.call({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", // contract address
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
+    to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe', // contract address
+    data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
 });
 // $ExpectType Promise<string>
-eth.call({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", // contract address
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
-}, 100);
+eth.call(
+    {
+        to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe', // contract address
+        data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
+    },
+    100
+);
 // $ExpectType Promise<string>
-eth.call({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", // contract address
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
-}, '100');
+eth.call(
+    {
+        to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe', // contract address
+        data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
+    },
+    '100'
+);
 // $ExpectType Promise<string>
-eth.call({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", // contract address
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
-}, (error: Error, data: string) => {});
+eth.call(
+    {
+        to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe', // contract address
+        data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
+    },
+    (error: Error, data: string) => {}
+);
 // $ExpectType Promise<string>
-eth.call({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", // contract address
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
-}, '100', (error: Error, data: string) => {});
+eth.call(
+    {
+        to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe', // contract address
+        data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
+    },
+    '100',
+    (error: Error, data: string) => {}
+);
 // $ExpectType Promise<string>
-eth.call({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", // contract address
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
-}, 100, (error: Error, data: string) => {});
+eth.call(
+    {
+        to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe', // contract address
+        data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
+    },
+    100,
+    (error: Error, data: string) => {}
+);
 
 // $ExpectType Promise<string>
-eth.call({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe", // contract address
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
-}, 100, (error: Error, data: string) => {});
+eth.call(
+    {
+        to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe', // contract address
+        data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
+    },
+    100,
+    (error: Error, data: string) => {}
+);
 
 // $ExpectType Promise<number>
 eth.estimateGas({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe",
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
+    to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+    data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
 });
 // $ExpectType Promise<number>
-eth.estimateGas({
-    to: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe",
-    data: "0xc6888fa10000000000000000000000000000000000000000000000000000000000000003"
-}, (error: Error, gas: number) => {});
+eth.estimateGas(
+    {
+        to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+        data: '0xc6888fa10000000000000000000000000000000000000000000000000000000000000003'
+    },
+    (error: Error, gas: number) => {}
+);
 
 // $ExpectType Promise<Log[]>
 eth.getPastLogs({
-    address: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe",
-    topics: ["0x033456732123ffff2342342dd12342434324234234fd234fd23fd4f23d4234"]
+    address: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+    topics: ['0x033456732123ffff2342342dd12342434324234234fd234fd23fd4f23d4234']
 });
 // $ExpectType Promise<Log[]>
-eth.getPastLogs({
-    address: "0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe",
-    topics: ["0x033456732123ffff2342342dd12342434324234234fd234fd23fd4f23d4234"]
-}, (error: Error, logs: Log[]) => {});
+eth.getPastLogs(
+    {
+        address: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+        topics: ['0x033456732123ffff2342342dd12342434324234234fd234fd23fd4f23d4234']
+    },
+    (error: Error, logs: Log[]) => {}
+);
 
 // $ExpectType Promise<string[]>
 eth.getWork();
@@ -369,14 +437,17 @@ eth.getWork((error: Error, result: string[]) => {});
 
 // $ExpectType Promise<boolean>
 eth.submitWork([
-    "0x0000000000000001",
-    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-    "0xD1FE5700000000000000000000000000D1FE5700000000000000000000000000"
+    '0x0000000000000001',
+    '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    '0xD1FE5700000000000000000000000000D1FE5700000000000000000000000000'
 ]);
 
 // $ExpectType Promise<boolean>
-eth.submitWork([
-    "0x0000000000000001",
-    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-    "0xD1FE5700000000000000000000000000D1FE5700000000000000000000000000"
-], (error: Error, result: boolean) => {});
+eth.submitWork(
+    [
+        '0x0000000000000001',
+        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        '0xD1FE5700000000000000000000000000D1FE5700000000000000000000000000'
+    ],
+    (error: Error, result: boolean) => {}
+);

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -74,7 +74,7 @@ eth.subscribe('pendingTransactions', (error: Error, result: Subscribe<Transactio
 // $ExpectType Providers
 eth.providers;
 
-// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | null
+// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider | null
 eth.givenProvider;
 
 // $ExpectType BatchRequest

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -86,6 +86,9 @@ eth.defaultAccount;
 // $ExpectType string | number
 eth.defaultBlock;
 
+// $ExpectType HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider
+eth.currentProvider;
+
 // $ExpectType Promise<string>
 eth.getProtocolVersion();
 // $ExpectType Promise<string>

--- a/packages/web3-shh/types/tests/shh-test.ts
+++ b/packages/web3-shh/types/tests/shh-test.ts
@@ -30,7 +30,7 @@ shh.providers;
 // $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | null
 shh.givenProvider;
 
-// $ExpectType AbstractProviderAdapter
+// $ExpectType HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider
 shh.currentProvider;
 
 // $ExpectType BatchRequest

--- a/packages/web3-shh/types/tests/shh-test.ts
+++ b/packages/web3-shh/types/tests/shh-test.ts
@@ -27,7 +27,7 @@ shh.setProvider('https://localhost:3000');
 // $ExpectType Providers
 shh.providers;
 
-// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | null
+// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider | null
 shh.givenProvider;
 
 // $ExpectType HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider

--- a/packages/web3-shh/types/tests/shh-test.ts
+++ b/packages/web3-shh/types/tests/shh-test.ts
@@ -21,6 +21,36 @@ import {Shh, Info, Notification} from 'web3-shh';
 
 const shh = new Shh('https://localhost:5000');
 
+// $ExpectType boolean
+shh.setProvider('https://localhost:3000');
+
+// $ExpectType Providers
+shh.providers;
+
+// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | null
+shh.givenProvider;
+
+// $ExpectType AbstractProviderAdapter
+shh.currentProvider;
+
+// $ExpectType BatchRequest
+new shh.BatchRequest();
+
+// $ExpectType Promise<number>
+shh.net.getId();
+// $ExpectType Promise<number>
+shh.net.getId((error: Error, id: number) => {});
+
+// $ExpectType Promise<boolean>
+shh.net.isListening();
+// $ExpectType Promise<boolean>
+shh.net.isListening((error: Error, listening: boolean) => {});
+
+// $ExpectType Promise<number>
+shh.net.getPeerCount();
+// $ExpectType Promise<number>
+shh.net.getPeerCount((error: Error, peerCount: number) => {});
+
 // $ExpectType Promise<string>
 shh.getVersion();
 // $ExpectType Promise<string>
@@ -54,27 +84,42 @@ shh.newKeyPair((error: Error, key: string) => {});
 // $ExpectType Promise<string>
 shh.addPrivateKey('0x8bda3abeb454847b515fa9b404cede50b1cc63cfdeddd4999d074284b4c21e15');
 // $ExpectType Promise<string>
-shh.addPrivateKey('0x8bda3abeb454847b515fa9b404cede50b1cc63cfdeddd4999d074284b4c21e15', (error: Error, privateKey: string) => {});
+shh.addPrivateKey(
+    '0x8bda3abeb454847b515fa9b404cede50b1cc63cfdeddd4999d074284b4c21e15',
+    (error: Error, privateKey: string) => {}
+);
 
 // $ExpectType Promise<boolean>
-shh.deleteKeyPair('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f')
+shh.deleteKeyPair('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f');
 // $ExpectType Promise<boolean>
-shh.deleteKeyPair('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f', (error: Error, result: boolean) => {});
+shh.deleteKeyPair(
+    '3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
+    (error: Error, result: boolean) => {}
+);
 
 // $ExpectType Promise<boolean>
 shh.hasKeyPair('fe22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f');
 // $ExpectType Promise<boolean>
-shh.hasKeyPair('fe22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f', (error: Error, result: boolean) => {});
+shh.hasKeyPair(
+    'fe22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
+    (error: Error, result: boolean) => {}
+);
 
 // $ExpectType Promise<string>
-shh.getPublicKey('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f')
+shh.getPublicKey('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f');
 // $ExpectType Promise<string>
-shh.getPublicKey('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f', (error: Error, publicKey: string) => {});
+shh.getPublicKey(
+    '3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
+    (error: Error, publicKey: string) => {}
+);
 
 // $ExpectType Promise<string>
 shh.getPrivateKey('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f');
 // $ExpectType Promise<string>
-shh.getPrivateKey('3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f', (error: Error, privateKey: string) => {});
+shh.getPrivateKey(
+    '3e22b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
+    (error: Error, privateKey: string) => {}
+);
 
 // $ExpectType Promise<string>
 shh.newSymKey();
@@ -94,7 +139,10 @@ shh.generateSymKeyFromPassword('Never use this password - password!', (error: Er
 // $ExpectType Promise<boolean>
 shh.hasSymKey('f6dcf21ed6a17bd78d8c4c63195ab997b3b65ea683705501eae82d32667adc92');
 // $ExpectType Promise<boolean>
-shh.hasSymKey('f6dcf21ed6a17bd78d8c4c63195ab997b3b65ea683705501eae82d32667adc92', (error: Error, result: boolean) => {});
+shh.hasSymKey(
+    'f6dcf21ed6a17bd78d8c4c63195ab997b3b65ea683705501eae82d32667adc92',
+    (error: Error, result: boolean) => {}
+);
 
 // $ExpectType Promise<string>
 shh.getSymKey('af33b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f');
@@ -104,7 +152,10 @@ shh.getSymKey('af33b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f'
 // $ExpectType Promise<boolean>
 shh.deleteSymKey('bf31b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f');
 // $ExpectType Promise<boolean>
-shh.deleteSymKey('bf31b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f', (error: Error, result: boolean) => {});
+shh.deleteSymKey(
+    'bf31b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
+    (error: Error, result: boolean) => {}
+);
 
 // $ExpectType Promise<string>
 shh.post({
@@ -117,32 +168,41 @@ shh.post({
     powTarget: 0.5
 });
 // $ExpectType Promise<string>
-shh.post({
-    symKeyID: 'sd3',
-    sig: 'sds5',
-    ttl: 10,
-    topic: '0xffaadd11',
-    payload: '0xffffffdddddd1122',
-    powTime: 3,
-    powTarget: 0.5
-}, (error: Error, result: string) => {});
+shh.post(
+    {
+        symKeyID: 'sd3',
+        sig: 'sds5',
+        ttl: 10,
+        topic: '0xffaadd11',
+        payload: '0xffffffdddddd1122',
+        powTime: 3,
+        powTarget: 0.5
+    },
+    (error: Error, result: string) => {}
+);
 
 // $ExpectType Subscribe
 shh.subscribe('messages', {
     symKeyID: 'bf31b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
-    sig: '0x04d1574d4eab8f3dde4d2dc7ed2c4d699d77cbbdd09167b8fffa099652ce4df00c4c6e0263eafe05007a46fdf0c8d32b11aeabcd3abbc7b2bc2bb967368a68e9c6',
+    sig:
+        '0x04d1574d4eab8f3dde4d2dc7ed2c4d699d77cbbdd09167b8fffa099652ce4df00c4c6e0263eafe05007a46fdf0c8d32b11aeabcd3abbc7b2bc2bb967368a68e9c6',
     ttl: 20,
     topics: ['0xffddaa11'],
-    minPow: 0.8,
+    minPow: 0.8
 });
 // $ExpectType Subscribe
-shh.subscribe('messages', {
-    symKeyID: 'bf31b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
-    sig: '0x04d1574d4eab8f3dde4d2dc7ed2c4d699d77cbbdd09167b8fffa099652ce4df00c4c6e0263eafe05007a46fdf0c8d32b11aeabcd3abbc7b2bc2bb967368a68e9c6',
-    ttl: 20,
-    topics: ['0xffddaa11'],
-    minPow: 0.8,
-}, (error: Error, message: Notification, subscription: any) => {});
+shh.subscribe(
+    'messages',
+    {
+        symKeyID: 'bf31b9ffc2387e18636e0a3d0c56b023264c16e78a2adcba1303cefc685e610f',
+        sig:
+            '0x04d1574d4eab8f3dde4d2dc7ed2c4d699d77cbbdd09167b8fffa099652ce4df00c4c6e0263eafe05007a46fdf0c8d32b11aeabcd3abbc7b2bc2bb967368a68e9c6',
+        ttl: 20,
+        topics: ['0xffddaa11'],
+        minPow: 0.8
+    },
+    (error: Error, message: Notification, subscription: any) => {}
+);
 
 // $ExpectType Promise<string>
 shh.newMessageFilter();

--- a/packages/web3/types/tests/web3-test.ts
+++ b/packages/web3/types/tests/web3-test.ts
@@ -24,6 +24,12 @@ Web3.modules;
 
 const web3 = new Web3('https://localhost:5000/');
 
+// $ExpectType string | HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider | null
+Web3.givenProvider;
+
+// $ExpectType Providers
+Web3.providers;
+
 // $ExpectType Utils
 web3.utils;
 
@@ -38,3 +44,6 @@ web3.shh;
 
 // $ExpectType Bzz
 web3.bzz;
+
+// $ExpectType BatchRequest
+new web3.BatchRequest();

--- a/packages/web3/types/tests/web3-test.ts
+++ b/packages/web3/types/tests/web3-test.ts
@@ -30,6 +30,9 @@ Web3.givenProvider;
 // $ExpectType Providers
 Web3.providers;
 
+// $ExpectType HttpProvider | IpcProvider | WebsocketProvider | EthereumProvider
+Web3.currentProvider;
+
 // $ExpectType Utils
 web3.utils;
 


### PR DESCRIPTION
## Description

A mistake happened in the web3 lib and somehow static methods had been removed from the type definitions which has caused a break of some logic. This should fix all the issues which got undone before. 

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
