### PR TITLE
Add "empty data" check to AbiCoder::decodeLog

### DIFF
--- a/packages/web3-eth-abi/src/AbiCoder.js
+++ b/packages/web3-eth-abi/src/AbiCoder.js
@@ -229,7 +229,7 @@ export default class AbiCoder {
             nonIndexedInputItems.push(input);
         });
 
-        if (data) {
+        if (data && data !== '0x' && data !== '0x0') {
             let values = this.decodeParameters(nonIndexedInputItems, data);
 
             let decodedValue;

--- a/packages/web3-eth-abi/src/AbiCoder.js
+++ b/packages/web3-eth-abi/src/AbiCoder.js
@@ -142,6 +142,9 @@ export default class AbiCoder {
      */
     decodeParameters(outputs, bytes) {
         if (isArray(outputs) && outputs.length === 0) {
+            if (bytes !== '0x' || bytes !== '0x0') {
+                return [];
+            }
             throw new Error('Empty outputs array given!');
         }
 
@@ -229,7 +232,7 @@ export default class AbiCoder {
             nonIndexedInputItems.push(input);
         });
 
-        if (data && data !== '0x' && data !== '0x0') {
+        if (data) {
             let values = this.decodeParameters(nonIndexedInputItems, data);
 
             let decodedValue;

--- a/packages/web3-eth-abi/src/AbiCoder.js
+++ b/packages/web3-eth-abi/src/AbiCoder.js
@@ -142,9 +142,6 @@ export default class AbiCoder {
      */
     decodeParameters(outputs, bytes) {
         if (isArray(outputs) && outputs.length === 0) {
-            if (bytes !== '0x' || bytes !== '0x0') {
-                return [];
-            }
             throw new Error('Empty outputs array given!');
         }
 
@@ -232,7 +229,7 @@ export default class AbiCoder {
             nonIndexedInputItems.push(input);
         });
 
-        if (data) {
+        if (data && data !== '0x' && data !== '0x0') {
             let values = this.decodeParameters(nonIndexedInputItems, data);
 
             let decodedValue;


### PR DESCRIPTION
## Description

This PR address an issue discussed in (and related to) #2582. `AbiCoder::decodeLog` is not performing the same "empty data" check that PR #2549 added to `EventLogDecoder::decode`.

I wasn't able to get the tests to run properly on my machine... not sure what I'm doing wrong there. But this is such a minor change I'm not sure it's necessary? I was able to test this locally with Ganache and it works just fine.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
