### PR TITLE
Websocket fork removed as dependency

### DIFF
--- a/packages/web3-providers/package-lock.json
+++ b/packages/web3-providers/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers",
-	"version": "1.0.0-beta.50",
+	"version": "1.0.0-beta.51",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -359,9 +359,9 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"nan": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.0.tgz",
-			"integrity": "sha512-5DDQvN0luhXdut8SCwzm/ZuAX2W+fwhqNzfq7CZ+OJzQ6NwpcqmIGyLD1R8MEt7BeErzcsI0JLr4pND2pNp2Cw=="
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -513,12 +513,13 @@
 			}
 		},
 		"websocket": {
-			"version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-			"from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+			"version": "1.0.28",
+			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.28.tgz",
+			"integrity": "sha512-00y/20/80P7H4bCYkzuuvvfDvh+dgtXi5kzDf3UcZwN6boTYaKvsrtZ5lIYm1Gsg48siMErd9M4zjSYfYFHTrA==",
 			"requires": {
 				"debug": "^2.2.0",
-				"nan": "^2.3.3",
-				"typedarray-to-buffer": "^3.1.2",
+				"nan": "^2.11.0",
+				"typedarray-to-buffer": "^3.1.5",
 				"yaeti": "^0.0.6"
 			}
 		},

--- a/packages/web3-providers/package.json
+++ b/packages/web3-providers/package.json
@@ -21,7 +21,7 @@
         "eventemitter3": "3.1.0",
         "lodash": "^4.17.11",
         "url-parse": "1.4.4",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+        "websocket": "^1.0.28",
         "xhr2-cookies": "1.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
## Description

The referenced issue talks about an older dependency which isn't used in version 1.0 of web3. But there was also an old dependency to remove in the 1.0 branch.

Fixes #1681

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
