### PR TITLE
Fix decodeLog() for non indexed params

### DIFF
--- a/packages/web3-eth-abi/src/AbiCoder.js
+++ b/packages/web3-eth-abi/src/AbiCoder.js
@@ -296,15 +296,18 @@ export default class AbiCoder {
 
         const nonIndexedData = data;
 
-        const notIndexedParams = nonIndexedData ? this.decodeParameters(notIndexedInputs, nonIndexedData) : [];
+        const notIndexedParams = nonIndexedData ? this.decodeParameters(notIndexedInputs.filter(Boolean), nonIndexedData) : [];
 
+        var notIndexedOffset = 0;
         const returnValues = {};
 
         inputs.forEach((res, i) => {
+            if (res.indexed) notIndexedOffset++;
+            
             returnValues[i] = res.type === 'string' ? '' : null;
 
-            if (typeof notIndexedParams[i] !== 'undefined') {
-                returnValues[i] = notIndexedParams[i];
+            if (!res.indexed && typeof notIndexedParams[i - notIndexedOffset] !== 'undefined') {
+                returnValues[i] = notIndexedParams[i - notIndexedOffset];
             }
             if (typeof indexedParams[i] !== 'undefined') {
                 returnValues[i] = indexedParams[i];

--- a/packages/web3-eth-abi/src/AbiCoder.js
+++ b/packages/web3-eth-abi/src/AbiCoder.js
@@ -298,7 +298,7 @@ export default class AbiCoder {
 
         const notIndexedParams = nonIndexedData ? this.decodeParameters(notIndexedInputs.filter(Boolean), nonIndexedData) : [];
 
-        var notIndexedOffset = 0;
+        let notIndexedOffset = 0;
         const returnValues = {};
 
         inputs.forEach((res, i) => {

--- a/packages/web3-eth-abi/tests/AbiCoderTest.js
+++ b/packages/web3-eth-abi/tests/AbiCoderTest.js
@@ -188,7 +188,7 @@ describe('AbiCoderTest', () => {
             }
         ];
 
-        expect(abiCoder.decodeLog(inputs, '0x0', ['0x0', '0x0'])).toEqual({'0': '0', '1': '0x0', '2': '0', input: '0'});
+        expect(abiCoder.decodeLog(inputs, '0x0', ['0x0', '0x0'])).toEqual({'0': '0', '1': '0x0', '2': '', input: ''});
 
         expect(ethersAbiCoderMock.decode).toHaveBeenNthCalledWith(1, [inputs[0].type], '0x0');
 


### PR DESCRIPTION
Fix `decodeLog()` for non indexed params. 

## Description

The issue can be reproduced for events like this:

```
event Authorize(
        bytes32 indexed platformId,
        bytes32 indexed uid,
        address indexed user,
        AuthorizationRequest request
    );
```

It is cause by `_mapTypes(types)` used in `decodeParameters(outputs, bytes)` (`var res = this.ethersAbiCoder.decode(this._mapTypes(outputs), "0x".concat(bytes.replace(/0x/i, '')));`) which returns `[ { indexed: false, name: 'request', type: 'address' } ]` for `types = outputs = [null, null, null, {"indexed":false,"name":"request","type":"address"}]` passed as argument. 

So when the iteration `outputs.forEach(function (output, i) {}` is performed the `returnValues` do not get `res[i]` assigned correctly because the index is shifted due to empty types cleanup.


Fixes https://github.com/ethereum/web3.js/issues/2268

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] My changes generate no warnings.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I have tested my code on the live network.