### PR TITLE
Updates OutputTransactionFormatter to handle null receipts

### DIFF
--- a/packages/web3-core-helpers/src/Formatters.js
+++ b/packages/web3-core-helpers/src/Formatters.js
@@ -216,6 +216,10 @@ export const inputSignFormatter = (data) => {
  * @returns {Object}
  */
 export const outputTransactionFormatter = (receipt) => {
+    if (receipt == null) {
+        return null;
+    }
+
     if (receipt.blockNumber !== null) {
         receipt.blockNumber = Utils.hexToNumber(receipt.blockNumber);
     }

--- a/packages/web3-core-helpers/tests/src/Formatters/OutputTransactionFormatterTest.js
+++ b/packages/web3-core-helpers/tests/src/Formatters/OutputTransactionFormatterTest.js
@@ -75,4 +75,11 @@ describe('OutputTransactionFormatterTest', () => {
             from: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
         });
     });
+
+    describe('when passed a null receipt', () => {
+        it('returns null', () => {
+            const receipt = null;
+            expect(outputTransactionFormatter(receipt)).toEqual(null);
+        });
+    });
 });


### PR DESCRIPTION
As a continuation of the work introduced in #2248, this change ensures that the formatter can now accommodate the potential null receipt being passed to it.


## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on the live network.
