### PR TITLE
fix: patch the angular `browser.js` to allow `{crypto: true, stream: …

### DIFF
--- a/packages/web3/angular-patch.js
+++ b/packages/web3/angular-patch.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const f = '../../node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser.js';
+
+// This is because we have to replace the `node:false` in the `/angular-cli-files/models/webpack-configs/browser.js` 
+// with `node: {crypto: true, stream: true}` to allow web3 to work with angular (as they enforce node: false.)
+// as explained here - https://github.com/ethereum/web3.js/issues/2260#issuecomment-458519127
+if (fs.existsSync(f)) {
+    fs.readFile(f, 'utf8', function (err, data) {
+        if (err) {
+            return console.log(err);
+        }
+        var result = data.replace(/node: false/g, 'node: {crypto: true, stream: true}');
+        fs.writeFile(f, result, 'utf8', function (err) {
+            if (err) return console.log(err);
+        });
+    });
+}

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -17,8 +17,7 @@
         "API"
     ],
     "author": "ethereum.org",
-    "authors": [
-        {
+    "authors": [{
             "name": "Samuel Furter",
             "email": "samuel@ethereum.org",
             "homepage": "https://github.com/nivida"
@@ -52,7 +51,8 @@
         "build": "rollup -c",
         "dev": "rollup -c -w",
         "test": "jest",
-        "dtslint": "dtslint types --onlyTestTsNext"
+        "dtslint": "dtslint types --onlyTestTsNext",
+        "postinstall": "node angular-patch.js"
     },
     "types": "types",
     "dependencies": {


### PR DESCRIPTION
…true`

## Description

When you install `web3` on a angular app and try to build with the `angular-cli` it will not work without writing your own `patch` script. This is because we have to replace the `node:false` in the `/angular-cli-files/models/webpack-configs/browser.js` with `node: {crypto: true, stream: true}` to allow web3 to work with angular (as they enforce `node: false` which will not allow `web3` to work).

Explained more in here: https://github.com/ethereum/web3.js/issues/2260#issuecomment-458519127

I have wrote a `angular-patch.js` script which will run on `post-install` and handle all this for them. I have checked to make sure it only runs if they are installing web3 within a angular app. 

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
