### PR TITLE
GetProtocolVersionMethod afterExecution added

### DIFF
--- a/packages/web3-core-method/src/methods/network/GetProtocolVersionMethod.js
+++ b/packages/web3-core-method/src/methods/network/GetProtocolVersionMethod.js
@@ -33,4 +33,17 @@ export default class GetProtocolVersionMethod extends AbstractMethod {
     constructor(utils, formatters, moduleInstance) {
         super('eth_protocolVersion', 0, utils, formatters, moduleInstance);
     }
+
+    /**
+     * This method will be executed after the RPC request.
+     *
+     * @method afterExecution
+     *
+     * @param {String} response
+     *
+     * @returns {Number}
+     */
+    afterExecution(response) {
+        return this.utils.hexToNumber(response);
+    }
 }

--- a/packages/web3-core-method/tests/src/methods/network/GetProtocolVersionMethodTest.js
+++ b/packages/web3-core-method/tests/src/methods/network/GetProtocolVersionMethodTest.js
@@ -1,5 +1,9 @@
+import * as Utils from 'web3-utils';
 import AbstractMethod from '../../../../lib/methods/AbstractMethod';
 import GetProtocolVersionMethod from '../../../../src/methods/network/GetProtocolVersionMethod';
+
+// Mocks
+jest.mock('Utils');
 
 /**
  * GetProtocolVersionMethod test
@@ -8,7 +12,7 @@ describe('GetProtocolVersionMethodTest', () => {
     let method;
 
     beforeEach(() => {
-        method = new GetProtocolVersionMethod(null, null, {});
+        method = new GetProtocolVersionMethod(Utils, null, {});
     });
 
     it('constructor check', () => {
@@ -18,8 +22,16 @@ describe('GetProtocolVersionMethodTest', () => {
 
         expect(method.parametersAmount).toEqual(0);
 
-        expect(method.utils).toEqual(null);
+        expect(method.utils).toEqual(Utils);
 
         expect(method.formatters).toEqual(null);
+    });
+
+    it('afterExecution should map the response', () => {
+        Utils.hexToNumber.mockReturnValueOnce(100);
+
+        expect(method.afterExecution('0x0')).toEqual(100);
+
+        expect(Utils.hexToNumber).toHaveBeenCalledWith('0x0');
     });
 });


### PR DESCRIPTION
## Description

The output of ``web3.eth.getProtocolVersion()`` doesn't get transformed  to a number.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
