### PR TITLE
Fix issue with boolean typed receipt status

### DIFF
--- a/packages/web3-core-method/lib/methods/transaction/AbstractObservedTransactionMethod.js
+++ b/packages/web3-core-method/lib/methods/transaction/AbstractObservedTransactionMethod.js
@@ -172,6 +172,9 @@ export default class AbstractObservedTransactionMethod extends AbstractMethod {
      * @returns {Boolean}
      */
     hasRevertReceiptStatus(receipt) {
+        if (typeof receipt.status === 'boolean') {
+            return !receipt.status;
+        }
         return Boolean(parseInt(receipt.status)) === false && receipt.status !== undefined && receipt.status !== null;
     }
 }

--- a/packages/web3-core-method/tests/lib/methods/transaction/AbstractObservedTransactionMethodTest.js
+++ b/packages/web3-core-method/tests/lib/methods/transaction/AbstractObservedTransactionMethodTest.js
@@ -134,6 +134,24 @@ describe('AbstractObservedTransactionMethodTest', () => {
         expect(afterExecutionMock).toHaveBeenCalledWith({status: '0x1'});
     });
 
+    it('calls execute and returns with the expected resolved Promise when the status is a boolean', async () => {
+        providerMock.send.mockReturnValueOnce(Promise.resolve('transactionHash'));
+
+        observableMock.subscribe = jest.fn((next, error, complete) => {
+            next({count: 0, receipt: {status: true}});
+
+            complete();
+        });
+
+        await expect(method.execute()).resolves.toEqual({status: true});
+
+        expect(providerMock.send).toHaveBeenCalledWith('rpcMethod', []);
+
+        expect(beforeExecutionMock).toHaveBeenCalledWith(moduleInstanceMock);
+
+        expect(afterExecutionMock).toHaveBeenCalledWith({status: true});
+    });
+
     it('calls execute and returns with the expected rejected Promise', async () => {
         providerMock.send.mockReturnValueOnce(Promise.resolve('transactionHash'));
 


### PR DESCRIPTION
## Description
The `status` field of the transaction receipt is sometimes returned as a boolean, not hex. This was causing web3 to think the transaction reverted when it had actually succeeded.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
