### PR TITLE
Setting of a provider after initiating a Web3 object without a provider fixed

### DIFF
--- a/packages/web3-core/src/AbstractWeb3Module.js
+++ b/packages/web3-core/src/AbstractWeb3Module.js
@@ -289,7 +289,7 @@ export default class AbstractWeb3Module {
      */
     isSameProvider(provider) {
         if (isObject(provider)) {
-            if (this.currentProvider.constructor.name === provider.constructor.name) {
+            if (this.currentProvider && this.currentProvider.constructor.name === provider.constructor.name) {
                 return this.currentProvider.host === provider.host;
             }
 

--- a/packages/web3-core/tests/src/AbstractWeb3ModuleTest.js
+++ b/packages/web3-core/tests/src/AbstractWeb3ModuleTest.js
@@ -125,6 +125,18 @@ describe('AbstractWeb3ModuleTest', () => {
         expect(abstractWeb3Module.setProvider('http://localhost:8545')).toEqual(false);
     });
 
+    it('calls isSameProvider without a currentProvider set and returns false', () => {
+        const provider = {
+            constructor: {
+                name: 'HttpProvider'
+            },
+            host: 'HOST1'
+        };
+
+        abstractWeb3Module.setProvider(false);
+        expect(abstractWeb3Module.isSameProvider(provider)).toEqual(false);
+    });
+
     it('calls isSameProvider and returns false', () => {
         const provider = {
             constructor: {


### PR DESCRIPTION
## Description

Fixes #2763 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
