### PR TITLE
[Quorum] Fix #2766, timestamp is not present on a Quorum node

### DIFF
--- a/packages/web3-core-helpers/src/Formatters.js
+++ b/packages/web3-core-helpers/src/Formatters.js
@@ -300,7 +300,11 @@ export const outputBlockFormatter = (block) => {
     block.gasLimit = Utils.hexToNumber(block.gasLimit);
     block.gasUsed = Utils.hexToNumber(block.gasUsed);
     block.size = Utils.hexToNumber(block.size);
-    block.timestamp = Utils.hexToNumber(block.timestamp);
+
+    // Support Quorum 2.2.0 - timestamp is not present in the Quorum getBlock response
+    if (block.timestamp !== null) {
+        block.timestamp = Utils.hexToNumber(block.timestamp);
+    }
 
     if (block.number !== null) {
         block.number = Utils.hexToNumber(block.number);

--- a/packages/web3-core-helpers/tests/src/Formatters/OutputBlockFormatterTest.js
+++ b/packages/web3-core-helpers/tests/src/Formatters/OutputBlockFormatterTest.js
@@ -51,4 +51,49 @@ describe('OutputBlockFormatterTest', () => {
             miner: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
         });
     });
+    it('[Quorum] call outputBlockFormatter with a valid block without a timestamp', () => {
+        const block = {
+            gasLimit: 0x0,
+            gasUsed: 0x0,
+            size: 0x0,
+            number: 0x0,
+            difficulty: 100,
+            totalDifficulty: 100,
+            transactions: [
+                {
+                    blockNumber: 0,
+                    transactionIndex: 0,
+                    gas: 100,
+                    gasPrice: 100,
+                    nonce: 1,
+                    value: 100,
+                    to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+                    from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+                }
+            ],
+            miner: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        };
+
+        expect(outputBlockFormatter(block)).toEqual({
+            gasLimit: 0x0,
+            gasUsed: 0x0,
+            size: 0x0,
+            number: 0x0,
+            difficulty: '100', // Strange some numbers will be handled as string and some as number (gas & nonce)
+            totalDifficulty: '100',
+            transactions: [
+                {
+                    blockNumber: 0,
+                    transactionIndex: 0,
+                    gas: 100,
+                    gasPrice: '100',
+                    nonce: 1,
+                    value: '100',
+                    to: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078',
+                    from: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+                }
+            ],
+            miner: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+        });
+    });
 });


### PR DESCRIPTION
## Description

This PR fix the #2766 issue on quorum node 

I made the `timestamp` field from the `getBlock` response as optional + added the according test.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [X] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [X] I have selected the correct base branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [X] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [X] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [X] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [X] I have tested my code on an ethereum test network.
- [X] I have tested my code on a quorum test network.
