### PR TITLE
README with lerna commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ Documentation can be found at [read the docs][docs]
 
 * [Node.js](https://nodejs.org)
 * npm
+* lerna
 
 ### Commands
 ```bash
-npm run clean // removes all the node_modules folders in all modules
-npm run bootstrap // install all dependencies and symlinks the internal modules for all modules
-npm run test // runs all tests 
-npm run build // runs rollup
-npm run dev // runs rollup with a watcher
-
+lerna clean     // removes all the node_modules folders in all modules
+lerna bootstrap // install all dependencies and symlinks the internal modules for all modules
+lerna run test  // runs all tests 
+lerna run build // runs rollup
+lerna run dev   // runs rollup with a watcher
 ```
 
 ### Support


### PR DESCRIPTION
## Description

Closes #2354.
The README info for developers is out of date. It lists the `npm run _` commands, but they break without the new lerna linking. I'm not sure exactly what commands @nivida uses for dev and test, however. 

Furthermore, the PR template still includes the npm commands, which could potentially lead to confusion:

> - [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
> - [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
> - [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct