### PR TITLE
add input to transaction type

### DIFF
--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -129,6 +129,7 @@ export interface Transaction {
     r?: string;
     s?: string;
     hash?: string;
+    input?: string;
 }
 
 export interface RLPEncodedTransaction {


### PR DESCRIPTION
## Description

Adds `input` to `Transaction` type for the Typescript types.

Fixes #2473 

## Type of change

- [x] Bug fix 

## Checklist:

- [x ] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
