### PR TITLE
Fix/types reference node types

### DIFF
--- a/packages/web3-bzz/types/index.d.ts
+++ b/packages/web3-bzz/types/index.d.ts
@@ -17,6 +17,8 @@
  * @date 2018
  */
 
+import {Buffer} from 'buffer';
+
 export class Bzz {
     constructor(provider: string | {});
 

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -17,6 +17,7 @@
  * @date 2018
  */
 
+///<reference path='../node_modules/@types/node/index.d.ts'/>
 import * as net from 'net';
 import {
     BatchRequest,

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -21,6 +21,7 @@
  */
 
 import BigNumber from 'bn.js';
+import {Buffer} from 'buffer';
 
 export type Unit =
     | 'noether'


### PR DESCRIPTION
## Description

`Cannot find name 'Buffer'. Can't find module 'net'.` issues when installing web3 on front-end typescript apps, current work around is to install `@types/node` and add the `types` to the `tsconfig.app.json` this PR resolves all of that and you don't need to install those types on every typescript project you install `web3` now. 

https://github.com/ethereum/web3.js/issues/2260

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
