### PR TITLE
update package.json to include lodash

### DIFF
--- a/packages/web3-core-method/package.json
+++ b/packages/web3-core-method/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@babel/runtime": "^7.3.1",
         "eventemitter3": "3.1.0",
+        "lodash":"4.17.11",
         "web3-core": "1.0.0-beta.41",
         "web3-core-helpers": "1.0.0-beta.41",
         "web3-core-promievent": "1.0.0-beta.41",


### PR DESCRIPTION
this prevents this error when trying to use Web3 1.0.0-beta.41: 
https://stackoverflow.com/questions/54509878/cannot-find-module-lodash-isstring

## Description

I've updated the package.json to include lodash so that a user doesn't have to manually go into their node_modules to update web3-core-methods package.json file.

error is found here: https://stackoverflow.com/questions/54509878/cannot-find-module-lodash-isstring


<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x ] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x ] I have selected the correct base branch.
- [x ] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have made corresponding changes to the documentation.
- [ x] My changes generate no warnings.
- [ x] I have updated or added types for all modules I've changed
- [x ] Any dependent changes have been merged and published in downstream modules.
- [x ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x ] I have tested my code on the live network.
