### PR TITLE
Fix Eth subscribe typings

### DIFF
--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -51,12 +51,10 @@ export class Eth extends AbstractWeb3Module {
 
     clearSubscriptions(): Promise<boolean>;
 
-    subscribe(type: 'logs', options?: Logs): Promise<Subscribe<Log>>;
-    subscribe(type: 'logs', callback?: (error: Error, result: Subscribe<Log>) => void): Promise<Subscribe<Log>>
-    subscribe(type: 'logs', options?: Logs, callback?: (error: Error, result: Subscribe<Log>) => void): Promise<Subscribe<Log>>;
-    subscribe(type: 'syncing', callback?: (error: Error, result: Subscribe<any>) => void): Promise<Subscribe<any>>
-    subscribe(type: 'newBlockHeaders', callback?: (error: Error, result: Subscribe<BlockHeader>) => void): Promise<Subscribe<BlockHeader>>
-    subscribe(type: 'pendingTransactions', callback?: (error: Error, result: Subscribe<Transaction>) => void): Promise<Subscribe<Transaction>>
+    subscribe(type: 'logs', options?: Logs, callback?: (error: Error, log: Log) => void): Subscription<Log>;
+    subscribe(type: 'syncing', options?: null, callback?: (error: Error, result: any) => void): Subscription<any>;
+    subscribe(type: 'newBlockHeaders', options?: null, callback?: (error: Error, blockHeader: BlockHeader) => void): Subscription<BlockHeader>;
+    subscribe(type: 'pendingTransactions', options?: null, callback?: (error: Error, transactionHash: string) => void): Subscription<string>;
 
     getProtocolVersion(callback?: (error: Error, protocolVersion: string) => void): Promise<string>;
 
@@ -195,13 +193,13 @@ export interface Logs {
     topics?: Array<string | string[]>
 }
 
-export interface Subscribe<T> {
-    subscription: {
-        id: string
-        subscribe(callback?: (error: Error, result: Subscribe<T>) => void): Subscribe<T>
-        unsubscribe(callback?: (error: Error, result: boolean) => void): void | boolean
-        options: {}
-    }
+export interface Subscription<T> {
+    id: string;
+    options: {};
+
+    subscribe(callback?: (error: Error, result: T) => void): Subscription<T>;
+
+    unsubscribe(callback?: (error: Error, result: boolean) => void): Promise<undefined | boolean>;
 
     on(type: 'data', handler: (data: T) => void): void
 

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -18,7 +18,7 @@
  */
 
 import {Log, Transaction, TransactionReceipt, RLPEncodedTransaction} from 'web3-core';
-import {Eth, Subscribe, BlockHeader, Syncing, Block} from 'web3-eth';
+import {Eth, BlockHeader, Syncing, Block} from 'web3-eth';
 
 const eth = new Eth('http://localhost:8545');
 
@@ -45,31 +45,28 @@ eth.net;
 
 eth.clearSubscriptions();
 
-// $ExpectType Promise<Subscribe<Log>>
+// $ExpectType Subscription<Log>
 eth.subscribe('logs');
-// $ExpectType Promise<Subscribe<Log>>
-eth.subscribe('logs');
-// $ExpectType Promise<Subscribe<Log>>
-eth.subscribe('logs', (error: Error, result: Subscribe<Log>) => {});
-// $ExpectType Promise<Subscribe<Log>>
+
+// $ExpectType Subscription<Log>
 eth.subscribe('logs', {});
-// $ExpectType Promise<Subscribe<Log>>
-eth.subscribe('logs', {}, (error: Error, result: Subscribe<Log>) => {});
+// $ExpectType Subscription<Log>
+eth.subscribe('logs', {}, (error: Error, log: Log) => {});
 
-// $ExpectType Promise<Subscribe<any>>
+// $ExpectType Subscription<any>
 eth.subscribe('syncing');
-// $ExpectType Promise<Subscribe<any>>
-eth.subscribe('syncing', (error: Error, result: Subscribe<any>) => {});
+// $ExpectType Subscription<any>
+eth.subscribe('syncing', null, (error: Error, result: any) => {});
 
-// $ExpectType Promise<Subscribe<BlockHeader>>
+// $ExpectType Subscription<BlockHeader>
 eth.subscribe('newBlockHeaders');
-// $ExpectType Promise<Subscribe<BlockHeader>>
-eth.subscribe('newBlockHeaders', (error: Error, result: Subscribe<BlockHeader>) => {});
+// $ExpectType Subscription<BlockHeader>
+eth.subscribe('newBlockHeaders', null, (error: Error, blockHeader: BlockHeader) => {});
 
-// $ExpectType Promise<Subscribe<Transaction>>
+// $ExpectType Subscription<string>
 eth.subscribe('pendingTransactions');
-// $ExpectType Promise<Subscribe<Transaction>>
-eth.subscribe('pendingTransactions', (error: Error, result: Subscribe<Transaction>) => {});
+// $ExpectType Subscription<string>
+eth.subscribe('pendingTransactions', null, (error: Error, transactionHash: string) => {});
 
 // $ExpectType Providers
 Eth.providers;


### PR DESCRIPTION
## Description

1. `subscribe` method has strict argument positioning (i.e. `options` is always second, `callback` is always third)
2. `callback` is called with `value` as argument not some `Subscribe`
3. `subscribe` method returns `subscription` not a `Promise`
4. `Subscription` extends `EventEmitter` not incapsulated in it.
5. `Subscription` unsubscribe return `Promise`
6. `pendingTransactions` value is transaction hash(i.e. `string`) not `transaction`

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
