### PR TITLE
Replacement of node-scrypt by crypto scrypt

### DIFF
--- a/packages/web3-eth-accounts/src/models/Account.js
+++ b/packages/web3-eth-accounts/src/models/Account.js
@@ -154,7 +154,14 @@ export default class Account {
             kdfparams.n = options.n || 8192; // 2048 4096 8192 16384
             kdfparams.r = options.r || 8;
             kdfparams.p = options.p || 1;
-            derivedKey = scryptsy(Buffer.from(password), salt, kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
+            
+            const scryptOptions = {
+                N : kdfparams.n,
+                blockSize: kdfparams.r,
+                parallelization: kdfparams.p
+            }
+            
+            derivedKey = crypto.scryptSync(Buffer.from(password), salt, kdfparams.dklen || 64, scryptOptions);
         } else {
             throw new Error('Unsupported kdf');
         }


### PR DESCRIPTION
## Description

Hi,
The changes here are to replace the `node-scrypt` module by the node standard library `crypto` scrypt. I went accross some issues with the `node-scrypt` module, like others users. I first searched online and found it was coming from a deprecated version of scrypt. In the [issue!2385](https://github.com/ethereum/web3.js/issues/2385) @Kaisle suggests to move to a standard library.
Here is my attempt.

### Resources
- [Node.js documentation Scrypt module](https://nodejs.org/api/crypto.html#crypto_crypto_scryptsync_password_salt_keylen_options)
- [web3.js issue](https://github.com/ethereum/web3.js/issues/2385)
- [Forked repo](https://github.com/Ugarz/web3.js)
- [Node-scrypt warning in README](https://github.com/barrysteyn/node-scrypt)
<!--- 
Optional if an issue is fixed:
Fixes #(2385)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
