### PR TITLE
Add string index signature to returnValues in EventData

### DIFF
--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -110,7 +110,9 @@ export interface EventOptions {
 }
 
 export interface EventData {
-    returnValues: {},
+    returnValues: {
+        [key: string]: any;
+    },
     raw: {
         data: string;
         topics: string[];


### PR DESCRIPTION
## Description

Add string index signature to `returnValues` in `EventData` for getting event values. This allows to write smth like this:

```ts
async function foo() {
  const events = await this.contract.getPastEvents('MyEvent', {
    fromBlock: 0,
    toBlock: 'latest',
  });

  return events.map(({ returnValues: { value } }: EventData) => ({
    value
  }));
}
```

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
