### PR TITLE
fix: add `status` onto `TransactionReceipt`

### DIFF
--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -123,6 +123,7 @@ export interface RLPEncodedTransaction {
 }
 
 export interface TransactionReceipt {
+    status: boolean;
     transactionHash: string;
     transactionIndex: number;
     blockHash: string;


### PR DESCRIPTION
## Description

Status was missing on interface `TransactionReceipt` as raised in https://github.com/ethereum/web3.js/issues/2287

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
