### PR TITLE
Fix issue decoding log with only indexed parameters

### DIFF
--- a/packages/web3-eth-contract/src/decoders/EventLogDecoder.js
+++ b/packages/web3-eth-contract/src/decoders/EventLogDecoder.js
@@ -47,6 +47,10 @@ export default class EventLogDecoder {
             argTopics = response.topics.slice(1);
         }
 
+        if (response.data === '0x') {
+            response.data = null;
+        }
+
         response.returnValues = this.abiCoder.decodeLog(abiItemModel.getInputs(), response.data, argTopics);
         response.event = abiItemModel.name;
         response.signature = abiItemModel.signature;

--- a/packages/web3-eth-contract/tests/src/decoders/EventLogDecoderTest.js
+++ b/packages/web3-eth-contract/tests/src/decoders/EventLogDecoderTest.js
@@ -61,6 +61,43 @@ describe('EventLogDecoderTest', () => {
         expect(abiItemModel.getInputs).toHaveBeenCalled();
     });
 
+    it('calls decode and returns the expected value when the data field is empty', () => {
+        new AbiItemModel({});
+        const abiItemModel = AbiItemModel.mock.instances[0];
+
+        const response = {
+            topics: ['0x0'],
+            data: '0x'
+        };
+
+        abiItemModel.name = 'Event';
+        abiItemModel.signature = 'Event()';
+
+        abiItemModel.getInputs.mockReturnValueOnce([]);
+
+        abiCoderMock.decodeLog.mockReturnValueOnce(['0x0']);
+
+        const decodedLog = eventLogDecoder.decode(abiItemModel, response);
+
+        expect(decodedLog.data).toEqual(undefined);
+
+        expect(decodedLog.topics).toEqual(undefined);
+
+        expect(decodedLog.raw.data).toEqual(null);
+
+        expect(decodedLog.raw.topics).toEqual(['0x0']);
+
+        expect(decodedLog.signature).toEqual(abiItemModel.signature);
+
+        expect(decodedLog.event).toEqual(abiItemModel.name);
+
+        expect(decodedLog.returnValues).toEqual(['0x0']);
+
+        expect(abiCoderMock.decodeLog).toHaveBeenCalledWith([], null, []);
+
+        expect(abiItemModel.getInputs).toHaveBeenCalled();
+    });
+
     it('calls decode without topics and with the anonymous property and returns the expected value', () => {
         new AbiItemModel({});
         const abiItemModel = AbiItemModel.mock.instances[0];


### PR DESCRIPTION
## Description
If a log has only indexed parameters, the data field may still be present as `0x`. The `AbiCoder` was attempting to decode this and erroring.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
