### PR TITLE
Resolve the PromiEvent that is returned when sending a transaction

### DIFF
--- a/packages/web3-core-method/lib/methods/AbstractSendMethod.js
+++ b/packages/web3-core-method/lib/methods/AbstractSendMethod.js
@@ -77,6 +77,7 @@ export default class AbstractSendMethod extends AbstractMethod {
                     this.callback(false, response);
                 }
 
+                promiEvent.resolve(response);
                 promiEvent.emit('transactionHash', response);
             })
             .catch((error) => {

--- a/packages/web3-core-method/tests/src/methods/transaction/SendTransactionMethodTest.js
+++ b/packages/web3-core-method/tests/src/methods/transaction/SendTransactionMethodTest.js
@@ -70,7 +70,7 @@ describe('SendTransactionMethodTest', () => {
         expect(method.transactionSigner).toEqual(transactionSignerMock);
     });
 
-    it('calls execute with wallets defined', async (done) => {
+    it('calls execute with wallets defined', async () => {
         accountsMock.wallet[0] = {privateKey: '0x0'};
 
         transactionSignerMock.sign = jest.fn(() => {
@@ -83,33 +83,36 @@ describe('SendTransactionMethodTest', () => {
 
         moduleInstanceMock.currentProvider = providerMock;
 
-        promiEvent.on('transactionHash', (response) => {
-            expect(response).toEqual('0x0');
+        const transactionHashEventFired = new Promise((resolve) => {
+            promiEvent.on('transactionHash', (response) => {
+                expect(response).toEqual('0x0');
 
-            expect(transactionConfirmationWorkflowMock.execute).toHaveBeenCalledWith(
-                method,
-                moduleInstanceMock,
-                '0x0',
-                promiEvent
-            );
+                expect(transactionConfirmationWorkflowMock.execute).toHaveBeenCalledWith(
+                    method,
+                    moduleInstanceMock,
+                    '0x0',
+                    promiEvent
+                );
 
-            expect(providerMock.send).toHaveBeenCalledWith(method.rpcMethod, method.parameters);
+                expect(providerMock.send).toHaveBeenCalledWith(method.rpcMethod, method.parameters);
 
-            expect(method.rpcMethod).toEqual('eth_sendRawTransaction');
+                expect(method.rpcMethod).toEqual('eth_sendRawTransaction');
 
-            expect(transactionSignerMock.sign).toHaveBeenCalledWith({gasPrice: '0x0'});
+                expect(transactionSignerMock.sign).toHaveBeenCalledWith({gasPrice: '0x0'});
 
-            done();
+                resolve();
+            });
         });
 
         const response = await method.execute(moduleInstanceMock, promiEvent);
+        await transactionHashEventFired;
 
         expect(response).toEqual('0x0');
 
         expect(method.callback).toHaveBeenCalledWith(false, '0x0');
     });
 
-    it('calls execute with wallets defined and uses the module default gas properties', async (done) => {
+    it('calls execute with wallets defined and uses the module default gas properties', async () => {
         accountsMock.wallet[0] = {privateKey: '0x0'};
 
         transactionSignerMock.sign = jest.fn(() => {
@@ -124,37 +127,36 @@ describe('SendTransactionMethodTest', () => {
         moduleInstanceMock.defaultGas = 100;
         moduleInstanceMock.defaultGasPrice = 100;
 
-        promiEvent.on('transactionHash', (response) => {
-            expect(response).toEqual('0x0');
+        const transactionHashEventFired = new Promise((resolve) => {
+            promiEvent.on('transactionHash', (response) => {
+                expect(response).toEqual('0x0');
 
-            expect(transactionConfirmationWorkflowMock.execute).toHaveBeenCalledWith(
-                method,
-                moduleInstanceMock,
-                '0x0',
-                promiEvent
-            );
+                expect(transactionConfirmationWorkflowMock.execute).toHaveBeenCalledWith(
+                    method,
+                    moduleInstanceMock,
+                    '0x0',
+                    promiEvent
+                );
 
-            expect(providerMock.send).toHaveBeenCalledWith(method.rpcMethod, method.parameters);
+                expect(providerMock.send).toHaveBeenCalledWith(method.rpcMethod, method.parameters);
 
-            expect(method.rpcMethod).toEqual('eth_sendRawTransaction');
+                expect(method.rpcMethod).toEqual('eth_sendRawTransaction');
 
-            expect(transactionSignerMock.sign).toHaveBeenCalledWith({gasPrice: 100, gas: 100});
+                expect(transactionSignerMock.sign).toHaveBeenCalledWith({gasPrice: 100, gas: 100});
 
-            done();
-        });
-
+                resolve();
+            });
+        })
+        
         const response = await method.execute(moduleInstanceMock, promiEvent);
+        await transactionHashEventFired;
 
         expect(response).toEqual('0x0');
 
         expect(method.callback).toHaveBeenCalledWith(false, '0x0');
-
-        expect(method.parameters[0].gas).toEqual(100);
-
-        expect(method.parameters[0].gasPrice).toEqual(100);
     });
 
-    it('calls execute and TransactionSigner throws error', async (done) => {
+    it('calls execute and TransactionSigner throws error', async () => {
         accountsMock.wallet[0] = {privateKey: '0x0'};
 
         providerMock.send = jest.fn(() => {
@@ -170,20 +172,23 @@ describe('SendTransactionMethodTest', () => {
 
         moduleInstanceMock.currentProvider = providerMock;
 
-        promiEvent.on('error', (e) => {
-            expect(e).toEqual(error);
+        const errorEventFired = new Promise((resolve) => {
+            promiEvent.on('error', (e) => {
+                expect(e).toEqual(error);
 
-            expect(providerMock.send).toHaveBeenCalledWith('eth_gasPrice', []);
+                expect(providerMock.send).toHaveBeenCalledWith('eth_gasPrice', []);
 
-            expect(method.rpcMethod).toEqual('eth_sendRawTransaction');
+                expect(method.rpcMethod).toEqual('eth_sendRawTransaction');
 
-            expect(transactionSignerMock.sign).toHaveBeenCalledWith({gasPrice: '0x0'});
+                expect(transactionSignerMock.sign).toHaveBeenCalledWith({gasPrice: '0x0'});
 
-            done();
+                resolve();
+            });
         });
 
         try {
             await method.execute(moduleInstanceMock, promiEvent);
+            await errorEventFired;
         } catch (error2) {
             expect(error2).toEqual(error);
 
@@ -191,7 +196,7 @@ describe('SendTransactionMethodTest', () => {
         }
     });
 
-    it('calls execute without wallets defined', async (done) => {
+    it('calls execute without wallets defined', async () => {
         method.parameters = [{gasPrice: false}];
 
         providerMock.send = jest.fn(() => {
@@ -200,25 +205,28 @@ describe('SendTransactionMethodTest', () => {
 
         moduleInstanceMock.currentProvider = providerMock;
 
-        promiEvent.on('transactionHash', (response) => {
-            expect(response).toEqual('0x0');
+        const transactionHashEventFired = new Promise((resolve) => {
+            promiEvent.on('transactionHash', (response) => {
+                expect(response).toEqual('0x0');
 
-            expect(transactionConfirmationWorkflowMock.execute).toHaveBeenCalledWith(
-                method,
-                moduleInstanceMock,
-                '0x0',
-                promiEvent
-            );
+                expect(transactionConfirmationWorkflowMock.execute).toHaveBeenCalledWith(
+                    method,
+                    moduleInstanceMock,
+                    '0x0',
+                    promiEvent
+                );
 
-            expect(providerMock.send).toHaveBeenCalledWith(method.rpcMethod, method.parameters);
+                expect(providerMock.send).toHaveBeenCalledWith(method.rpcMethod, method.parameters);
 
-            expect(method.rpcMethod).toEqual('eth_sendTransaction');
+                expect(method.rpcMethod).toEqual('eth_sendTransaction');
 
-            done();
+                resolve();
+            });
         });
 
         const response = await method.execute(moduleInstanceMock, promiEvent);
-
+        await transactionHashEventFired;
+        
         expect(response).toEqual('0x0');
 
         expect(method.callback).toHaveBeenCalledWith(false, '0x0');


### PR DESCRIPTION
## Description

#### TL;DR:
- The `PromiEvent` returned from sending a method to the Ethereum chain is never resolved
- The tests just wait for the `transactionHash` event to be fired and succeed without waiting for the `PromiEvent` to be resolved. Thus the issue was never covered in tests.
- Fixing the second bug uncovers some failing tests that were previously not executed, which I fixed.

#### Long story

I noticed that the `PromiEvents` returned from sending a method to a smart contract is never resolved. Trying to write tests that catch that behaviour, I noticed that you can assert `expect(true).toBe(false)` at the end of `'calls execute with wallets defined'` in `SendTransactionMethodTest.js` without any test failing. It appears the root cause of this is that the test finishes executing when `done` is called from within the callback of the `transactionHash` event. The `await` for the `PromiEvent` is never fulfilled because of the above issue and thus the code after the `await` is never executed. 

## Resolution

The first issue can easily been addressed by calling `promiEvent.resolve(response);` in `AbstractSendMethod.js`.

For the second issue, I think the `done` callback shouldn't be used in combination with an `async` test body. Wrapping the `'transactionHash'` callback inside a promise and awaiting it makes the test body wait for both the `'transactionHash'` event to be fired and the `PromiEvent` to be resolved.

I eliminated all cases where a `done` callback was used in an async test body. That uncovered some test code that was previously not executed. I was able to fix these test cases by just modifying the test code. I'll add comments on GitHub to lines where I'm not 100% sure what the correct behaviour should be. 