### PR TITLE
Include hexToUtf8 in index.js exports

### DIFF
--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -272,6 +272,7 @@ export const toDecimal = utils.hexToNumber;
 export const hexToNumber = utils.hexToNumber;
 export const fromDecimal = utils.numberToHex;
 export const numberToHex = utils.numberToHex;
+export const hexToUtf8 = utils.hexToUtf8;
 export const hexToString = utils.hexToUtf8;
 export const toUtf8 = utils.hexToUtf8;
 export const stringToHex = utils.utf8ToHex;


### PR DESCRIPTION
## Description

When importing web3-utils, I found that hexToUtf8 is not being exported correctly (I get `TypeError: web3Utils.hexToutf8 is not a function`), but hexToString works fine. I added hexToUtf8 to the index.js exports. I didn't test any other functions, but I assume it's quite possible that other functions might have been left out as well.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch. (I'm not actually sure?)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed

