### PR TITLE
Update AbstractObservedTransaction to use formatted receipt.status

### DIFF
--- a/packages/web3-core-method/lib/methods/transaction/AbstractObservedTransactionMethod.js
+++ b/packages/web3-core-method/lib/methods/transaction/AbstractObservedTransactionMethod.js
@@ -172,6 +172,6 @@ export default class AbstractObservedTransactionMethod extends AbstractMethod {
      * @returns {Boolean}
      */
     hasRevertReceiptStatus(receipt) {
-        return Boolean(parseInt(receipt.status)) === false && receipt.status !== undefined && receipt.status !== null;
+        return receipt.status === false && receipt.status !== undefined && receipt.status !== null;
     }
 }

--- a/packages/web3-core-method/tests/lib/methods/transaction/AbstractObservedTransactionMethodTest.js
+++ b/packages/web3-core-method/tests/lib/methods/transaction/AbstractObservedTransactionMethodTest.js
@@ -69,7 +69,7 @@ describe('AbstractObservedTransactionMethodTest', () => {
         providerMock.send.mockReturnValueOnce(Promise.resolve('transactionHash'));
 
         observableMock.subscribe = jest.fn((next, error, complete) => {
-            next({confirmations: 0, receipt: {status: '0x1'}});
+            next({confirmations: 0, receipt: {status: true}});
 
             complete();
         });
@@ -78,17 +78,17 @@ describe('AbstractObservedTransactionMethodTest', () => {
         promiEvent.on('transactionHash', transactionHashCallback);
         promiEvent.on('confirmation', confirmationCallback);
         promiEvent.on('receipt', (receipt) => {
-            expect(receipt).toEqual({status: '0x1'});
+            expect(receipt).toEqual({status: true});
 
             expect(providerMock.send).toHaveBeenCalledWith('rpcMethod', []);
 
             expect(beforeExecutionMock).toHaveBeenCalledWith(moduleInstanceMock);
 
-            expect(afterExecutionMock).toHaveBeenCalledWith({status: '0x1'});
+            expect(afterExecutionMock).toHaveBeenCalledWith({status: true});
 
             expect(transactionHashCallback).toHaveBeenCalledWith('transactionHash');
 
-            expect(confirmationCallback).toHaveBeenCalledWith(0, {status: '0x1'});
+            expect(confirmationCallback).toHaveBeenCalledWith(0, {status: true});
 
             done();
         });
@@ -120,18 +120,18 @@ describe('AbstractObservedTransactionMethodTest', () => {
         providerMock.send.mockReturnValueOnce(Promise.resolve('transactionHash'));
 
         observableMock.subscribe = jest.fn((next, error, complete) => {
-            next({count: 0, receipt: {status: '0x1'}});
+            next({count: 0, receipt: {status: true}});
 
             complete();
         });
 
-        await expect(method.execute()).resolves.toEqual({status: '0x1'});
+        await expect(method.execute()).resolves.toEqual({status: true});
 
         expect(providerMock.send).toHaveBeenCalledWith('rpcMethod', []);
 
         expect(beforeExecutionMock).toHaveBeenCalledWith(moduleInstanceMock);
 
-        expect(afterExecutionMock).toHaveBeenCalledWith({status: '0x1'});
+        expect(afterExecutionMock).toHaveBeenCalledWith({status: true});
     });
 
     it('calls execute and returns with the expected rejected Promise', async () => {
@@ -152,7 +152,7 @@ describe('AbstractObservedTransactionMethodTest', () => {
         providerMock.send.mockReturnValueOnce(Promise.resolve('transactionHash'));
 
         observableMock.subscribe = jest.fn((next, error, complete) => {
-            next({count: 0, receipt: {status: '0x0', gasUsed: 1}});
+            next({count: 0, receipt: {status: false, gasUsed: 1}});
 
             complete();
         });
@@ -160,7 +160,7 @@ describe('AbstractObservedTransactionMethodTest', () => {
         method.parameters = [{gas: 0}];
 
         await expect(method.execute()).rejects.toThrow(
-            `Transaction has been reverted by the EVM:\n${JSON.stringify({status: '0x0', gasUsed: 1}, null, 2)}`
+            `Transaction has been reverted by the EVM:\n${JSON.stringify({status: false, gasUsed: 1}, null, 2)}`
         );
 
         expect(providerMock.send).toHaveBeenCalledWith('rpcMethod', method.parameters);
@@ -170,7 +170,7 @@ describe('AbstractObservedTransactionMethodTest', () => {
         providerMock.send.mockReturnValueOnce(Promise.resolve('transactionHash'));
 
         observableMock.subscribe = jest.fn((next, error, complete) => {
-            next({count: 0, receipt: {status: '0x0', gasUsed: 1}});
+            next({count: 0, receipt: {status: false, gasUsed: 1}});
 
             complete();
         });
@@ -179,7 +179,7 @@ describe('AbstractObservedTransactionMethodTest', () => {
 
         await expect(method.execute()).rejects.toThrow(
             `Transaction ran out of gas. Please provide more gas:\n${JSON.stringify(
-                {status: '0x0', gasUsed: 1},
+                {status: false, gasUsed: 1},
                 null,
                 2
             )}`


### PR DESCRIPTION
## Description

Formatted transactions now expose receipt.status as a Type(Boolean) and no longer require re/casting. Parsing status has moved from this file [to HERE](https://github.com/ethereum/web3.js/blob/9dfc93eff1998136f739c8040cea8d0e733a991e/packages/web3-core-helpers/src/Formatters.js#L282) for incoming transaction receipts. Therefore the parse/cast combo can be removed from the Observer and the status can be explicitly checked for value.

Fixes [#2587](https://github.com/ethereum/web3.js/issues/2587), [#2560](https://github.com/ethereum/web3.js/issues/2560), [#2542](https://github.com/ethereum/web3.js/issues/2542), [#2595](https://github.com/ethereum/web3.js/issues/2595)

## Type of change

- [X] Bug fix 

## Checklist:

- [X] I have selected the correct base branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no warnings.
- [X] I have updated or added types for all modules I've changed
- [X] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [X] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [X] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [X] I have tested my code on an ethereum test network.