### PR TITLE
Change if condition to accept 0 nonce without calling the ethereum node

### DIFF
--- a/packages/web3-eth-accounts/src/Accounts.js
+++ b/packages/web3-eth-accounts/src/Accounts.js
@@ -155,7 +155,7 @@ export default class Accounts extends AbstractWeb3Module {
                 tx.gasPrice = await this.getGasPrice();
             }
 
-            if (!tx.nonce) {
+            if (tx.nonce == undefined) {
                 tx.nonce = await this.getTransactionCount(account.address);
             }
 


### PR DESCRIPTION
## Description

Change the if condition to accept nonce equal 0 and not call the ethereum node


Fixes #2733

## Type of change
- [x] Bug fix 


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
