### PR TITLE
output formatter updated in GetTransactionReceiptMethod

### DIFF
--- a/packages/web3-core-helpers/src/Formatters.js
+++ b/packages/web3-core-helpers/src/Formatters.js
@@ -259,10 +259,6 @@ export const outputTransactionFormatter = (receipt) => {
  * @returns {Object}
  */
 export const outputTransactionReceiptFormatter = (receipt) => {
-    if (typeof receipt !== 'object') {
-        throw new TypeError(`Received receipt is invalid: ${receipt}`);
-    }
-
     if (receipt.blockNumber !== null) {
         receipt.blockNumber = Utils.hexToNumber(receipt.blockNumber);
     }

--- a/packages/web3-core-helpers/tests/src/Formatters/OutputTransactionReceiptFormatterTest.js
+++ b/packages/web3-core-helpers/tests/src/Formatters/OutputTransactionReceiptFormatterTest.js
@@ -76,10 +76,4 @@ describe('OutputTransactionReceiptFormatterTest', () => {
             ]
         });
     });
-
-    it('call outputTransactionReceiptFormatter with invalid argument', () => {
-        expect(() => {
-            outputTransactionReceiptFormatter('STRING');
-        }).toThrow('Received receipt is invalid: STRING');
-    });
 });

--- a/packages/web3-core-method/src/methods/transaction/GetTransactionReceiptMethod.js
+++ b/packages/web3-core-method/src/methods/transaction/GetTransactionReceiptMethod.js
@@ -44,7 +44,7 @@ export default class GetTransactionReceiptMethod extends AbstractCallMethod {
      */
     afterExecution(response) {
         if (response !== null) {
-            return this.formatters.outputTransactionFormatter(response);
+            return this.formatters.outputTransactionReceiptFormatter(response);
         }
 
         return response;

--- a/packages/web3-core-method/src/validators/TransactionReceiptValidator.js
+++ b/packages/web3-core-method/src/validators/TransactionReceiptValidator.js
@@ -55,7 +55,7 @@ export default class TransactionReceiptValidator {
      * @returns {Boolean}
      */
     isValidReceiptStatus(receipt) {
-        return receipt.status === true || receipt.status === '0x1' || typeof receipt.status === 'undefined';
+        return receipt.status === true || typeof receipt.status === 'undefined';
     }
 
     /**

--- a/packages/web3-core-method/tests/src/methods/transaction/GetTransactionReceiptMethodTest.js
+++ b/packages/web3-core-method/tests/src/methods/transaction/GetTransactionReceiptMethodTest.js
@@ -28,11 +28,11 @@ describe('GetTransactionReceiptMethodTest', () => {
     });
 
     it('afterExecution should map the response', () => {
-        formatters.outputTransactionFormatter.mockReturnValueOnce({empty: false});
+        formatters.outputTransactionReceiptFormatter.mockReturnValueOnce({empty: false});
 
         expect(method.afterExecution({})).toHaveProperty('empty', false);
 
-        expect(formatters.outputTransactionFormatter).toHaveBeenCalledWith({});
+        expect(formatters.outputTransactionReceiptFormatter).toHaveBeenCalledWith({});
     });
 
     it('afterExecution should return null', () => {

--- a/packages/web3-core-method/tests/src/validators/TransactionReceiptValidatorTest.js
+++ b/packages/web3-core-method/tests/src/validators/TransactionReceiptValidatorTest.js
@@ -37,6 +37,22 @@ describe('TransactionReceiptValidatorTest', () => {
         expect(Utils.hexToNumber).toHaveBeenCalledWith(110);
     });
 
+    it('calls validate and returns true with undefined status property', () => {
+        delete receipt.status;
+        
+        Utils.hexToNumber.mockReturnValueOnce(110);
+
+        method.parameters = [
+            {
+                gas: 110
+            }
+        ];
+
+        expect(transactionReceiptValidator.validate(receipt, method)).toEqual(true);
+
+        expect(Utils.hexToNumber).toHaveBeenCalledWith(110);
+    });
+
     it('calls validate and returns error because of invalid gasUsage', () => {
         Utils.hexToNumber.mockReturnValueOnce(100);
 


### PR DESCRIPTION
## Description

This PR does not actually fix issue #2410 because it was an implementation issue. But during testing it I've noticed that web3.js was not using the correct output formatter for the ``eth_getTransactionReceipt`` call. 

Edit: I've started to fix #2401 and saw that this PR does already fix it.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on the live network.
