### PR TITLE
remove redundant comments

### DIFF
--- a/packages/web3-eth-accounts/types/index.d.ts
+++ b/packages/web3-eth-accounts/types/index.d.ts
@@ -101,8 +101,6 @@ export interface EncryptedKeystoreV3Json {
     }
 }
 
-/** TODO - MOVE ALL BELOW TO WEB3-CORE ONCE FIXED CONFUSING WITH RETURN TYPES !!! */
-
 export interface SignedTransaction {
     messageHash?: string;
     r: string;
@@ -114,5 +112,3 @@ export interface SignedTransaction {
 export interface Sign extends SignedTransaction {
     message: string;
 }
-
-/** END !!! */

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -118,11 +118,8 @@ export class Eth extends AbstractWeb3Module {
 
     sign(dataToSign: string, address: string | number, callback?: (error: Error, signature: string) => void): Promise<string>;
 
-    // TODO - WRITE CORRECT TYPES ONCE INVESTIGATE WHY web3.accounts.signTransaction RETURNS A DIFFERENT OBJECT
     signTransaction(transaction: Transaction, callback?: (error: Error, signedTransaction: RLPEncodedTransaction) => void): Promise<RLPEncodedTransaction>;
-    // TODO - WRITE CORRECT TYPES ONCE INVESTIGATE WHY web3.accounts.signTransaction RETURNS A DIFFERENT OBJECT
     signTransaction(transaction: Transaction, address: string): Promise<RLPEncodedTransaction>;
-    // TODO - WRITE CORRECT TYPES ONCE INVESTIGATE WHY web3.accounts.signTransaction RETURNS A DIFFERENT OBJECT
     signTransaction(transaction: Transaction, address: string, callback: (error: Error, signedTransaction: RLPEncodedTransaction) => void): Promise<RLPEncodedTransaction>;
 
     call(transaction: Transaction): Promise<string>;


### PR DESCRIPTION
## Description

Remove redundant comments in types (as they show up when importing them and don't look professional)

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
