### PR TITLE
Fix eth_sign parameter ordering

### DIFF
--- a/packages/web3-core-method/src/methods/SignMethod.js
+++ b/packages/web3-core-method/src/methods/SignMethod.js
@@ -44,5 +44,6 @@ export default class SignMethod extends AbstractMethod {
     beforeExecution(moduleInstance) {
         this.parameters[0] = this.formatters.inputSignFormatter(this.parameters[0]);
         this.parameters[1] = this.formatters.inputAddressFormatter(this.parameters[1]);
+        this.parameters.reverse()
     }
 }

--- a/packages/web3-core-method/src/methods/SignMethod.js
+++ b/packages/web3-core-method/src/methods/SignMethod.js
@@ -44,6 +44,6 @@ export default class SignMethod extends AbstractMethod {
     beforeExecution(moduleInstance) {
         this.parameters[0] = this.formatters.inputSignFormatter(this.parameters[0]);
         this.parameters[1] = this.formatters.inputAddressFormatter(this.parameters[1]);
-        this.parameters.reverse()
+        this.parameters.reverse();
     }
 }

--- a/packages/web3-core-method/tests/src/methods/SignMethodTest.js
+++ b/packages/web3-core-method/tests/src/methods/SignMethodTest.js
@@ -23,7 +23,7 @@ describe('SignMethodTest', () => {
         expect(method.rpcMethod).toEqual('eth_sign');
     });
 
-    it('beforeExecution should call the inputSignFormatter and inputAddressFormatter', () => {
+    it('beforeExecution should call the inputSignFormatter and inputAddressFormatter and swap order of parameters', () => {
         method.parameters = ['string', 'string'];
 
         formatters.inputSignFormatter.mockReturnValueOnce('string');
@@ -32,9 +32,9 @@ describe('SignMethodTest', () => {
 
         method.beforeExecution(moduleInstanceMock);
 
-        expect(method.parameters[0]).toEqual('string');
+        expect(method.parameters[1]).toEqual('string');
 
-        expect(method.parameters[1]).toEqual('0x0');
+        expect(method.parameters[0]).toEqual('0x0');
 
         expect(formatters.inputSignFormatter).toHaveBeenCalledWith('string');
 

--- a/packages/web3-eth/src/methods/EthSignMethod.js
+++ b/packages/web3-eth/src/methods/EthSignMethod.js
@@ -62,8 +62,8 @@ export default class EthSignMethod extends SignMethod {
             this.beforeExecution(this.moduleInstance);
 
             let signedMessage = this.moduleInstance.accounts.sign(
-                this.parameters[0],
-                this.moduleInstance.accounts.wallet[this.parameters[1]].address
+                this.parameters[1],
+                this.moduleInstance.accounts.wallet[this.parameters[0]].address
             );
 
             if (this.callback) {

--- a/packages/web3-eth/tests/src/methods/EthSignMethodTest.js
+++ b/packages/web3-eth/tests/src/methods/EthSignMethodTest.js
@@ -46,9 +46,9 @@ describe('EthSignMethodTest', () => {
 
         expect(method.callback).toHaveBeenCalledWith(false, '0x00');
 
-        expect(method.parameters[0]).toEqual('string');
+        expect(method.parameters[0]).toEqual('0x0');
 
-        expect(method.parameters[1]).toEqual('0x0');
+        expect(method.parameters[1]).toEqual('string');
 
         expect(formatters.inputAddressFormatter).toHaveBeenCalledWith('0x0');
 


### PR DESCRIPTION
## Description

eth_sign is receiving the address and data parameters the wrong way round.
I have tested this on both ganache on rinkeby to confirm the issue.

If there is a callback, it isn't included in `this.parameters` so calling `reverse()` works fine

Fixes #2555 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
