### PR TITLE
Contract calls should return a BigNumber object

### DIFF
--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -36,13 +36,6 @@ import EthAbiCoder from './AbiCoder.js';
 export function AbiCoder() {
     return new EthAbiCoder(
         Utils,
-        // TODO: Change this anonymous method to a accessable method because of the testing.
-        new EthersAbiCoder((type, value) => {
-            if (!isArray(value) && isObject(value) && value.toString) {
-                return value.toString();
-            }
-
-            return value;
-        })
+        new EthersAbiCoder()
     );
 }

--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -39,8 +39,7 @@ export function AbiCoder() {
         // TODO: Change this anonymous method to a accessable method because of the testing.
         new EthersAbiCoder((type, value) => {
             if (
-                (type.match(/^u?int/) && !isArray(value) && !isObject(value)) ||
-                value.constructor.name === 'BigNumber'
+                (type.match(/^u?int/) && !isArray(value) && !isObject(value)) || isObject(value) && value.toString
             ) {
                 return value.toString();
             }

--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -38,9 +38,7 @@ export function AbiCoder() {
         Utils,
         // TODO: Change this anonymous method to a accessable method because of the testing.
         new EthersAbiCoder((type, value) => {
-            if (
-                (type.match(/^u?int/) && !isArray(value) && !isObject(value)) || isObject(value) && value.toString
-            ) {
+            if (!isArray(value) && isObject(value) && value.toString) {
                 return value.toString();
             }
 


### PR DESCRIPTION
## Description

Not a string should be returned on a contract call it should return the BigNumber object we have.

Fixes #2570 

## Type of change

- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
