### PR TITLE
Fix CSP "script-src" errors in Firefox

### DIFF
--- a/packages/web3-providers/src/detectors/ProviderDetector.js
+++ b/packages/web3-providers/src/detectors/ProviderDetector.js
@@ -20,14 +20,11 @@
  * @date 2018
  */
 
-/* eslint-disable no-new-func */
-let global;
-try {
-    global = new Function('return this')();
-} catch (error) {
-    global = window;
-}
-/* eslint-enable */
+const global =
+    (function() {
+        return this || (typeof self === 'object' && self);
+        // eslint-disable-next-line no-new-func
+    })() || new Function('return this')();
 
 export default class ProviderDetector {
     /**

--- a/packages/web3-providers/src/resolvers/ProviderResolver.js
+++ b/packages/web3-providers/src/resolvers/ProviderResolver.js
@@ -23,14 +23,11 @@
 import isFunction from 'lodash/isFunction';
 import isObject from 'lodash/isObject';
 
-/* eslint-disable no-new-func */
-let global;
-try {
-    global = new Function('return this')();
-} catch (error) {
-    global = window;
-}
-/* eslint-enable */
+const global =
+    (function() {
+        return this || (typeof self === 'object' && self);
+        // eslint-disable-next-line no-new-func
+    })() || new Function('return this')();
 
 export default class ProviderResolver {
     /**


### PR DESCRIPTION
Hi guys!

I'm trying to get a bundle js file with `web3@1.0.0-beta.46` packed into it into a page but the only thing I'm seeing is:
> _Content Security Policy: The page’s settings blocked the loading of a resource at eval (“script-src”)._

It happens only on Firefox. Tested on FF v65.0.1, Chrome and Safari. Here are CSP settings I'm using:
  > `default-src *; script-src 'self'; object-src 'none'; style-src 'self';`

Created a quick demo that shows the issue I'm seeing:
https://github.com/mondoreale/web3-csp-fix-demo

Apparently in this case Firefox does not care about `try…catch` block around `new Function('return this')()`. As soon as it hits `new Function(…)` it fails.

In this PR I address this issue. Let me know if you have any suggestions! It's my first PR here. Go easy on me! ;)

Cheers,
MR

## Type of change

- [x] Bug fix

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] ~I have commented my code, particularly in hard-to-understand areas.~
- [x] ~I have made corresponding changes to the documentation.~
- [x] My changes generate no warnings.
- [x] ~I have updated or added types for all modules I've changed~
- [x] ~Any dependent changes have been merged and published in downstream modules.~
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] ~I have tested my code on the live network.~
