### PR TITLE
fix websocket provider basic auth handling

### DIFF
--- a/packages/web3-providers/src/factories/ProvidersModuleFactory.js
+++ b/packages/web3-providers/src/factories/ProvidersModuleFactory.js
@@ -132,11 +132,11 @@ export default class ProvidersModuleFactory {
             const urlObject = new URL(url);
 
             if (urlObject.username && urlObject.password) {
-                authToken = Buffer.from(`${urlObject.username}:${urlObject.password}`, 'base64');
+                authToken = Buffer.from(`${urlObject.username}:${urlObject.password}`).toString('base64');
                 headers.authorization = `Basic ${authToken}`;
             }
 
-            if (urlObject.auth) {
+            else if (urlObject.auth) {
                 headers.authorization = Buffer.from(urlObject.auth, 'base64');
             }
 

--- a/packages/web3-providers/tests/src/factories/ProvidersModuleFactoryTest.js
+++ b/packages/web3-providers/tests/src/factories/ProvidersModuleFactoryTest.js
@@ -76,7 +76,7 @@ describe('ProvidersModuleFactoryTest', () => {
             'ws://username:password@hallo:5544',
             'string',
             null,
-            {authorization: Buffer.from([186, 199, 171, 157, 169, 158, 165, 171, 44, 194, 138, 221])},
+            {authorization: 'Basic dXNlcm5hbWU6cGFzc3dvcmQ='},
             null,
             'string'
         );


### PR DESCRIPTION
## Description

Previous handling of basic authentication credentials created base64 buffer concatenated user/pass. Should be creating buffer of base64 encoded string.

url-parse used always includes `.auth` object which overrides header built using `.username` and `.password`. Switch to `else if`.

NOTE: Fix does not address the lack of testing around the URL.auth object

I was unable to test against the ethereum test network because I couldn't figure out how to load the module locally (I am brand new to node).

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
