### PR TITLE
Replace scryptsy by crypto.scryptSync

### DIFF
--- a/packages/web3-eth-accounts/jest.config.js
+++ b/packages/web3-eth-accounts/jest.config.js
@@ -7,5 +7,6 @@ module.exports = jestConfig({
     ProvidersModuleFactory: 'web3-providers',
     ProviderDetector: 'web3-providers',
     ProviderResolver: 'web3-providers',
-    MethodModuleFactory: 'web3-core-method'
+    MethodModuleFactory: 'web3-core-method',
+    scryptsy: 'scrypt.js'
 });

--- a/packages/web3-eth-accounts/jest.config.js
+++ b/packages/web3-eth-accounts/jest.config.js
@@ -7,6 +7,5 @@ module.exports = jestConfig({
     ProvidersModuleFactory: 'web3-providers',
     ProviderDetector: 'web3-providers',
     ProviderResolver: 'web3-providers',
-    MethodModuleFactory: 'web3-core-method',
-    scryptsy: 'scrypt.js'
+    MethodModuleFactory: 'web3-core-method'
 });

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -20,7 +20,7 @@
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.8",
         "lodash": "^4.17.11",
-        "scrypt.js": "0.2.0",
+        "scrypt.js": "0.3.0",
         "uuid": "3.3.2",
         "web3-core": "1.0.0-beta.46",
         "web3-core-helpers": "1.0.0-beta.46",

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -20,7 +20,6 @@
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.8",
         "lodash": "^4.17.11",
-        "scrypt.js": "0.2.0",
         "uuid": "3.3.2",
         "web3-core": "1.0.0-beta.46",
         "web3-core-helpers": "1.0.0-beta.46",

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -20,6 +20,7 @@
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.8",
         "lodash": "^4.17.11",
+        "scrypt.js": "0.3.0",
         "uuid": "3.3.2",
         "web3-core": "1.0.0-beta.46",
         "web3-core-helpers": "1.0.0-beta.46",

--- a/packages/web3-eth-accounts/src/Accounts.js
+++ b/packages/web3-eth-accounts/src/Accounts.js
@@ -32,7 +32,6 @@ import Hash from 'eth-lib/lib/hash';
 import RLP from 'eth-lib/lib/rlp';
 import Nat from 'eth-lib/lib/nat';
 import Bytes from 'eth-lib/lib/bytes';
-import scryptsy from 'scrypt.js';
 import uuid from 'uuid';
 import {AbstractWeb3Module} from 'web3-core';
 
@@ -372,13 +371,15 @@ export default class Accounts extends AbstractWeb3Module {
             kdfparams = json.crypto.kdfparams;
 
             // FIXME: support progress reporting callback
-            derivedKey = scryptsy(
+            derivedKey = cryp.scryptSync(
                 Buffer.from(password),
                 Buffer.from(kdfparams.salt, 'hex'),
-                kdfparams.n,
-                kdfparams.r,
-                kdfparams.p,
-                kdfparams.dklen
+                kdfparams.dklen,
+                {
+                  N: kdfparams.n,
+                  r: kdfparams.r,
+                  p: kdfparams.p
+                }
             );
         } else if (json.crypto.kdf === 'pbkdf2') {
             kdfparams = json.crypto.kdfparams;
@@ -449,7 +450,12 @@ export default class Accounts extends AbstractWeb3Module {
             kdfparams.n = options.n || 8192; // 2048 4096 8192 16384
             kdfparams.r = options.r || 8;
             kdfparams.p = options.p || 1;
-            derivedKey = scryptsy(Buffer.from(password), salt, kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
+            derivedKey = cryp.scryptSync(Buffer.from(password), salt, kdfparams.dklen, {
+              N: kdfparams.n,
+              r: kdfparams.r,
+              p: kdfparams.p
+
+            });
         } else {
             throw new Error('Unsupported kdf');
         }

--- a/packages/web3-eth-accounts/src/Accounts.js
+++ b/packages/web3-eth-accounts/src/Accounts.js
@@ -33,6 +33,7 @@ import RLP from 'eth-lib/lib/rlp';
 import Nat from 'eth-lib/lib/nat';
 import Bytes from 'eth-lib/lib/bytes';
 import uuid from 'uuid';
+import scryptSync from './Scrypt';
 import {AbstractWeb3Module} from 'web3-core';
 
 const cryp = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto');
@@ -371,7 +372,7 @@ export default class Accounts extends AbstractWeb3Module {
             kdfparams = json.crypto.kdfparams;
 
             // FIXME: support progress reporting callback
-            derivedKey = cryp.scryptSync(
+            derivedKey = scryptSync(
                 Buffer.from(password),
                 Buffer.from(kdfparams.salt, 'hex'),
                 kdfparams.dklen,
@@ -450,7 +451,7 @@ export default class Accounts extends AbstractWeb3Module {
             kdfparams.n = options.n || 8192; // 2048 4096 8192 16384
             kdfparams.r = options.r || 8;
             kdfparams.p = options.p || 1;
-            derivedKey = cryp.scryptSync(Buffer.from(password), salt, kdfparams.dklen, {
+            derivedKey = scryptSync(Buffer.from(password), salt, kdfparams.dklen, {
               N: kdfparams.n,
               r: kdfparams.r,
               p: kdfparams.p

--- a/packages/web3-eth-accounts/src/Scrypt.js
+++ b/packages/web3-eth-accounts/src/Scrypt.js
@@ -1,6 +1,6 @@
 const cryp = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto');
 
-const scryptSync (key, salt, dklen, options) => {
+const scryptSync = (key, salt, dklen, options) => {
   var version = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
   return version >= 10 ? cryp.scryptSync(key, salt, dklen, {N: options.N, r: options.r, p: options.p}) : require('scrypt.js')(key, salt, options.N, options.r, options.p, dklen);
 }

--- a/packages/web3-eth-accounts/src/Scrypt.js
+++ b/packages/web3-eth-accounts/src/Scrypt.js
@@ -5,4 +5,4 @@ const scryptSync = (key, salt, dklen, options) => {
   return version >= 10 ? cryp.scryptSync(key, salt, dklen, {N: options.N, r: options.r, p: options.p}) : require('scrypt.js')(key, salt, options.N, options.r, options.p, dklen);
 }
 
-module.exports = scryptSync;
+export default scryptSync

--- a/packages/web3-eth-accounts/src/Scrypt.js
+++ b/packages/web3-eth-accounts/src/Scrypt.js
@@ -1,0 +1,8 @@
+const cryp = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto');
+
+const scryptSync (key, salt, dklen, options) => {
+  var version = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
+  return version >= 10 ? cryp.scryptSync(key, salt, dklen, {N: options.N, r: options.r, p: options.p}) : require('scrypt.js')(key, salt, options.N, options.r, options.p, dklen);
+}
+
+module.exports = scryptSync;

--- a/packages/web3-eth-accounts/tests/src/AccountsTest.js
+++ b/packages/web3-eth-accounts/tests/src/AccountsTest.js
@@ -26,6 +26,7 @@ jest.mock('eth-lib/lib/nat');
 jest.mock('eth-lib/lib/bytes');
 jest.mock('eth-lib/lib/hash');
 jest.mock('crypto');
+jest.mock('scryptSync');
 jest.mock('uuid');
 
 /**

--- a/packages/web3-eth-accounts/tests/src/AccountsTest.js
+++ b/packages/web3-eth-accounts/tests/src/AccountsTest.js
@@ -8,10 +8,12 @@ import Hash from 'eth-lib/lib/hash';
 import RLP from 'eth-lib/lib/rlp';
 import Nat from 'eth-lib/lib/nat';
 import Bytes from 'eth-lib/lib/bytes';
+import scryptsy from 'scrypt.js';
 import crypto from 'crypto';
 import uuid from 'uuid';
 import MethodFactory from '../../src/factories/MethodFactory';
 import Accounts from '../../src/Accounts';
+import scryptSync from '../../src/Scrypt';
 
 // Mocks
 jest.mock('Utils');
@@ -24,6 +26,7 @@ jest.mock('eth-lib/lib/rlp');
 jest.mock('eth-lib/lib/nat');
 jest.mock('eth-lib/lib/bytes');
 jest.mock('eth-lib/lib/hash');
+jest.mock('scryptsy');
 jest.mock('crypto');
 jest.mock('uuid');
 
@@ -769,7 +772,7 @@ describe('AccountsTest', () => {
             return object;
         });
 
-        crypto.scryptSync.mockReturnValueOnce(Buffer.from('00000000000000000000000000000000'));
+        scryptSync.mockReturnValueOnce(Buffer.from('00000000000000000000000000000000'));
 
         Utils.sha3.mockReturnValueOnce('0xmac');
 
@@ -794,7 +797,7 @@ describe('AccountsTest', () => {
 
         expect(accounts.decrypt(json, 'password', false)).toEqual(object);
 
-        expect(crypto.scryptSync).toHaveBeenCalledWith(
+        expect(scryptSync).toHaveBeenCalledWith(
             Buffer.from('password'),
             Buffer.from('salt', 'hex'),
             'dklen',
@@ -1004,7 +1007,7 @@ describe('AccountsTest', () => {
 
         crypto.createCipheriv.mockReturnValue(cipher);
 
-        crypto.scryptSync.mockReturnValueOnce(Buffer.from('0000000000000000'));
+        scryptSync.mockReturnValueOnce(Buffer.from('0000000000000000'));
 
         Utils.sha3.mockReturnValueOnce('0xmac');
 
@@ -1036,7 +1039,7 @@ describe('AccountsTest', () => {
 
         expect(crypto.randomBytes).toHaveBeenNthCalledWith(3, 16);
 
-        expect(crypto.scryptSync).toHaveBeenCalledWith(Buffer.from('password'), Buffer.from('random'), 32, {N: 8192, r: 8, p:1});
+        expect(scryptSync).toHaveBeenCalledWith(Buffer.from('password'), Buffer.from('random'), 32, {N: 8192, r: 8, p:1});
 
         expect(crypto.createCipheriv).toHaveBeenCalledWith(
             'aes-128-ctr',

--- a/packages/web3-eth-accounts/tests/src/AccountsTest.js
+++ b/packages/web3-eth-accounts/tests/src/AccountsTest.js
@@ -8,7 +8,6 @@ import Hash from 'eth-lib/lib/hash';
 import RLP from 'eth-lib/lib/rlp';
 import Nat from 'eth-lib/lib/nat';
 import Bytes from 'eth-lib/lib/bytes';
-import scryptsy from 'scrypt.js';
 import crypto from 'crypto';
 import uuid from 'uuid';
 import MethodFactory from '../../src/factories/MethodFactory';
@@ -25,7 +24,6 @@ jest.mock('eth-lib/lib/rlp');
 jest.mock('eth-lib/lib/nat');
 jest.mock('eth-lib/lib/bytes');
 jest.mock('eth-lib/lib/hash');
-jest.mock('scryptsy');
 jest.mock('crypto');
 jest.mock('uuid');
 
@@ -771,7 +769,7 @@ describe('AccountsTest', () => {
             return object;
         });
 
-        scryptsy.mockReturnValueOnce(Buffer.from('00000000000000000000000000000000'));
+        crypto.scryptSync.mockReturnValueOnce(Buffer.from('00000000000000000000000000000000'));
 
         Utils.sha3.mockReturnValueOnce('0xmac');
 
@@ -796,7 +794,7 @@ describe('AccountsTest', () => {
 
         expect(accounts.decrypt(json, 'password', false)).toEqual(object);
 
-        expect(scryptsy).toHaveBeenCalledWith(
+        expect(crypto.scryptSync).toHaveBeenCalledWith(
             Buffer.from('password'),
             Buffer.from('salt', 'hex'),
             'n',
@@ -1004,7 +1002,7 @@ describe('AccountsTest', () => {
 
         crypto.createCipheriv.mockReturnValue(cipher);
 
-        scryptsy.mockReturnValueOnce(Buffer.from('0000000000000000'));
+        crypto.scryptSync.mockReturnValueOnce(Buffer.from('0000000000000000'));
 
         Utils.sha3.mockReturnValueOnce('0xmac');
 
@@ -1036,7 +1034,7 @@ describe('AccountsTest', () => {
 
         expect(crypto.randomBytes).toHaveBeenNthCalledWith(3, 16);
 
-        expect(scryptsy).toHaveBeenCalledWith(Buffer.from('password'), Buffer.from('random'), 8192, 8, 1, 32);
+        expect(crypto.scryptSync).toHaveBeenCalledWith(Buffer.from('password'), Buffer.from('random'), 8192, 8, 1, 32);
 
         expect(crypto.createCipheriv).toHaveBeenCalledWith(
             'aes-128-ctr',

--- a/packages/web3-eth-accounts/tests/src/AccountsTest.js
+++ b/packages/web3-eth-accounts/tests/src/AccountsTest.js
@@ -797,10 +797,12 @@ describe('AccountsTest', () => {
         expect(crypto.scryptSync).toHaveBeenCalledWith(
             Buffer.from('password'),
             Buffer.from('salt', 'hex'),
-            'n',
-            'r',
-            'p',
-            'dklen'
+            'dklen',
+            {
+              N: 'n',
+              r: 'r',
+              p: 'p'
+            }
         );
 
         expect(Utils.sha3).toHaveBeenCalledWith(
@@ -1034,7 +1036,7 @@ describe('AccountsTest', () => {
 
         expect(crypto.randomBytes).toHaveBeenNthCalledWith(3, 16);
 
-        expect(crypto.scryptSync).toHaveBeenCalledWith(Buffer.from('password'), Buffer.from('random'), 8192, 8, 1, 32);
+        expect(crypto.scryptSync).toHaveBeenCalledWith(Buffer.from('password'), Buffer.from('random'), 32, {N: 8192, r: 8, p:1});
 
         expect(crypto.createCipheriv).toHaveBeenCalledWith(
             'aes-128-ctr',

--- a/packages/web3-eth-accounts/tests/src/AccountsTest.js
+++ b/packages/web3-eth-accounts/tests/src/AccountsTest.js
@@ -8,7 +8,6 @@ import Hash from 'eth-lib/lib/hash';
 import RLP from 'eth-lib/lib/rlp';
 import Nat from 'eth-lib/lib/nat';
 import Bytes from 'eth-lib/lib/bytes';
-import scryptsy from 'scrypt.js';
 import crypto from 'crypto';
 import uuid from 'uuid';
 import MethodFactory from '../../src/factories/MethodFactory';
@@ -26,7 +25,6 @@ jest.mock('eth-lib/lib/rlp');
 jest.mock('eth-lib/lib/nat');
 jest.mock('eth-lib/lib/bytes');
 jest.mock('eth-lib/lib/hash');
-jest.mock('scryptsy');
 jest.mock('crypto');
 jest.mock('uuid');
 


### PR DESCRIPTION
## Description

Replace [scryptsy](https://github.com/cryptocoinjs/scryptsy) by the native scrypt implementation [crypto.scryptSync.](https://nodejs.org/api/crypto.html#crypto_crypto_scrypt_password_salt_keylen_options_callback)

## Type of change

<!--- Please delete options that are not relevant. -->

- [X] New feature 

## Checklist:

- [X] I have selected the correct base branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no warnings.
- [X] I have updated or added types for all modules I've changed
- [] Any dependent changes have been merged and published in downstream modules.
- [] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on the live network.
