### PR TITLE
Fix callback types

### DIFF
--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -66,7 +66,7 @@ export interface DeployOptions {
 }
 
 export interface ContractSendMethod {
-    send(options: SendOptions, callback?: (err: Error, contracts: Contract) => void): PromiEvent<Contract>;
+    send(options: SendOptions, callback?: (err: Error, transactionHash: string) => void): PromiEvent<Contract>;
 
     estimateGas(options: EstimateGasOptions, callback?: (err: Error, gas: number) => void): Promise<number>;
 

--- a/packages/web3-eth-contract/types/tests/contract-test.ts
+++ b/packages/web3-eth-contract/types/tests/contract-test.ts
@@ -108,4 +108,4 @@ contract.deploy({
 contract.deploy({
     data: '0x12345...',
     arguments: [123, 'My String']
-}).send({from: '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe'}, (err: Error, contract: Contract) => { console.log(contract) });
+}).send({from: '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe'}, (err: Error, transactionHash: string) => { console.log(transactionHash) });

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -121,7 +121,7 @@ export class Eth extends AbstractWeb3Module {
 
     sendTransaction(transactionConfig: TransactionConfig, callback?: (error: Error, hash: string) => void): PromiEvent<TransactionReceipt>;
 
-    sendSignedTransaction(signedTransactionData: string, callback?: (error: Error, gas: string) => void): PromiEvent<TransactionReceipt>
+    sendSignedTransaction(signedTransactionData: string, callback?: (error: Error, hash: string) => void): PromiEvent<TransactionReceipt>
 
     sign(dataToSign: string, address: string | number, callback?: (error: Error, signature: string) => void): Promise<string>;
 

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -286,7 +286,7 @@ eth.sendTransaction(
 // $ExpectType PromiEvent<TransactionReceipt>
 eth.sendSignedTransaction('0xf889808609184e72a0008227109');
 // $ExpectType PromiEvent<TransactionReceipt>
-eth.sendSignedTransaction('0xf889808609184e72a0008227109', (error: Error, gas: string) => {});
+eth.sendSignedTransaction('0xf889808609184e72a0008227109', (error: Error, hash: string) => {});
 
 // $ExpectType Promise<string>
 eth.sign('Hello world', '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe');


### PR DESCRIPTION
sendSignedTransaction returns transaction hash in callback.
contract.deploy.send returns transaction hash in callback.
