### PR TITLE
LogSubscription extended with changed event

### DIFF
--- a/docs/web3-eth-subscribe.rst
+++ b/docs/web3-eth-subscribe.rst
@@ -36,7 +36,9 @@ Returns
     - ``subscription.id``: The subscription id, used to identify and unsubscribing the subscription.
     - ``subscription.subscribe([callback])``: Can be used to re-subscribe with the same parameters.
     - ``subscription.unsubscribe([callback])``: Unsubscribes the subscription and returns `TRUE` in the callback if successfull.
-    - ``subscription.arguments``: The subscription arguments, used when re-subscribing.
+    - ``subscription.options``: The subscription options, used when re-subscribing.
+    - ``subscription.type``: The subscription type.
+    - ``subscription.method``: The subscription method e.g.: ``logs``.
     - ``on("data")`` returns ``Object``: Fires on each incoming log with the log object as argument.
     - ``on("changed")`` returns ``Object``: Fires on each log which was removed from the blockchain. The log will have the additional property ``"removed: true"``.
     - ``on("error")`` returns ``Object``: Fires when an error in the subscription occurs.

--- a/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
+++ b/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
@@ -94,6 +94,12 @@ export default class LogSubscription extends AbstractSubscription {
      * @returns {Object}
      */
     onNewSubscriptionItem(subscriptionItem) {
-        return this.formatters.outputLogFormatter(subscriptionItem);
+        const log = this.formatters.outputLogFormatter(subscriptionItem);
+
+        if (log.removed) {
+            this.emit('changed', log);
+        }
+
+        return log;
     }
 }

--- a/packages/web3-core-subscriptions/tests/src/subscriptions/eth/LogSubscriptionTest.js
+++ b/packages/web3-core-subscriptions/tests/src/subscriptions/eth/LogSubscriptionTest.js
@@ -200,4 +200,26 @@ describe('LogSubscriptionTest', () => {
             })
         ).toBeInstanceOf(LogSubscription);
     });
+
+    it('calls onNewSubscriptionItem with removed set to true', (done) => {
+        formatters.outputLogFormatter.mockReturnValueOnce({removed: true});
+
+        logSubscription.on('changed', (response) => {
+            expect(response).toEqual({removed: true});
+
+            expect(formatters.outputLogFormatter).toHaveBeenCalledWith({removed: false});
+
+            done();
+        });
+
+        expect(logSubscription.onNewSubscriptionItem({removed: false})).toEqual({removed: true});
+    });
+
+    it('calls onNewSubscriptionItem with removed set to false', () => {
+        formatters.outputLogFormatter.mockReturnValueOnce({removed: true});
+
+        expect(logSubscription.onNewSubscriptionItem({removed: false})).toEqual({removed: true});
+
+        expect(formatters.outputLogFormatter).toHaveBeenCalledWith({removed: false});
+    });
 });


### PR DESCRIPTION
## Description

Adds the missing changed event for the LogSubscription.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
