### PR TITLE
abi.decodeLog returns incorrect log parameter values

### DIFF
--- a/packages/web3-eth-abi/src/AbiCoder.js
+++ b/packages/web3-eth-abi/src/AbiCoder.js
@@ -283,6 +283,7 @@ export default class AbiCoder {
 
         inputs.forEach((input, i) => {
             if (input.indexed) {
+                topics = topics.slice(1);
                 indexedParams[i] = ['bool', 'int', 'uint', 'address', 'fixed', 'ufixed'].find((staticType) => {
                     return input.type.indexOf(staticType) !== -1;
                 })


### PR DESCRIPTION
I have observed the same problems as follows：
https://stackoverflow.com/questions/50283291/web3-eth-abi-decodelog-returns-incorrect-log-parameter-values.

## Description

Please include a summary of the change.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change 

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on the live network.
