### PR TITLE
Transaction.to can be null

### DIFF
--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -125,7 +125,7 @@ export interface Transaction {
     blockNumber: number | null;
     transactionIndex: number | null;
     from: string;
-    to?: string;
+    to: string | null;
     value: string;
     gasPrice: string;
     gas: number;

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -125,7 +125,7 @@ export interface Transaction {
     blockNumber: number | null;
     transactionIndex: number | null;
     from: string;
-    to: string;
+    to?: string;
     value: string;
     gasPrice: string;
     gas: number;


### PR DESCRIPTION
According to [docs](https://web3js.readthedocs.io/en/1.0/web3-eth.html#gettransaction)
`to` - `String`: Address of the receiver. `null` when its a contract creation transaction.