### PR TITLE
Use genuine BN type

### DIFF
--- a/packages/web3-core/package-lock.json
+++ b/packages/web3-core/package-lock.json
@@ -12,6 +12,14 @@
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
+		"@types/bn.js": {
+			"version": "4.11.4",
+			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.4.tgz",
+			"integrity": "sha512-AO8WW+aRcKWKQAYTfKLzwnpL6U+TfPqS+haRrhCy5ff04Da8WZud3ZgVjspQXaEXJDcTlsjUEVvL39wegDek5w==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/node": {
 			"version": "10.12.18",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",

--- a/packages/web3-core/package-lock.json
+++ b/packages/web3-core/package-lock.json
@@ -180,10 +180,22 @@
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"dev": true,
 			"requires": {
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
 				"typescript": "^3.4.0-dev.20190315"
+			},
+			"dependencies": {
+				"definitelytyped-header-parser": {
+					"version": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
+					"from": "github:Microsoft/definitelytyped-header-parser#production",
+					"dev": true,
+					"requires": {
+						"@types/parsimmon": "^1.3.0",
+						"parsimmon": "^1.2.0"
+					}
+				}
 			}
 		},
 		"escape-string-regexp": {

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -16,8 +16,8 @@
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "dependencies": {
-        "@types/bn.js": "^4.11.4",
         "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
         "@types/node": "^10.12.18",
         "lodash": "^4.17.11",
         "web3-utils": "1.0.0-beta.50"

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -16,6 +16,7 @@
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "dependencies": {
+        "@types/bn.js": "^4.11.4",
         "@babel/runtime": "^7.3.1",
         "@types/node": "^10.12.18",
         "lodash": "^4.17.11",

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -18,6 +18,7 @@
  */
 
 import * as net from 'net';
+import BN = require('bn.js');
 import {AbstractMethodFactory} from 'web3-core-method';
 import {
     BatchRequest,
@@ -29,7 +30,6 @@ import {
     WebsocketProvider,
     WebsocketProviderOptions
 } from 'web3-providers';
-import {BN} from 'web3-utils';
 
 export class AbstractWeb3Module {
     constructor(

--- a/packages/web3-eth-contract/package-lock.json
+++ b/packages/web3-eth-contract/package-lock.json
@@ -12,6 +12,14 @@
 				"regenerator-runtime": "^0.12.0"
 			}
 		},
+		"@types/bn.js": {
+			"version": "4.11.4",
+			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.4.tgz",
+			"integrity": "sha512-AO8WW+aRcKWKQAYTfKLzwnpL6U+TfPqS+haRrhCy5ff04Da8WZud3ZgVjspQXaEXJDcTlsjUEVvL39wegDek5w==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/parsimmon": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",

--- a/packages/web3-eth-contract/package-lock.json
+++ b/packages/web3-eth-contract/package-lock.json
@@ -20,6 +20,11 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/node": {
+			"version": "11.11.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+			"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+		},
 		"@types/parsimmon": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
@@ -175,10 +180,22 @@
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"dev": true,
 			"requires": {
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
 				"typescript": "^3.4.0-dev.20190315"
+			},
+			"dependencies": {
+				"definitelytyped-header-parser": {
+					"version": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
+					"from": "github:Microsoft/definitelytyped-header-parser#production",
+					"dev": true,
+					"requires": {
+						"@types/parsimmon": "^1.3.0",
+						"parsimmon": "^1.2.0"
+					}
+				}
 			}
 		},
 		"escape-string-regexp": {

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -16,8 +16,8 @@
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "dependencies": {
-        "@types/bn.js": "^4.11.4",
         "@babel/runtime": "^7.3.1",
+        "@types/bn.js": "^4.11.4",
         "lodash": "^4.17.11",
         "web3-core": "1.0.0-beta.50",
         "web3-core-helpers": "1.0.0-beta.50",

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -16,6 +16,7 @@
         "dtslint": "dtslint types --onlyTestTsNext"
     },
     "dependencies": {
+        "@types/bn.js": "^4.11.4",
         "@babel/runtime": "^7.3.1",
         "lodash": "^4.17.11",
         "web3-core": "1.0.0-beta.48",

--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -17,8 +17,9 @@
  * @date 2018
  */
 
+import BN = require('bn.js');
 import {provider} from 'web3-providers';
-import {AbiItem, BN} from 'web3-utils';
+import {AbiItem} from 'web3-utils';
 import {PromiEvent} from 'web3-core';
 
 export class Contract {

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -214,11 +214,11 @@ export interface AbiInput {
     name: string;
     type: string;
     indexed?: boolean;
-    components?: AbiInput[];
+	components?: AbiInput[];
 }
 
 export interface AbiOutput {
     name: string;
     type: string;
-    components?: AbiOutput[];
+	components?: AbiOutput[];
 }

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -20,7 +20,7 @@
  * @date 2018
  */
 
-import BigNumber = require('bn.js');
+import BN = require('bn.js');
 import {Buffer} from 'buffer';
 
 export type Unit =
@@ -67,11 +67,6 @@ export type Mixed =
     | boolean;
 
 export type Hex = string | number;
-
-export class BN extends BigNumber {
-    constructor(number: number | string | number[] | Buffer | BN, base?: number | 'hex', endian?: 'le' | 'be');
-    super(number: number | string | number[] | Buffer | BN, base?: number | 'hex', endian?: 'le' | 'be'): BigNumber;
-}
 
 // utils types
 export function isBN(value: string | number): boolean;
@@ -219,11 +214,11 @@ export interface AbiInput {
     name: string;
     type: string;
     indexed?: boolean;
-	components?: AbiInput[];
+    components?: AbiInput[];
 }
 
 export interface AbiOutput {
     name: string;
     type: string;
-	components?: AbiOutput[];
+    components?: AbiOutput[];
 }

--- a/packages/web3-utils/types/tests/ascii-to-hex-test.ts
+++ b/packages/web3-utils/types/tests/ascii-to-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {asciiToHex, BN} from 'web3-utils';
+import BN = require('bn.js');
+import {asciiToHex} from 'web3-utils';
 
 // $ExpectType string
 asciiToHex('I have 100!');

--- a/packages/web3-utils/types/tests/bytes-to-hex-test.ts
+++ b/packages/web3-utils/types/tests/bytes-to-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, bytesToHex} from 'web3-utils';
+import BN = require('bn.js');
+import {bytesToHex} from 'web3-utils';
 
 // $ExpectType string
 bytesToHex([72]);

--- a/packages/web3-utils/types/tests/check-address-checksum-test.ts
+++ b/packages/web3-utils/types/tests/check-address-checksum-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, checkAddressChecksum} from 'web3-utils';
+import BN = require('bn.js');
+import {checkAddressChecksum} from 'web3-utils';
 
 // $ExpectType boolean
 checkAddressChecksum('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51');

--- a/packages/web3-utils/types/tests/from-ascii-test.ts
+++ b/packages/web3-utils/types/tests/from-ascii-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, fromAscii} from 'web3-utils';
+import BN = require('bn.js');
+import {fromAscii} from 'web3-utils';
 
 // $ExpectType string
 fromAscii('I have 100!');

--- a/packages/web3-utils/types/tests/from-decimal-test.ts
+++ b/packages/web3-utils/types/tests/from-decimal-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, fromDecimal} from 'web3-utils';
+import BN = require('bn.js');
+import {fromDecimal} from 'web3-utils';
 
 // $ExpectType string
 fromDecimal('232');

--- a/packages/web3-utils/types/tests/from-utf8-test.ts
+++ b/packages/web3-utils/types/tests/from-utf8-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, fromUtf8} from 'web3-utils';
+import BN = require('bn.js');
+import {fromUtf8} from 'web3-utils';
 
 // $ExpectType string
 fromUtf8('I have 100£');

--- a/packages/web3-utils/types/tests/from-wei-test.ts
+++ b/packages/web3-utils/types/tests/from-wei-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, fromWei} from 'web3-utils';
+import BN = require('bn.js');
+import {fromWei} from 'web3-utils';
 
 const bigNumber = new BN(3);
 

--- a/packages/web3-utils/types/tests/get-signature-params-test.ts
+++ b/packages/web3-utils/types/tests/get-signature-params-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, getSignatureParameters} from 'web3-utils';
+import BN = require('bn.js');
+import {getSignatureParameters} from 'web3-utils';
 
 // $ExpectType { r: string; s: string; v: number; }
 getSignatureParameters(

--- a/packages/web3-utils/types/tests/get-unit-value-test.ts
+++ b/packages/web3-utils/types/tests/get-unit-value-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, getUnitValue} from 'web3-utils';
+import BN = require('bn.js');
+import {getUnitValue} from 'web3-utils';
 
 // $ExpectType string
 getUnitValue('ether');

--- a/packages/web3-utils/types/tests/hex-to-ascii-test.ts
+++ b/packages/web3-utils/types/tests/hex-to-ascii-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, hexToAscii} from 'web3-utils';
+import BN = require('bn.js');
+import {hexToAscii} from 'web3-utils';
 
 // $ExpectType string
 hexToAscii('0x4920686176652031303021');

--- a/packages/web3-utils/types/tests/hex-to-bytes-test.ts
+++ b/packages/web3-utils/types/tests/hex-to-bytes-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, hexToBytes} from 'web3-utils';
+import BN = require('bn.js');
+import {hexToBytes} from 'web3-utils';
 
 // $ExpectType number[]
 hexToBytes('0x000000ea');

--- a/packages/web3-utils/types/tests/hex-to-number-string-test.ts
+++ b/packages/web3-utils/types/tests/hex-to-number-string-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, hexToNumberString} from 'web3-utils';
+import BN = require('bn.js');
+import {hexToNumberString} from 'web3-utils';
 
 // $ExpectType string
 hexToNumberString('0xea');

--- a/packages/web3-utils/types/tests/hex-to-number-test.ts
+++ b/packages/web3-utils/types/tests/hex-to-number-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, hexToNumber} from 'web3-utils';
+import BN = require('bn.js');
+import {hexToNumber} from 'web3-utils';
 
 // $ExpectType number
 hexToNumber('232');

--- a/packages/web3-utils/types/tests/hex-to-string-test.ts
+++ b/packages/web3-utils/types/tests/hex-to-string-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, hexToString} from 'web3-utils';
+import BN = require('bn.js');
+import {hexToString} from 'web3-utils';
 
 // $ExpectType string
 hexToString('0x49206861766520313030e282ac');

--- a/packages/web3-utils/types/tests/hex-to-utf8-test.ts
+++ b/packages/web3-utils/types/tests/hex-to-utf8-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, hexToUtf8} from 'web3-utils';
+import BN = require('bn.js');
+import {hexToUtf8} from 'web3-utils';
 
 // $ExpectType string
 hexToUtf8('0x49206861766520313030e282ac');

--- a/packages/web3-utils/types/tests/is-address-test.ts
+++ b/packages/web3-utils/types/tests/is-address-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, isAddress} from 'web3-utils';
+import BN = require('bn.js');
+import {isAddress} from 'web3-utils';
 
 // $ExpectType boolean
 isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51');

--- a/packages/web3-utils/types/tests/is-big-number-test.ts
+++ b/packages/web3-utils/types/tests/is-big-number-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {isBigNumber, BN} from 'web3-utils';
+import BN = require('bn.js');
+import {isBigNumber} from 'web3-utils';
 
 // $ExpectType boolean
 isBigNumber(new BN(3));

--- a/packages/web3-utils/types/tests/is-bloom-test.ts
+++ b/packages/web3-utils/types/tests/is-bloom-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, isBloom} from 'web3-utils';
+import BN = require('bn.js');
+import {isBloom} from 'web3-utils';
 
 // $ExpectType boolean
 isBloom('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef');

--- a/packages/web3-utils/types/tests/is-bn-test.ts
+++ b/packages/web3-utils/types/tests/is-bn-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {isBN, BN} from 'web3-utils';
+import BN = require('bn.js');
+import {isBN} from 'web3-utils';
 
 // $ExpectType boolean
 isBN(7);

--- a/packages/web3-utils/types/tests/is-hex-strict-test.ts
+++ b/packages/web3-utils/types/tests/is-hex-strict-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, isHexStrict} from 'web3-utils';
+import BN = require('bn.js');
+import {isHexStrict} from 'web3-utils';
 
 // $ExpectType boolean
 isHexStrict('0xc1912');

--- a/packages/web3-utils/types/tests/is-hex-test.ts
+++ b/packages/web3-utils/types/tests/is-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, isHex} from 'web3-utils';
+import BN = require('bn.js');
+import {isHex} from 'web3-utils';
 
 // $ExpectType boolean
 isHex('0xc1912');

--- a/packages/web3-utils/types/tests/is-topic-test.ts
+++ b/packages/web3-utils/types/tests/is-topic-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, isTopic} from 'web3-utils';
+import BN = require('bn.js');
+import {isTopic} from 'web3-utils';
 
 // $ExpectType boolean
 isTopic('0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef');

--- a/packages/web3-utils/types/tests/keccak256-test.ts
+++ b/packages/web3-utils/types/tests/keccak256-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, keccak256} from 'web3-utils';
+import BN = require('bn.js');
+import {keccak256} from 'web3-utils';
 
 // $ExpectType string
 keccak256('234');

--- a/packages/web3-utils/types/tests/left-pad-test.ts
+++ b/packages/web3-utils/types/tests/left-pad-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, leftPad} from 'web3-utils';
+import BN = require('bn.js');
+import {leftPad} from 'web3-utils';
 
 const bigNumber = new BN(3);
 // $ExpectType string

--- a/packages/web3-utils/types/tests/number-to-hex-test.ts
+++ b/packages/web3-utils/types/tests/number-to-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, numberToHex} from 'web3-utils';
+import BN = require('bn.js');
+import {numberToHex} from 'web3-utils';
 
 // $ExpectType string
 numberToHex('232');

--- a/packages/web3-utils/types/tests/pad-left-test.ts
+++ b/packages/web3-utils/types/tests/pad-left-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, padLeft} from 'web3-utils';
+import BN = require('bn.js');
+import {padLeft} from 'web3-utils';
 
 const bigNumber = new BN(3);
 

--- a/packages/web3-utils/types/tests/pad-right-test.ts
+++ b/packages/web3-utils/types/tests/pad-right-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, padRight} from 'web3-utils';
+import BN = require('bn.js');
+import {padRight} from 'web3-utils';
 
 const bigNumber = new BN(3);
 

--- a/packages/web3-utils/types/tests/random-hex-test.ts
+++ b/packages/web3-utils/types/tests/random-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, randomHex} from 'web3-utils';
+import BN = require('bn.js');
+import {randomHex} from 'web3-utils';
 
 // $ExpectType string
 randomHex(32);

--- a/packages/web3-utils/types/tests/right-pad-test.ts
+++ b/packages/web3-utils/types/tests/right-pad-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, rightPad} from 'web3-utils';
+import BN = require('bn.js');
+import {rightPad} from 'web3-utils';
 
 const bigNumber = new BN(3);
 

--- a/packages/web3-utils/types/tests/sha3-test.ts
+++ b/packages/web3-utils/types/tests/sha3-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, sha3} from 'web3-utils';
+import BN = require('bn.js');
+import {sha3} from 'web3-utils';
 
 // $ExpectType string
 sha3('234');

--- a/packages/web3-utils/types/tests/solidity-sha3-test.ts
+++ b/packages/web3-utils/types/tests/solidity-sha3-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, soliditySha3} from 'web3-utils';
+import BN = require('bn.js');
+import {soliditySha3} from 'web3-utils';
 
 // $ExpectType string
 soliditySha3('234564535', '0xfff23243', true, -10);

--- a/packages/web3-utils/types/tests/string-to-hex-test.ts
+++ b/packages/web3-utils/types/tests/string-to-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, stringToHex} from 'web3-utils';
+import BN = require('bn.js');
+import {stringToHex} from 'web3-utils';
 
 // $ExpectType string
 stringToHex('I have 100£');

--- a/packages/web3-utils/types/tests/test-address-test.ts
+++ b/packages/web3-utils/types/tests/test-address-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, testAddress} from 'web3-utils';
+import BN = require('bn.js');
+import {testAddress} from 'web3-utils';
 
 const bigNumber = new BN(3);
 

--- a/packages/web3-utils/types/tests/test-topic-test.ts
+++ b/packages/web3-utils/types/tests/test-topic-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, testTopic} from 'web3-utils';
+import BN = require('bn.js');
+import {testTopic} from 'web3-utils';
 
 const bigNumber = new BN(3);
 

--- a/packages/web3-utils/types/tests/to-ascii-test.ts
+++ b/packages/web3-utils/types/tests/to-ascii-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, toAscii} from 'web3-utils';
+import BN = require('bn.js');
+import {toAscii} from 'web3-utils';
 
 // $ExpectType string
 toAscii('0x4920686176652031303021');

--- a/packages/web3-utils/types/tests/to-check-sum-address-test.ts
+++ b/packages/web3-utils/types/tests/to-check-sum-address-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, toChecksumAddress} from 'web3-utils';
+import BN = require('bn.js');
+import {toChecksumAddress} from 'web3-utils';
 
 // $ExpectType string
 toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51');

--- a/packages/web3-utils/types/tests/to-decimal-test.ts
+++ b/packages/web3-utils/types/tests/to-decimal-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, toDecimal} from 'web3-utils';
+import BN = require('bn.js');
+import {toDecimal} from 'web3-utils';
 
 // $ExpectType number
 toDecimal('232');

--- a/packages/web3-utils/types/tests/to-hex-test.ts
+++ b/packages/web3-utils/types/tests/to-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, toHex} from 'web3-utils';
+import BN = require('bn.js');
+import {toHex} from 'web3-utils';
 
 // $ExpectType string
 toHex('234');

--- a/packages/web3-utils/types/tests/to-twos-compement-test.ts
+++ b/packages/web3-utils/types/tests/to-twos-compement-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {toTwosComplement, BN} from 'web3-utils';
+import BN = require('bn.js');
+import {toTwosComplement} from 'web3-utils';
 
 // $ExpectType string
 toTwosComplement(4);

--- a/packages/web3-utils/types/tests/to-utf8-test.ts
+++ b/packages/web3-utils/types/tests/to-utf8-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, toUtf8} from 'web3-utils';
+import BN = require('bn.js');
+import {toUtf8} from 'web3-utils';
 
 // $ExpectType string
 toUtf8('0x49206861766520313030e282ac');

--- a/packages/web3-utils/types/tests/to-wei-test.ts
+++ b/packages/web3-utils/types/tests/to-wei-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, toWei} from 'web3-utils';
+import BN = require('bn.js');
+import {toWei} from 'web3-utils';
 
 const bigNumber = new BN(3);
 

--- a/packages/web3-utils/types/tests/utf8-to-hex-test.ts
+++ b/packages/web3-utils/types/tests/utf8-to-hex-test.ts
@@ -20,7 +20,8 @@
  * @date 2018
  */
 
-import {BN, utf8ToHex} from 'web3-utils';
+import BN = require('bn.js');
+import {utf8ToHex} from 'web3-utils';
 
 // $ExpectType string
 utf8ToHex('I have 100£');


### PR DESCRIPTION
## Description

Don't wrap BN but use type from BN library to improve compatibility with BN operations. Without this change this code is invalid:
```ts
const bigNumber = new BN(3);

fromWei(bigNumber.add(new BN(100)));
```

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

Fixes #2350

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
