### PR TITLE
remove docs for non-existent Web.utils static prop

### DIFF
--- a/docs/web3.rst
+++ b/docs/web3.rst
@@ -92,20 +92,3 @@ Example
 
     web3.version;
     > "1.0.0"
-
-
-------------------------------------------------------------------------------
-
-
-utils
-=====================
-
-    Static property of the Web3 class.
-
-.. code-block:: javascript
-
-    Web3.utils
-
-    Utility functions are also exposes on the ``Web3`` class object directly.
-
-See :ref:`web3.utils <utils>` for more.


### PR DESCRIPTION
## Description

*Relates to #2328*

> The static property utils do no longer exist on the Web3 class.

This PR removes the docs on that static property

## Type of change

- [x] Documentation

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on the live network.
