### PR TITLE
Renaming sha3 to keccak256

### DIFF
--- a/docs/web3-utils.rst
+++ b/docs/web3-utils.rst
@@ -177,17 +177,17 @@ Example
 
 ------------------------------------------------------------------------------
 
-sha3
+keccak256
 =====================
 
 .. code-block:: javascript
 
-    web3.utils.sha3(string)
-    web3.utils.keccak256(string) // ALIAS
+    web3.utils.keccak256(string)
+    web3.utils.sha3(string) // ALIAS
 
-Will calculate the sha3 of the input.
+Will calculate the keccak256 of the input.
 
-.. note::  To mimic the sha3 behaviour of solidity use :ref:`soliditySha3 <utils-soliditysha3>`
+.. note::  To mimic the keccak256 behaviour of solidity use :ref:`soliditySha3 <utils-soliditysha3>`
 
 ----------
 Parameters
@@ -207,19 +207,19 @@ Example
 
 .. code-block:: javascript
 
-    web3.utils.sha3('234'); // taken as string
+    web3.utils.keccak256('234'); // taken as string
     > "0xc1912fee45d61c87cc5ea59dae311904cd86b84fee17cc96966216f811ce6a79"
 
-    web3.utils.sha3(new BN('234'));
+    web3.utils.keccak256(new BN('234'));
     > "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
 
-    web3.utils.sha3(234);
+    web3.utils.keccak256(234);
     > null // can't calculate the hash of a number
 
-    web3.utils.sha3(0xea); // same as above, just the HEX representation of the number
+    web3.utils.keccak256(0xea); // same as above, just the HEX representation of the number
     > null
 
-    web3.utils.sha3('0xea'); // will be converted to a byte array first, and then hashed
+    web3.utils.keccak256('0xea'); // will be converted to a byte array first, and then hashed
     > "0x2f20677459120677484f7104c76deb6846a2c071f9b3152c103bb12cd54d1a4a"
 
 

--- a/packages/web3-core-helpers/src/Formatters.js
+++ b/packages/web3-core-helpers/src/Formatters.js
@@ -396,7 +396,7 @@ export const outputLogFormatter = (log) => {
         typeof log.transactionHash === 'string' &&
         typeof log.logIndex === 'string'
     ) {
-        const shaId = Utils.sha3(
+        const shaId = Utils.keccak256(
             log.blockHash.replace('0x', '') + log.transactionHash.replace('0x', '') + log.logIndex.replace('0x', '')
         );
 

--- a/packages/web3-eth-abi/src/AbiCoder.js
+++ b/packages/web3-eth-abi/src/AbiCoder.js
@@ -38,7 +38,7 @@ export default class AbiCoder {
     }
 
     /**
-     * Encodes the function name to its ABI representation, which are the first 4 bytes of the sha3 of the function name including  types.
+     * Encodes the function name to its ABI representation, which are the first 4 bytes of the keccak256 of the function name including  types.
      *
      * @method encodeFunctionSignature
      *
@@ -51,11 +51,11 @@ export default class AbiCoder {
             functionName = this.utils.jsonInterfaceMethodToString(functionName);
         }
 
-        return this.utils.sha3(functionName).slice(0, 10);
+        return this.utils.keccak256(functionName).slice(0, 10);
     }
 
     /**
-     * Encodes the function name to its ABI representation, which are the first 4 bytes of the sha3 of the function name including  types.
+     * Encodes the function name to its ABI representation, which are the first 4 bytes of the keccak256 of the function name including  types.
      *
      * @method encodeEventSignature
      *
@@ -68,7 +68,7 @@ export default class AbiCoder {
             functionName = this.utils.jsonInterfaceMethodToString(functionName);
         }
 
-        return this.utils.sha3(functionName);
+        return this.utils.keccak256(functionName);
     }
 
     /**

--- a/packages/web3-eth-abi/tests/AbiCoderTest.js
+++ b/packages/web3-eth-abi/tests/AbiCoderTest.js
@@ -30,9 +30,14 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
+        Utils.sha3 = jest.fn(() => {
+            return '0x000000000';
+        });
+
         expect(abiCoder.encodeFunctionSignature('functionName')).toEqual('0x00000000');
 
         expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
+        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
     });
 
     it('calls encodeFunctionSignature with a object as parameter', () => {
@@ -42,11 +47,16 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
+        Utils.sha3 = jest.fn(() => {
+            return '0x000000000';
+        });
+
         expect(abiCoder.encodeFunctionSignature({})).toEqual('0x00000000');
 
         expect(Utils.jsonInterfaceMethodToString).toHaveBeenCalledWith({});
 
         expect(Utils.keccak256).toHaveBeenCalledWith('0x000000000');
+        expect(Utils.sha3).toHaveBeenCalledWith('0x000000000');
     });
 
     it('calls encodeEventSignature with a object as parameter', () => {
@@ -56,11 +66,16 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
+        Utils.sha3 = jest.fn(() => {
+            return '0x000000000';
+        });
+
         expect(abiCoder.encodeEventSignature({})).toEqual('0x000000000');
 
         expect(Utils.jsonInterfaceMethodToString).toHaveBeenCalledWith({});
 
         expect(Utils.keccak256).toHaveBeenCalledWith('0x000000000');
+        expect(Utils.sha3).toHaveBeenCalledWith('0x000000000');
     });
 
     it('calls encodeEventSignature with a string as parameter', () => {
@@ -68,9 +83,14 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
+        Utils.sha3 = jest.fn(() => {
+            return '0x000000000';
+        });
+
         expect(abiCoder.encodeEventSignature('functionName')).toEqual('0x000000000');
 
         expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
+        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
     });
 
     it('calls encodeParameters', () => {
@@ -94,11 +114,18 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
+        Utils.sha3 = jest.fn(() => {
+            return '0x000000000';
+        });
+
         ethersAbiCoderMock.encode.mockReturnValueOnce('0x0');
 
         expect(abiCoder.encodeFunctionCall({inputs: [{components: true}]}, [])).toEqual('0x000000000');
 
         expect(ethersAbiCoderMock.encode).toHaveBeenCalledWith([{components: true}], []);
+
+        expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
+        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
     });
 
     it('calls decodeParameters and returns the expected object', () => {

--- a/packages/web3-eth-abi/tests/AbiCoderTest.js
+++ b/packages/web3-eth-abi/tests/AbiCoderTest.js
@@ -99,8 +99,6 @@ describe('AbiCoderTest', () => {
         expect(abiCoder.encodeFunctionCall({inputs: [{components: true}]}, [])).toEqual('0x000000000');
 
         expect(ethersAbiCoderMock.encode).toHaveBeenCalledWith([{components: true}], []);
-
-        expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
     });
 
     it('calls decodeParameters and returns the expected object', () => {

--- a/packages/web3-eth-abi/tests/AbiCoderTest.js
+++ b/packages/web3-eth-abi/tests/AbiCoderTest.js
@@ -30,14 +30,9 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
-        Utils.sha3 = jest.fn(() => {
-            return '0x000000000';
-        });
-
         expect(abiCoder.encodeFunctionSignature('functionName')).toEqual('0x00000000');
 
         expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
-        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
     });
 
     it('calls encodeFunctionSignature with a object as parameter', () => {
@@ -47,16 +42,11 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
-        Utils.sha3 = jest.fn(() => {
-            return '0x000000000';
-        });
-
         expect(abiCoder.encodeFunctionSignature({})).toEqual('0x00000000');
 
         expect(Utils.jsonInterfaceMethodToString).toHaveBeenCalledWith({});
 
         expect(Utils.keccak256).toHaveBeenCalledWith('0x000000000');
-        expect(Utils.sha3).toHaveBeenCalledWith('0x000000000');
     });
 
     it('calls encodeEventSignature with a object as parameter', () => {
@@ -66,16 +56,11 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
-        Utils.sha3 = jest.fn(() => {
-            return '0x000000000';
-        });
-
         expect(abiCoder.encodeEventSignature({})).toEqual('0x000000000');
 
         expect(Utils.jsonInterfaceMethodToString).toHaveBeenCalledWith({});
 
         expect(Utils.keccak256).toHaveBeenCalledWith('0x000000000');
-        expect(Utils.sha3).toHaveBeenCalledWith('0x000000000');
     });
 
     it('calls encodeEventSignature with a string as parameter', () => {
@@ -83,14 +68,9 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
-        Utils.sha3 = jest.fn(() => {
-            return '0x000000000';
-        });
-
         expect(abiCoder.encodeEventSignature('functionName')).toEqual('0x000000000');
 
         expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
-        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
     });
 
     it('calls encodeParameters', () => {
@@ -114,10 +94,6 @@ describe('AbiCoderTest', () => {
             return '0x000000000';
         });
 
-        Utils.sha3 = jest.fn(() => {
-            return '0x000000000';
-        });
-
         ethersAbiCoderMock.encode.mockReturnValueOnce('0x0');
 
         expect(abiCoder.encodeFunctionCall({inputs: [{components: true}]}, [])).toEqual('0x000000000');
@@ -125,7 +101,6 @@ describe('AbiCoderTest', () => {
         expect(ethersAbiCoderMock.encode).toHaveBeenCalledWith([{components: true}], []);
 
         expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
-        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
     });
 
     it('calls decodeParameters and returns the expected object', () => {

--- a/packages/web3-eth-abi/tests/AbiCoderTest.js
+++ b/packages/web3-eth-abi/tests/AbiCoderTest.js
@@ -26,19 +26,19 @@ describe('AbiCoderTest', () => {
     });
 
     it('calls encodeFunctionSignature with a string as parameter', () => {
-        Utils.sha3 = jest.fn(() => {
+        Utils.keccak256 = jest.fn(() => {
             return '0x000000000';
         });
 
         expect(abiCoder.encodeFunctionSignature('functionName')).toEqual('0x00000000');
 
-        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
+        expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
     });
 
     it('calls encodeFunctionSignature with a object as parameter', () => {
         Utils.jsonInterfaceMethodToString.mockReturnValueOnce('0x000000000');
 
-        Utils.sha3 = jest.fn(() => {
+        Utils.keccak256 = jest.fn(() => {
             return '0x000000000';
         });
 
@@ -46,13 +46,13 @@ describe('AbiCoderTest', () => {
 
         expect(Utils.jsonInterfaceMethodToString).toHaveBeenCalledWith({});
 
-        expect(Utils.sha3).toHaveBeenCalledWith('0x000000000');
+        expect(Utils.keccak256).toHaveBeenCalledWith('0x000000000');
     });
 
     it('calls encodeEventSignature with a object as parameter', () => {
         Utils.jsonInterfaceMethodToString.mockReturnValueOnce('0x000000000');
 
-        Utils.sha3 = jest.fn(() => {
+        Utils.keccak256 = jest.fn(() => {
             return '0x000000000';
         });
 
@@ -60,17 +60,17 @@ describe('AbiCoderTest', () => {
 
         expect(Utils.jsonInterfaceMethodToString).toHaveBeenCalledWith({});
 
-        expect(Utils.sha3).toHaveBeenCalledWith('0x000000000');
+        expect(Utils.keccak256).toHaveBeenCalledWith('0x000000000');
     });
 
     it('calls encodeEventSignature with a string as parameter', () => {
-        Utils.sha3 = jest.fn(() => {
+        Utils.keccak256 = jest.fn(() => {
             return '0x000000000';
         });
 
         expect(abiCoder.encodeEventSignature('functionName')).toEqual('0x000000000');
 
-        expect(Utils.sha3).toHaveBeenCalledWith('functionName');
+        expect(Utils.keccak256).toHaveBeenCalledWith('functionName');
     });
 
     it('calls encodeParameters', () => {
@@ -90,7 +90,7 @@ describe('AbiCoderTest', () => {
     });
 
     it('calls encodeFunctionCall and returns the expected string', () => {
-        Utils.sha3 = jest.fn(() => {
+        Utils.keccak256 = jest.fn(() => {
             return '0x000000000';
         });
 

--- a/packages/web3-eth-accounts/src/models/Account.js
+++ b/packages/web3-eth-accounts/src/models/Account.js
@@ -23,7 +23,7 @@ import isObject from 'lodash/isObject';
 import * as EthLibAccount from 'eth-lib/lib/account'; // TODO: Remove this dependency
 import uuid from 'uuid';
 import Hash from 'eth-lib/lib/hash';
-import {isHexStrict, hexToBytes, randomHex, sha3} from 'web3-utils'; // TODO: Use the VO's of a web3-types module.
+import {isHexStrict, hexToBytes, randomHex, keccak256} from 'web3-utils'; // TODO: Use the VO's of a web3-types module.
 const crypto = typeof global === 'undefined' ? require('crypto-browserify') : require('crypto');
 
 export default class Account {
@@ -169,7 +169,7 @@ export default class Account {
             cipher.final()
         ]);
 
-        const mac = sha3(Buffer.concat([derivedKey.slice(16, 32), Buffer.from(ciphertext, 'hex')])).replace('0x', '');
+        const mac = keccak256(Buffer.concat([derivedKey.slice(16, 32), Buffer.from(ciphertext, 'hex')])).replace('0x', '');
 
         return {
             version: 3,
@@ -249,7 +249,7 @@ export default class Account {
 
         const ciphertext = Buffer.from(json.crypto.ciphertext, 'hex');
 
-        const mac = sha3(Buffer.concat([derivedKey.slice(16, 32), ciphertext])).replace('0x', '');
+        const mac = keccak256(Buffer.concat([derivedKey.slice(16, 32), ciphertext])).replace('0x', '');
         if (mac !== json.crypto.mac) {
             throw new Error('Key derivation failed - possibly wrong password');
         }

--- a/packages/web3-eth-accounts/tests/src/models/AccountTest.js
+++ b/packages/web3-eth-accounts/tests/src/models/AccountTest.js
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import uuid from 'uuid';
 import Hash from 'eth-lib/lib/hash';
 import {fromPrivate, sign, decodeSignature} from 'eth-lib/lib/account';
-import {hexToBytes, isHexStrict, sha3} from 'web3-utils';
+import {hexToBytes, isHexStrict, keccak256} from 'web3-utils';
 import TransactionSigner from '../../__mocks__/TransactionSigner';
 import Accounts from '../../../src/Accounts';
 import Account from '../../../src/models/Account';
@@ -141,7 +141,7 @@ describe('AccountTest', () => {
 
         scryptsy.mockReturnValueOnce(Buffer.from('00000000000000000000000000000000'));
 
-        sha3.mockReturnValueOnce('0xmac');
+        keccak256.mockReturnValueOnce('0xmac');
 
         const decipher = {
             update: jest.fn(),
@@ -177,7 +177,7 @@ describe('AccountTest', () => {
             'dklen'
         );
 
-        expect(sha3).toHaveBeenCalledWith(
+        expect(keccak256).toHaveBeenCalledWith(
             Buffer.concat([Buffer.from('0000000000000000'), Buffer.from(json.crypto.ciphertext, 'hex')])
         );
 
@@ -213,7 +213,7 @@ describe('AccountTest', () => {
             privateKey: '0x0'
         });
 
-        sha3.mockReturnValueOnce('0xmac');
+        keccak256.mockReturnValueOnce('0xmac');
 
         const decipher = {
             update: jest.fn(),
@@ -256,7 +256,7 @@ describe('AccountTest', () => {
 
         expect(crypto.pbkdf2Sync).toHaveBeenCalled();
 
-        expect(sha3).toHaveBeenCalledWith(
+        expect(keccak256).toHaveBeenCalledWith(
             Buffer.concat([Buffer.from('0000000000000000'), Buffer.from(json.crypto.ciphertext, 'hex')])
         );
 
@@ -311,7 +311,7 @@ describe('AccountTest', () => {
             }
         };
 
-        sha3.mockReturnValueOnce('0xmac');
+        keccak256.mockReturnValueOnce('0xmac');
 
         crypto.pbkdf2Sync = jest.fn((password, salt, c, dklen, sha256) => {
             expect(password).toEqual(Buffer.from(password));
@@ -333,7 +333,7 @@ describe('AccountTest', () => {
 
         expect(crypto.pbkdf2Sync).toHaveBeenCalled();
 
-        expect(sha3).toHaveBeenCalledWith(
+        expect(keccak256).toHaveBeenCalledWith(
             Buffer.concat([Buffer.from('0000000000000000'), Buffer.from(json.crypto.ciphertext, 'hex')])
         );
     });
@@ -361,7 +361,7 @@ describe('AccountTest', () => {
 
         scryptsy.mockReturnValueOnce(Buffer.from('0000000000000000'));
 
-        sha3.mockReturnValueOnce('0xmac');
+        keccak256.mockReturnValueOnce('0xmac');
 
         uuid.v4.mockReturnValueOnce(0);
 
@@ -405,7 +405,7 @@ describe('AccountTest', () => {
 
         expect(cipher.final).toHaveBeenCalled();
 
-        expect(sha3).toHaveBeenCalledWith(
+        expect(keccak256).toHaveBeenCalledWith(
             Buffer.concat([
                 Buffer.from('0000000000000000').slice(16, 32),
                 Buffer.from(Buffer.concat([Buffer.from('0'), Buffer.from('0')]), 'hex')
@@ -440,7 +440,7 @@ describe('AccountTest', () => {
             return Buffer.from('0000000000000000');
         });
 
-        sha3.mockReturnValueOnce('0xmac');
+        keccak256.mockReturnValueOnce('0xmac');
 
         uuid.v4.mockReturnValueOnce(0);
 
@@ -489,7 +489,7 @@ describe('AccountTest', () => {
 
         expect(cipher.final).toHaveBeenCalled();
 
-        expect(sha3).toHaveBeenCalledWith(
+        expect(keccak256).toHaveBeenCalledWith(
             Buffer.concat([
                 Buffer.from('0000000000000000').slice(16, 32),
                 Buffer.from(Buffer.concat([Buffer.from('0'), Buffer.from('0')]), 'hex')
@@ -534,7 +534,7 @@ describe('AccountTest', () => {
             return Buffer.from('0000000000000000');
         });
 
-        sha3.mockReturnValueOnce('0xmac');
+        keccak256.mockReturnValueOnce('0xmac');
 
         expect(() => {
             Account.fromPrivateKey('pk').toV3Keystore('password', options);

--- a/packages/web3-eth/src/signers/TransactionSigner.js
+++ b/packages/web3-eth/src/signers/TransactionSigner.js
@@ -70,7 +70,7 @@ export default class TransactionSigner {
 
         const rlpEncoded = ethTx.serialize().toString('hex');
         const rawTransaction = '0x' + rlpEncoded;
-        const transactionHash = this.utils.sha3(rawTransaction);
+        const transactionHash = this.utils.keccak256(rawTransaction);
 
         return {
             messageHash: Buffer.from(ethTx.hash(false)).toString('hex'),

--- a/packages/web3-utils/README.md
+++ b/packages/web3-utils/README.md
@@ -2,7 +2,7 @@
 
 This is a sub package of [web3.js][repo]
 
-This contains useful utility functions for Dapp developers.   
+This contains useful utility functions for Dapp developers.
 Please read the [documentation][docs] for more.
 
 ## Installation
@@ -20,7 +20,7 @@ import * as Utils from 'web3-utils';
 
 console.log(Utils);
 > {
-    sha3: Function,
+    keccak256: Function,
     soliditySha3: Function,
     isAddress: Function,
     ...
@@ -36,7 +36,7 @@ console.log(asciiToHex('I have 100!'));
 > "0x49206861766520313030e282ac"
 ```
 
-## Types 
+## Types
 
 All the typescript typings are placed in the types folder.
 

--- a/packages/web3-utils/src/BloomFilter.js
+++ b/packages/web3-utils/src/BloomFilter.js
@@ -58,7 +58,7 @@ function codePointToInt(codePoint) {
  * @returns {Boolean}
  */
 function testBytes(bloom, bytes) {
-    const hash = utils.sha3(bytes).replace('0x', '');
+    const hash = utils.keccak256(bytes).replace('0x', '');
 
     for (let i = 0; i < 12; i += 4) {
         // calculate bit position in bloom filter that must be active

--- a/packages/web3-utils/src/SoliditySha3.js
+++ b/packages/web3-utils/src/SoliditySha3.js
@@ -243,5 +243,5 @@ export const soliditySha3 = function() {
 
     const hexArguments = map(arguments_, _processSoliditySha3Arguments);
 
-    return utils.sha3(`0x${hexArguments.join('')}`);
+    return utils.keccak256(`0x${hexArguments.join('')}`);
 };

--- a/packages/web3-utils/src/Utils.js
+++ b/packages/web3-utils/src/Utils.js
@@ -17,6 +17,7 @@
 /**
  * @file Utils.js
  * @author Fabian Vogelsteller <fabian@ethereum.org>
+ * @author Prince Sinha <sinhaprince013@gmail.com>
  * @date 2017
  */
 
@@ -122,7 +123,7 @@ export const isAddress = (address) => {
 export const checkAddressChecksum = (address) => {
     // Check each case
     address = address.replace(/^0x/i, '');
-    const addressHash = sha3(address.toLowerCase()).replace(/^0x/i, '');
+    const addressHash = keccak256(address.toLowerCase()).replace(/^0x/i, '');
 
     for (let i = 0; i < 40; i++) {
         // the nth letter should be uppercase if the nth digit of casemap is 1
@@ -466,30 +467,30 @@ export const isTopic = (topic) => {
 };
 
 /**
- * Hashes values to a sha3 hash using keccak 256
+ * Hashes values to a keccak256 hash using keccak 256
  *
  * To hash a HEX string the hex must have 0x in front.
  *
- * @method sha3
- * @return {String} the sha3 string
+ * @method keccak256
+ * @return {String} the keccak256 string
  */
-const SHA3_NULL_S = '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
+const KECCAK256_NULL_S = '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
 
-export const sha3 = (value) => {
+export const keccak256 = (value) => {
     if (isHexStrict(value) && /^0x/i.test(value.toString())) {
         value = hexToBytes(value);
     }
 
     const returnValue = Hash.keccak256(value); // jshint ignore:line
 
-    if (returnValue === SHA3_NULL_S) {
+    if (returnValue === KECCAK256_NULL_S) {
         return null;
     } else {
         return returnValue;
     }
 };
 // expose the under the hood keccak256
-sha3._Hash = Hash;
+keccak256._Hash = Hash;
 
 /**
  * Gets the r,s,v values from a signature

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -251,7 +251,7 @@ export const toChecksumAddress = (address) => {
         throw new Error(`Given address "${address}" is not a valid Ethereum address.`);
 
     address = address.toLowerCase().replace(/^0x/i, '');
-    const addressHash = utils.sha3(address).replace(/^0x/i, '');
+    const addressHash = utils.keccak256(address).replace(/^0x/i, '');
     let checksumAddress = '0x';
 
     for (let i = 0; i < address.length; i++) {

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -267,8 +267,8 @@ export const toChecksumAddress = (address) => {
 };
 
 // aliases
-export const keccak256 = utils.sha3;
-export const sha3 = utils.sha3;
+export const keccak256 = utils.keccak256;
+export const sha3 = utils.keccak256;
 export const toDecimal = utils.hexToNumber;
 export const hexToNumber = utils.hexToNumber;
 export const fromDecimal = utils.numberToHex;

--- a/packages/web3-utils/tests/src/UtilsTest.js
+++ b/packages/web3-utils/tests/src/UtilsTest.js
@@ -9,7 +9,7 @@ import {
     isAddress,
     isBN,
     numberToHex,
-    sha3,
+    keccak256,
     toAscii,
     toBN,
     toHex,
@@ -182,16 +182,16 @@ describe('UtilsTest', () => {
     });
 
     /* eslint-disable jest/no-identical-title */
-    describe('calls sha3', () => {
-        it('should return sha3 with hex prefix', () => {
-            expect(sha3('test123')).toEqual(
+    describe('calls keccak256', () => {
+        it('should return keccak256 with hex prefix', () => {
+            expect(keccak256('test123')).toEqual(
                 '0x' +
                     cjsSha3('test123', {
                         outputLength: 256
                     }).toString()
             );
 
-            expect(sha3('test(int)')).toEqual(
+            expect(keccak256('test(int)')).toEqual(
                 '0x' +
                     cjsSha3('test(int)', {
                         outputLength: 256
@@ -199,8 +199,8 @@ describe('UtilsTest', () => {
             );
         });
 
-        it('should return sha3 with hex prefix when hex input', () => {
-            const sha3Hex = (value) => {
+        it('should return keccak256 with hex prefix when hex input', () => {
+            const keccak256Hex = (value) => {
                 if (value.length > 2 && value.substr(0, 2) === '0x') {
                     value = value.substr(2);
                 }
@@ -211,16 +211,16 @@ describe('UtilsTest', () => {
                 }).toString();
             };
 
-            expect(sha3('0x80')).toEqual('0x' + sha3Hex('0x80'));
+            expect(keccak256('0x80')).toEqual('0x' + keccak256Hex('0x80'));
 
-            expect(sha3('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1')).toEqual(
-                '0x' + sha3Hex('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1')
+            expect(keccak256('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1')).toEqual(
+                '0x' + keccak256Hex('0x3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca1')
             );
         });
 
-        it('should return sha3 with hex prefix', () => {
+        it('should return keccak256 with hex prefix', () => {
             const test = (value, expected) => {
-                expect(sha3(value)).toEqual(expected);
+                expect(keccak256(value)).toEqual(expected);
             };
 
             test('test123', '0xf81b517a242b218999ec8eec0ea6e2ddbef2a367a14e93f4a32a39e260f686ad');

--- a/packages/web3-utils/types/tests/sha3-test.ts
+++ b/packages/web3-utils/types/tests/sha3-test.ts
@@ -15,30 +15,31 @@
     along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 /**
- * @file sha3-tests.ts
+ * @file keccak256-tests.ts
  * @author Josh Stevens <joshstevens19@hotmail.co.uk>
+ * @author Prince Sinha <sinhaprince013@gmail.com>
  * @date 2018
  */
 
 import BN = require('bn.js');
-import {sha3} from 'web3-utils';
+import {keccak256} from 'web3-utils';
 
 // $ExpectType string
-sha3('234');
+keccak256('234');
 // $ExpectType string
-sha3(new BN(3));
+keccak256(new BN(3));
 
 // $ExpectError
-sha3(['string']);
+keccak256(['string']);
 // $ExpectError
-sha3(234);
+keccak256(234);
 // $ExpectError
-sha3([4]);
+keccak256([4]);
 // $ExpectError
-sha3({});
+keccak256({});
 // $ExpectError
-sha3(true);
+keccak256(true);
 // $ExpectError
-sha3(null);
+keccak256(null);
 // $ExpectError
-sha3(undefined);
+keccak256(undefined);

--- a/packages/web3-utils/types/tests/sha3-test.ts
+++ b/packages/web3-utils/types/tests/sha3-test.ts
@@ -15,31 +15,31 @@
     along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 /**
- * @file keccak256-tests.ts
+ * @file sha3-tests.ts
  * @author Josh Stevens <joshstevens19@hotmail.co.uk>
  * @author Prince Sinha <sinhaprince013@gmail.com>
  * @date 2018
  */
 
 import BN = require('bn.js');
-import {keccak256} from 'web3-utils';
+import {sha3} from 'web3-utils';
 
 // $ExpectType string
-keccak256('234');
+sha3('234');
 // $ExpectType string
-keccak256(new BN(3));
+sha3(new BN(3));
 
 // $ExpectError
-keccak256(['string']);
+sha3(['string']);
 // $ExpectError
-keccak256(234);
+sha3(234);
 // $ExpectError
-keccak256([4]);
+sha3([4]);
 // $ExpectError
-keccak256({});
+sha3({});
 // $ExpectError
-keccak256(true);
+sha3(true);
 // $ExpectError
-keccak256(null);
+sha3(null);
 // $ExpectError
-keccak256(undefined);
+sha3(undefined);

--- a/packages/web3-utils/types/tests/sha3-test.ts
+++ b/packages/web3-utils/types/tests/sha3-test.ts
@@ -17,7 +17,6 @@
 /**
  * @file sha3-tests.ts
  * @author Josh Stevens <joshstevens19@hotmail.co.uk>
- * @author Prince Sinha <sinhaprince013@gmail.com>
  * @date 2018
  */
 


### PR DESCRIPTION
## Description

According to EIP56, I renamed sha3 to keccak256.

Fixes #2707 

## Type of change
- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
