### PR TITLE
Add index to Wallet type

### DIFF
--- a/packages/web3-eth-accounts/types/index.d.ts
+++ b/packages/web3-eth-accounts/types/index.d.ts
@@ -54,6 +54,8 @@ export class Wallet {
     length: number;
     defaultKeyName: string;
 
+    [key: number]: Account;
+
     create(numberOfAccounts: number, entropy?: string): Wallet;
 
     add(account: string | AddAccount): AddedAccount;

--- a/packages/web3-eth-accounts/types/tests/accounts-tests.ts
+++ b/packages/web3-eth-accounts/types/tests/accounts-tests.ts
@@ -112,6 +112,9 @@ accounts.decrypt(
 // $ExpectType Wallet
 accounts.wallet.create(2);
 
+// $ExpectType Account
+accounts.wallet[0];
+
 // $ExpectType Wallet
 accounts.wallet.create(2, '54674321§3456764321§345674321§3453647544±±±§±±±!!!43534534534534');
 


### PR DESCRIPTION
## Description

Currently there is no way to access accounts in wallet. This change make it possible.

```ts
web3.eth.accounts.wallet[0].address;
```

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
