### PR TITLE
Adapts checksum functionality to RSKIP60 and EIP55

### DIFF
--- a/docs/_build/html/_sources/web3-utils.rst.txt
+++ b/docs/_build/html/_sources/web3-utils.rst.txt
@@ -418,7 +418,7 @@ Parameters
 ----------
 
 1. ``address`` - ``String``: An address string.
-2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``.
+2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``. RSKIP-60 <https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md> for details.
 
 -------
 Returns
@@ -467,7 +467,7 @@ Parameters
 ----------
 
 1. ``address`` - ``String``: An address string.
-2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``.
+2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``. RSKIP-60 <https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md> for details.
 
 -------
 Returns
@@ -541,7 +541,7 @@ Parameters
 ----------
 
 1. ``address`` - ``String``: An address string.
-2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``.
+2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``. RSKIP-60 <https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md> for details.
 
 -------
 Returns

--- a/docs/_build/html/_sources/web3-utils.rst.txt
+++ b/docs/_build/html/_sources/web3-utils.rst.txt
@@ -408,7 +408,7 @@ isAddress
 
 .. code-block:: javascript
 
-    web3.utils.isAddress(address)
+    web3.utils.isAddress(address [, chainId])
 
 Checks if a given string is a valid Ethereum address.
 It will also check the checksum, if the address has upper and lowercase letters.
@@ -418,6 +418,7 @@ Parameters
 ----------
 
 1. ``address`` - ``String``: An address string.
+2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``.
 
 -------
 Returns
@@ -446,6 +447,9 @@ Example
     web3.utils.isAddress('0xC1912fEE45d61C87Cc5EA59DaE31190FFFFf232d');
     > false // wrong checksum
 
+    web3.utils.isAddress('0x5aaEB6053f3e94c9b9a09f33669435E7ef1bEAeD', 30);
+    > true
+
 ------------------------------------------------------------------------------
 
 
@@ -454,7 +458,7 @@ toChecksumAddress
 
 .. code-block:: javascript
 
-    web3.utils.toChecksumAddress(address)
+    web3.utils.toChecksumAddress(address [, chainId])
 
 Will convert an upper or lowercase Ethereum address to a checksum address.
 
@@ -463,6 +467,7 @@ Parameters
 ----------
 
 1. ``address`` - ``String``: An address string.
+2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``.
 
 -------
 Returns
@@ -482,6 +487,42 @@ Example
     web3.utils.toChecksumAddress('0XC1912FEE45D61C87CC5EA59DAE31190FFFFF232D');
     > "0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d" // same as above
 
+    web3.utils.toChecksumAddress('0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', 30);
+    > "0x5aaEB6053f3e94c9b9a09f33669435E7ef1bEAeD"
+
+------------------------------------------------------------------------------
+
+
+stripHexPrefix
+=====================
+
+.. code-block:: javascript
+
+    web3.utils.stripHexPrefix(address)
+
+Removes prefix from address if exists.
+
+----------
+Parameters
+----------
+
+1. ``address`` - ``String``: An address string.
+
+-------
+Returns
+-------
+
+``String``: address without prefix.
+
+-------
+Example
+-------
+
+.. code-block:: javascript
+
+    web3.utils.stripHexPrefix('0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d');
+    > "c1912fEE45d61C87Cc5EA59DaE31190FFFFf232d"
+
 
 ------------------------------------------------------------------------------
 
@@ -491,7 +532,7 @@ checkAddressChecksum
 
 .. code-block:: javascript
 
-    web3.utils.checkAddressChecksum(address)
+    web3.utils.checkAddressChecksum(address [, chainId])
 
 Checks the checksum of a given address. Will also return false on non-checksum addresses.
 
@@ -500,6 +541,7 @@ Parameters
 ----------
 
 1. ``address`` - ``String``: An address string.
+2. ``chainId`` - ``number`` (optional): Chain id where checksummed address should be valid, defaults to ``null``.
 
 -------
 Returns
@@ -514,6 +556,9 @@ Example
 .. code-block:: javascript
 
     web3.utils.checkAddressChecksum('0xc1912fEE45d61C87Cc5EA59DaE31190FFFFf232d');
+    > true
+
+    web3.utils.checkAddressChecksum('0x5aAeb6053F3e94c9b9A09F33669435E7EF1BEaEd', 31);
     > true
 
 

--- a/packages/web3-utils/src/Utils.js
+++ b/packages/web3-utils/src/Utils.js
@@ -136,14 +136,14 @@ export const stripHexPrefix = (str) => {
  * @returns {Boolean}
  */
 export const checkAddressChecksum = (address, chainId = null) => {
-    const strip_address = stripHexPrefix(address).toLowerCase()
+    const stripAddress = stripHexPrefix(address).toLowerCase()
     const prefix = chainId != null ? (chainId.toString() + '0x') : ''
-    const keccak_hash = Hash.keccak256(prefix + strip_address).toString('hex').replace(/^0x/i, '');
+    const keccakHash = Hash.keccak256(prefix + stripAddress).toString('hex').replace(/^0x/i, '');
 
-    for (let i = 0; i < strip_address.length; i++) {
-        let output = parseInt(keccak_hash[i], 16) >= 8 ?
-            strip_address[i].toUpperCase() :
-            strip_address[i];
+    for (let i = 0; i < stripAddress.length; i++) {
+        let output = parseInt(keccakHash[i], 16) >= 8 ?
+            stripAddress[i].toUpperCase() :
+            stripAddress[i];
         if (stripHexPrefix(address)[i] !== output) {
             return false;
         }

--- a/packages/web3-utils/src/Utils.js
+++ b/packages/web3-utils/src/Utils.js
@@ -133,6 +133,8 @@ export const stripHexPrefix = (str) => {
  *
  * @param {String} address the given HEX address
  *
+ * @param {number} chain where checksummed address should be valid.
+ *
  * @returns {Boolean}
  */
 export const checkAddressChecksum = (address, chainId = null) => {

--- a/packages/web3-utils/src/Utils.js
+++ b/packages/web3-utils/src/Utils.js
@@ -96,9 +96,11 @@ export const toTwosComplement = (number) => {
  *
  * @param {String} address the given HEX address
  *
+ * @param {Number} chainId to define checksum behavior
+ *
  * @returns {Boolean}
  */
-export const isAddress = (address) => {
+export const isAddress = (address, chainId = null) => {
     // check if it has the basic requirements of an address
     if (!/^(0x)?[0-9a-f]{40}$/i.test(address)) {
         return false;
@@ -107,9 +109,22 @@ export const isAddress = (address) => {
         return true;
         // Otherwise check each case
     } else {
-        return checkAddressChecksum(address);
+        return checkAddressChecksum(address, chainId);
     }
 };
+
+/**
+ * Removes prefix from address if exists.
+ *
+ * @method stripHexPrefix
+ *
+ * @param {string} address
+ *
+ * @returns {string} address without prefix
+ */
+export const stripHexPrefix = (str) => {
+    return str.slice(0, 2) === '0x' ? str.slice(2) : str
+}
 
 /**
  * Checks if the given string is a checksummed address
@@ -120,17 +135,16 @@ export const isAddress = (address) => {
  *
  * @returns {Boolean}
  */
-export const checkAddressChecksum = (address) => {
-    // Check each case
-    address = address.replace(/^0x/i, '');
-    const addressHash = keccak256(address.toLowerCase()).replace(/^0x/i, '');
+export const checkAddressChecksum = (address, chainId = null) => {
+    const strip_address = stripHexPrefix(address).toLowerCase()
+    const prefix = chainId != null ? (chainId.toString() + '0x') : ''
+    const keccak_hash = Hash.keccak256(prefix + strip_address).toString('hex').replace(/^0x/i, '');
 
-    for (let i = 0; i < 40; i++) {
-        // the nth letter should be uppercase if the nth digit of casemap is 1
-        if (
-            (parseInt(addressHash[i], 16) > 7 && address[i].toUpperCase() !== address[i]) ||
-            (parseInt(addressHash[i], 16) <= 7 && address[i].toLowerCase() !== address[i])
-        ) {
+    for (let i = 0; i < strip_address.length; i++) {
+        let output = parseInt(keccak_hash[i], 16) >= 8 ?
+            strip_address[i].toUpperCase() :
+            strip_address[i];
+        if (stripHexPrefix(address)[i] !== output) {
             return false;
         }
     }

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -26,6 +26,7 @@ import isString from 'lodash/isString';
 import isArray from 'lodash/isArray';
 import * as utils from './Utils';
 import * as ethjsUnit from 'ethjs-unit';
+import Hash from 'eth-lib/lib/hash';
 
 export BN from 'bn.js';
 export {soliditySha3} from './SoliditySha3';
@@ -240,31 +241,32 @@ export const toWei = (number, unit) => {
  *
  * @method toChecksumAddress
  *
- * @param {String} address the given HEX address
+ * @param {string} address the given HEX address
  *
- * @returns {String}
+ * @param {number} chain where checksummed address should be valid.
+ *
+ * @returns {string} address with checksum applied.
  */
-export const toChecksumAddress = (address) => {
-    if (typeof address === 'undefined') return '';
+export const toChecksumAddress = (address, chainId = null) => {
+    if (typeof address !== 'string') {
+        return '';
+    }
 
     if (!/^(0x)?[0-9a-f]{40}$/i.test(address))
         throw new Error(`Given address "${address}" is not a valid Ethereum address.`);
 
-    address = address.toLowerCase().replace(/^0x/i, '');
-    const addressHash = utils.keccak256(address).replace(/^0x/i, '');
+    const strip_address = stripHexPrefix(address).toLowerCase();
+    const prefix = chainId != null ? (chainId.toString() + '0x') : '';
+    const keccak_hash = Hash.keccak256(prefix + strip_address).toString('hex').replace(/^0x/i, '');
     let checksumAddress = '0x';
 
-    for (let i = 0; i < address.length; i++) {
-        // If ith character is 9 to f then make it uppercase
-        if (parseInt(addressHash[i], 16) > 7) {
-            checksumAddress += address[i].toUpperCase();
-        } else {
-            checksumAddress += address[i];
-        }
-    }
+    for (let i = 0; i < strip_address.length; i++)
+        checksumAddress += parseInt(keccak_hash[i], 16) >= 8 ?
+            strip_address[i].toUpperCase() :
+            strip_address[i];
 
     return checksumAddress;
-};
+}
 
 // aliases
 export const keccak256 = utils.keccak256;
@@ -297,3 +299,4 @@ export const isBloom = utils.isBloom;
 export const isTopic = utils.isTopic;
 export const bytesToHex = utils.bytesToHex;
 export const hexToBytes = utils.hexToBytes;
+export const stripHexPrefix = utils.stripHexPrefix;

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -255,15 +255,15 @@ export const toChecksumAddress = (address, chainId = null) => {
     if (!/^(0x)?[0-9a-f]{40}$/i.test(address))
         throw new Error(`Given address "${address}" is not a valid Ethereum address.`);
 
-    const strip_address = stripHexPrefix(address).toLowerCase();
+    const stripAddress = stripHexPrefix(address).toLowerCase();
     const prefix = chainId != null ? (chainId.toString() + '0x') : '';
-    const keccak_hash = Hash.keccak256(prefix + strip_address).toString('hex').replace(/^0x/i, '');
+    const keccakHash = Hash.keccak256(prefix + stripAddress).toString('hex').replace(/^0x/i, '');
     let checksumAddress = '0x';
 
-    for (let i = 0; i < strip_address.length; i++)
-        checksumAddress += parseInt(keccak_hash[i], 16) >= 8 ?
-            strip_address[i].toUpperCase() :
-            strip_address[i];
+    for (let i = 0; i < stripAddress.length; i++)
+        checksumAddress += parseInt(keccakHash[i], 16) >= 8 ?
+            stripAddress[i].toUpperCase() :
+            stripAddress[i];
 
     return checksumAddress;
 }

--- a/packages/web3-utils/tests/src/UtilsTest.js
+++ b/packages/web3-utils/tests/src/UtilsTest.js
@@ -18,7 +18,8 @@ import {
     toWei,
     utf8ToHex,
     getSignatureParameters,
-    toChecksumAddress
+    toChecksumAddress,
+    stripHexPrefix
 } from '../../src';
 
 /**
@@ -238,6 +239,18 @@ describe('UtilsTest', () => {
 
         tests.forEach((test) => {
             expect(toChecksumAddress(test.value)).toEqual(test.is);
+        });
+    });
+
+    it('calls stripHexPrefix and returns the expected results', () => {
+        const tests = [
+            {value: '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', is: '5aaeb6053f3e94c9b9a09f33669435e7ef1beaed'},
+            {value: '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359', is: 'fb6916095ca1df60bb79ce92ce3ea74c37c5d359'},
+            {value: 'dbf03b407c01e7cd3cbea99509d93f8dddc8c6fb', is: 'dbf03b407c01e7cd3cbea99509d93f8dddc8c6fb'}
+        ];
+
+        tests.forEach((test) => {
+            expect(stripHexPrefix(test.value)).toEqual(test.is);
         });
     });
 

--- a/packages/web3-utils/tests/src/UtilsTest.js
+++ b/packages/web3-utils/tests/src/UtilsTest.js
@@ -17,7 +17,8 @@ import {
     toUtf8,
     toWei,
     utf8ToHex,
-    getSignatureParameters
+    getSignatureParameters,
+    toChecksumAddress
 } from '../../src';
 
 /**
@@ -140,6 +141,22 @@ describe('UtilsTest', () => {
         });
     });
 
+    it('calls isAddress with chainId 30 and returns the expected results', () => {
+        const tests = [
+            {value: '0x5aaEB6053f3e94c9b9a09f33669435E7ef1bEAeD', is: true},
+            {value: '0xFb6916095cA1Df60bb79ce92cE3EA74c37c5d359', is: true},
+            {value: '0xDBF03B407c01E7CD3cBea99509D93F8Dddc8C6FB', is: true},
+            {value: '0xE247a45c287191d435A8a5D72A7C8dc030451E9F', is: false},
+            {value: '0xD1220A0Cf47c7B9BE7a2e6ba89F429762E7B9adB', is: true},
+            {value: '0xe247a45c287191d435a8a5d72a7c8dc030451e9f', is: true},
+            {value: '0xE247A45C287191D435A8A5D72A7C8DC030451E9F', is: true}
+        ];
+
+        tests.forEach((test) => {
+            expect(isAddress(test.value, 30)).toEqual(test.is);
+        });
+    });
+
     it('calls isBN and returns the expected results', () => {
         const tests = [
             {
@@ -178,6 +195,49 @@ describe('UtilsTest', () => {
 
         tests.forEach((test) => {
             expect(checkAddressChecksum(test.value)).toEqual(test.is);
+        });
+    });
+
+    it('calls checkAddressChecksum with chainId 31 and returns the expected results', () => {
+        const tests = [
+            {value: '0x5aAeb6053F3e94c9b9A09F33669435E7EF1BEaEd', is: true},
+            {value: '0xFb6916095CA1dF60bb79CE92ce3Ea74C37c5D359', is: true},
+            {value: '0xdbF03B407C01E7cd3cbEa99509D93f8dDDc8C6fB', is: true},
+            {value: '0xd1220a0CF47c7B9Be7A2E6Ba89f429762E7b9adB', is: true},
+            {value: '0XD1220A0CF47C7B9BE7A2E6BA89F429762E7B9ADB', is: false},
+            {value: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', is: false},
+            {value: '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB', is: false},
+            {value: '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb', is: false}
+        ];
+
+        tests.forEach((test) => {
+            expect(checkAddressChecksum(test.value, 31)).toEqual(test.is);
+        });
+    });
+
+    it('calls toChecksumAddress with chainId 30 and returns the expected results', () => {
+        const tests = [
+            {value: '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', is: '0x5aaEB6053f3e94c9b9a09f33669435E7ef1bEAeD'},
+            {value: '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359', is: '0xFb6916095cA1Df60bb79ce92cE3EA74c37c5d359'},
+            {value: '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb', is: '0xDBF03B407c01E7CD3cBea99509D93F8Dddc8C6FB'},
+            {value: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', is: '0xD1220A0Cf47c7B9BE7a2e6ba89F429762E7B9adB'}
+        ];
+
+        tests.forEach((test) => {
+            expect(toChecksumAddress(test.value, 30)).toEqual(test.is);
+        });
+    });
+
+    it('calls toChecksumAddress and returns the expected results', () => {
+        const tests = [
+            {value: '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed', is: '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'},
+            {value: '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359', is: '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359'},
+            {value: '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb', is: '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB'},
+            {value: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', is: '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb'}
+        ];
+
+        tests.forEach((test) => {
+            expect(toChecksumAddress(test.value)).toEqual(test.is);
         });
     });
 

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -81,7 +81,7 @@ export function hexToAscii(string: string): string;
 export function toAscii(string: string): string;
 export function bytesToHex(bytes: number[]): string;
 export function numberToHex(value: number | string | BN): string;
-export function checkAddressChecksum(address: string): boolean;
+export function checkAddressChecksum(address: string, chainId?: number): boolean;
 export function fromAscii(string: string): string;
 export function fromDecimal(value: string | number): string;
 export function fromUtf8(string: string): string;
@@ -123,7 +123,7 @@ export interface Utils {
     isBigNumber(value: BN): boolean;
     toBN(value: number | string): BN;
     toTwosComplement(value: number | string | BN): string;
-    isAddress(address: string, chainId?: null): boolean;
+    isAddress(address: string, chainId?: number): boolean;
     isHex(hex: Hex): boolean;
     isHexStrict(hex: Hex): boolean;
     asciiToHex(string: string, length?: number): string;

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -100,7 +100,7 @@ export function sha3(value: string | BN): string;
 export function randomHex(bytesSize: number): string;
 export function utf8ToHex(string: string): string;
 export function stringToHex(string: string): string;
-export function toChecksumAddress(address: string): string;
+export function toChecksumAddress(address: string, chainId?: number): string;
 export function toDecimal(hex: Hex): number;
 export function toHex(value: number | string | BN): string;
 export function toUtf8(string: string): string;
@@ -149,7 +149,7 @@ export interface Utils {
     randomHex(bytesSize: number): string;
     utf8ToHex(string: string): string;
     stringToHex(string: string): string;
-    toChecksumAddress(address: string): string;
+    toChecksumAddress(address: string, chainId?: number): string;
     toDecimal(hex: Hex): number;
     toHex(value: number | string | BN): string;
     toUtf8(string: string): string;

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -73,7 +73,7 @@ export function isBN(value: string | number): boolean;
 export function isBigNumber(value: BN): boolean;
 export function toBN(value: number | string): BN;
 export function toTwosComplement(value: number | string | BN): string;
-export function isAddress(address: string): boolean;
+export function isAddress(address: string, chainId?: number): boolean;
 export function isHex(hex: Hex): boolean;
 export function isHexStrict(hex: Hex): boolean;
 export function asciiToHex(string: string, length?: number): string;
@@ -115,6 +115,7 @@ export function unitMap(): Units;
 export function testAddress(bloom: string, address: string): boolean;
 export function testTopic(bloom: string, topic: string): boolean;
 export function getSignatureParameters(signature: string): {r: string; s: string; v: number};
+export function stripHexPrefix(str: string): string;
 
 // interfaces
 export interface Utils {
@@ -122,7 +123,7 @@ export interface Utils {
     isBigNumber(value: BN): boolean;
     toBN(value: number | string): BN;
     toTwosComplement(value: number | string | BN): string;
-    isAddress(address: string): boolean;
+    isAddress(address: string, chainId?: null): boolean;
     isHex(hex: Hex): boolean;
     isHexStrict(hex: Hex): boolean;
     asciiToHex(string: string, length?: number): string;
@@ -130,7 +131,7 @@ export interface Utils {
     toAscii(string: string): string;
     bytesToHex(bytes: number[]): string;
     numberToHex(value: number | string | BN): string;
-    checkAddressChecksum(address: string): boolean;
+    checkAddressChecksum(address: string, chainId?: number): boolean;
     fromAscii(string: string): string;
     fromDecimal(value: string | number): string;
     fromUtf8(string: string): string;
@@ -164,6 +165,7 @@ export interface Utils {
     testAddress(bloom: string, address: string): boolean;
     testTopic(bloom: string, topic: string): boolean;
     getSignatureParameters(signature: string): {r: string; s: string; v: number};
+    stripHexPrefix(str: string): string;
 }
 
 export interface Units {

--- a/packages/web3-utils/types/tests/check-address-checksum-test.ts
+++ b/packages/web3-utils/types/tests/check-address-checksum-test.ts
@@ -25,6 +25,10 @@ import {checkAddressChecksum} from 'web3-utils';
 
 // $ExpectType boolean
 checkAddressChecksum('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51');
+// $ExpectType boolean
+checkAddressChecksum('0xFb6916095CA1dF60bb79CE92ce3Ea74C37c5D359', 31);
+// $ExpectType boolean
+checkAddressChecksum('0xFb6916095CA1dF60bb79CE92ce3Ea74C37c5D359', undefined);
 
 // $ExpectError
 checkAddressChecksum([4]);
@@ -42,3 +46,15 @@ checkAddressChecksum(true);
 checkAddressChecksum(null);
 // $ExpectError
 checkAddressChecksum(undefined);
+// $ExpectError
+checkAddressChecksum('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', 'string');
+// $ExpectError
+checkAddressChecksum('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', [4]);
+// $ExpectError
+checkAddressChecksum('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', new BN(3));
+// $ExpectError
+checkAddressChecksum('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', {});
+// $ExpectError
+checkAddressChecksum('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', true);
+// $ExpectError
+checkAddressChecksum('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb', null);

--- a/packages/web3-utils/types/tests/is-address-test.ts
+++ b/packages/web3-utils/types/tests/is-address-test.ts
@@ -25,6 +25,10 @@ import {isAddress} from 'web3-utils';
 
 // $ExpectType boolean
 isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51');
+// $ExpectType boolean
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', 30);
+// $ExpectType boolean
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', undefined);
 
 // $ExpectError
 isAddress(4);
@@ -42,3 +46,15 @@ isAddress([4]);
 isAddress(null);
 // $ExpectError
 isAddress(undefined);
+// $ExpectError
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', new BN(3));
+// $ExpectError
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', {});
+// $ExpectError
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', true);
+// $ExpectError
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', ['string']);
+// $ExpectError
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', [4]);
+// $ExpectError
+isAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', null);

--- a/packages/web3-utils/types/tests/strip-hex-prefix-test.ts
+++ b/packages/web3-utils/types/tests/strip-hex-prefix-test.ts
@@ -1,0 +1,44 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file strip-hex-prefix-test.ts
+ * @author Alejandro Cavallero <acavallero@iovlabs.org>
+ * @date 2019
+ */
+
+import BN = require('bn.js');
+import {stripHexPrefix} from 'web3-utils';
+
+// $ExpectType string
+stripHexPrefix('0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb');
+
+// $ExpectError
+stripHexPrefix(123);
+// $ExpectError
+stripHexPrefix(new BN(3));
+// $ExpectError
+stripHexPrefix(['string']);
+// $ExpectError
+stripHexPrefix([4]);
+// $ExpectError
+stripHexPrefix({});
+// $ExpectError
+stripHexPrefix(true);
+// $ExpectError
+stripHexPrefix(null);
+// $ExpectError
+stripHexPrefix(undefined);

--- a/packages/web3-utils/types/tests/to-check-sum-address-test.ts
+++ b/packages/web3-utils/types/tests/to-check-sum-address-test.ts
@@ -25,6 +25,10 @@ import {toChecksumAddress} from 'web3-utils';
 
 // $ExpectType string
 toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51');
+// $ExpectType string
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', 31);
+// $ExpectType string
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', undefined);
 
 // $ExpectError
 toChecksumAddress([4]);
@@ -42,3 +46,15 @@ toChecksumAddress(true);
 toChecksumAddress(null);
 // $ExpectError
 toChecksumAddress(undefined);
+// $ExpectError
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', [4]);
+// $ExpectError
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', ['string']);
+// $ExpectError
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', new BN(3));
+// $ExpectError
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', {});
+// $ExpectError
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', true);
+// $ExpectError
+toChecksumAddress('0x8ee7f17bb3f88b01247c21ab6603880b64ae53e811f5e01138822e558cf1ab51', null);


### PR DESCRIPTION
## Description

This PR adapts checksum functionality to [RSKIP-60](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60.md) compatible with  [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md).
The implementation considers sending optional `chainId` parameter to checksum methods (with `chainId = null` as default, Ethereum checksum is applied).

Benefit

- Allows checksum implementation in any network.
- Can distinguish between testnets and mainnets.

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change
- [X] Enhancement

## Checklist:

- [X] I have selected the correct base branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no warnings.
- [X] I have updated or added types for all modules I've changed
- [X] Any dependent changes have been merged and published in downstream modules.
- [X] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [X] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [X] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
