### PR TITLE
Exports added for all subscriptions in core-subscription

### DIFF
--- a/packages/web3-core-subscriptions/src/index.js
+++ b/packages/web3-core-subscriptions/src/index.js
@@ -35,5 +35,14 @@ export const SubscriptionsFactory = () => {
     return new SubscriptionsModuleFactory().createSubscriptionsFactory(Utils, formatters);
 };
 
-export LogSubscription from './subscriptions/eth/LogSubscription';
 export AbstractSubscription from '../lib/subscriptions/AbstractSubscription';
+
+// Eth
+export LogSubscription from './subscriptions/eth/LogSubscription';
+export NewHeadsSubscription from './subscriptions/eth/NewHeadsSubscription';
+export NewPendingTransactionsSubscription from './subscriptions/eth/NewPendingTransactionsSubscription';
+export SyncingSubscription from './subscriptions/eth/SyncingSubscription';
+
+// Shh
+export MessagesSubscription from './subscriptions/shh/MessagesSubscription';
+


### PR DESCRIPTION
## Description

Not all subscription classes were exported from the core-subscriptions module. I've added now all exports in the index.js of the module. 
These subscription classes will be used in the new [``Web3 Module API``](https://github.com/ethereum/web3.js/pull/2236) web3.js does provide. 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on the live network.
