### PR TITLE
Increasing the default module options

### DIFF
--- a/packages/web3-core-method/src/workflows/TransactionConfirmationWorkflow.js
+++ b/packages/web3-core-method/src/workflows/TransactionConfirmationWorkflow.js
@@ -72,7 +72,10 @@ export default class TransactionConfirmationWorkflow {
                 if (!this.isTimeoutTimeExceeded(moduleInstance, this.newHeadsWatcher.isPolling)) {
                     this.getTransactionReceiptMethod.execute(moduleInstance).then((receipt) => {
                         if (receipt && receipt.blockHash) {
-                            const validationResult = this.transactionReceiptValidator.validate(receipt, method.parameters);
+                            const validationResult = this.transactionReceiptValidator.validate(
+                                receipt,
+                                method.parameters
+                            );
 
                             if (validationResult === true) {
                                 this.confirmationsCounter++;

--- a/packages/web3-core/src/AbstractWeb3Module.js
+++ b/packages/web3-core/src/AbstractWeb3Module.js
@@ -51,7 +51,7 @@ export default class AbstractWeb3Module {
         this._defaultBlock = options.defaultBlock || 'latest';
         this._transactionBlockTimeout = options.transactionBlockTimeout || 50;
         this._transactionConfirmationBlocks = options.transactionConfirmationBlocks || 24;
-        this._transactionPollingTimeout = options.transactionPollingTimeout || 15;
+        this._transactionPollingTimeout = options.transactionPollingTimeout || 750;
         this._defaultGasPrice = options.defaultGasPrice;
         this._defaultGas = options.defaultGas;
 

--- a/packages/web3-core/tests/src/AbstractWeb3ModuleTest.js
+++ b/packages/web3-core/tests/src/AbstractWeb3ModuleTest.js
@@ -103,7 +103,7 @@ describe('AbstractWeb3ModuleTest', () => {
 
         expect(abstractWeb3Module.transactionConfirmationBlocks).toEqual(24);
 
-        expect(abstractWeb3Module.transactionPollingTimeout).toEqual(15);
+        expect(abstractWeb3Module.transactionPollingTimeout).toEqual(750);
 
         expect(abstractWeb3Module.defaultGasPrice).toEqual(100);
 


### PR DESCRIPTION
## Description

Before the polling time was 15 * 50. I've updated it to 750. This means it will watch for 750s until it will reject the promise and response with an error. This is the same behavior as we had before.

## Type of change

- [x] Bug fix 

