### PR TITLE
fix typo

### DIFF
--- a/docs/web3-module.rst
+++ b/docs/web3-module.rst
@@ -27,7 +27,7 @@ Example
 .. code-block:: javascript
 
     import * as Utils from 'web3-utils';
-    import {formatters} from 'web3-core-formatters';
+    import {formatters} from 'web3-core-helpers';
     import {AbstractWeb3Module} from 'web3-core';
     import {AbstractMethodFactory, GetBlockByNumberMethod, AbstractMethod} from 'web3-core-method';
 


### PR DESCRIPTION
## Description
`web3-core-formatters` does not exists.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change
- [x] document

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
