### PR TITLE
--unsafe-perm=true, else it throws errors on MacOS

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -24,7 +24,7 @@ Adding web3.js
 
 First you need to get web3.js into your project. This can be done using the following methods:
 
-- npm: ``npm install web3``
+- npm: ``npm install web3 --unsafe-perm=true``
 - meteor: ``meteor add ethereum:web3``
 - pure js: link the ``dist/web3.min.js``
 


### PR DESCRIPTION
The only way I have managed to install it on MacOS was by using "npm install web3 --unsafe-perm=true", without the unsafe perm it didn't work. Either. fix the package or add the flag on the instructions...

## Description

Please include a summary of the change.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
