### PR TITLE
Version 6 and 7 removed from travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-    - "6"
-    - "7"
     - "8"
     - "9"
     - "10"


### PR DESCRIPTION
## Description

I'm removing this because version 6 and 7 of nodejs does have problems with the dtslint module on TravisCI. 

I've created an [issue](https://github.com/Microsoft/dtslint/issues/204) there and asked about further details and they don't support version 6&7. Web3.js will still support these versions but I removed them from the PR TravisCI build.

## Type of change

- [x] TravisCI

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on the live network.
