### PR TITLE
fix: turn allowSyntheticDefaultImports to false

### DIFF
--- a/packages/web3-bzz/types/tsconfig.json
+++ b/packages/web3-bzz/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-bzz": ["."] 
+        "paths": {
+            "web3-bzz": ["."]
         }
     }
 }

--- a/packages/web3-core-helpers/types/tsconfig.json
+++ b/packages/web3-core-helpers/types/tsconfig.json
@@ -8,7 +8,7 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
             "web3-core-helpers": ["."]

--- a/packages/web3-core-method/types/tsconfig.json
+++ b/packages/web3-core-method/types/tsconfig.json
@@ -8,7 +8,7 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
             "web3-core-method": ["."]

--- a/packages/web3-core/types/tsconfig.json
+++ b/packages/web3-core/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-core": ["."] 
+        "paths": {
+            "web3-core": ["."]
         }
     }
 }

--- a/packages/web3-eth-abi/types/tsconfig.json
+++ b/packages/web3-eth-abi/types/tsconfig.json
@@ -8,7 +8,7 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
             "web3-eth-abi": ["."]

--- a/packages/web3-eth-accounts/types/tsconfig.json
+++ b/packages/web3-eth-accounts/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-eth-accounts": ["."] 
+        "paths": {
+            "web3-eth-accounts": ["."]
         }
     }
 }

--- a/packages/web3-eth-contract/types/tsconfig.json
+++ b/packages/web3-eth-contract/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-eth-contract": ["."] 
+        "paths": {
+            "web3-eth-contract": ["."]
         }
     }
 }

--- a/packages/web3-eth-ens/types/tsconfig.json
+++ b/packages/web3-eth-ens/types/tsconfig.json
@@ -8,7 +8,7 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
             "web3-eth-ens": ["."]

--- a/packages/web3-eth-iban/types/tsconfig.json
+++ b/packages/web3-eth-iban/types/tsconfig.json
@@ -8,7 +8,7 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
             "web3-eth-iban": ["."]

--- a/packages/web3-eth-personal/types/tsconfig.json
+++ b/packages/web3-eth-personal/types/tsconfig.json
@@ -8,7 +8,7 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
             "web3-eth-personal": ["."]

--- a/packages/web3-eth/types/tsconfig.json
+++ b/packages/web3-eth/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-eth": ["."] 
+        "paths": {
+            "web3-eth": ["."]
         }
     }
 }

--- a/packages/web3-net/types/tsconfig.json
+++ b/packages/web3-net/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-net": ["."] 
+        "paths": {
+            "web3-net": ["."]
         }
     }
 }

--- a/packages/web3-providers/types/tsconfig.json
+++ b/packages/web3-providers/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-providers": ["."] 
+        "paths": {
+            "web3-providers": ["."]
         }
     }
 }

--- a/packages/web3-shh/types/tsconfig.json
+++ b/packages/web3-shh/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-shh": ["."] 
+        "paths": {
+            "web3-shh": ["."]
         }
     }
 }

--- a/packages/web3-utils/types/tsconfig.json
+++ b/packages/web3-utils/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3-utils": ["."] 
+        "paths": {
+            "web3-utils": ["."]
         }
     }
 }

--- a/packages/web3/types/tsconfig.json
+++ b/packages/web3/types/tsconfig.json
@@ -8,10 +8,10 @@
         "strictNullChecks": true,
         "strictFunctionTypes": true,
         "noEmit": true,
-        "allowSyntheticDefaultImports": true,
+        "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
-        "paths": { 
-            "web3": ["."] 
+        "paths": {
+            "web3": ["."]
         }
     }
 }


### PR DESCRIPTION
## Description

`allowSyntheticDefaultImports` is too opinionated - https://github.com/ethereum/web3.js/issues/2382

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
