### PR TITLE
Fix error on contract method proxy when method parameter is null.

### DIFF
--- a/packages/web3-eth-contract/src/proxies/MethodsProxy.js
+++ b/packages/web3-eth-contract/src/proxies/MethodsProxy.js
@@ -191,7 +191,7 @@ export default class MethodsProxy {
         method.setArguments(methodArguments);
 
         // If no parameters are given for the eth_call or eth_send* methods then it will set a empty options object.
-        if (typeof method.parameters[0] === 'undefined') {
+        if (!method.parameters[0]) {
             method.parameters[0] = {};
         }
 

--- a/packages/web3-eth-contract/tests/src/proxies/MethodsProxyTest.js
+++ b/packages/web3-eth-contract/tests/src/proxies/MethodsProxyTest.js
@@ -115,6 +115,47 @@ describe('MethodsProxyTest', () => {
         expect(methodOptionsValidatorMock.validate).toHaveBeenCalledWith(abiItemModelMock, callMethodMock);
     });
 
+    it('calls a call method over the proxy should allow null parameters', async () => {
+        abiModelMock.hasMethod.mockReturnValueOnce(true);
+
+        abiModelMock.getMethod.mockReturnValueOnce(abiItemModelMock);
+
+        const callMethodMock = {};
+        callMethodMock.parameters = [null];
+        callMethodMock.setArguments = jest.fn();
+        callMethodMock.execute = jest.fn(() => {
+            return Promise.resolve(true);
+        });
+
+        methodFactoryMock.createMethodByRequestType.mockReturnValueOnce(callMethodMock);
+
+        methodEncoderMock.encode.mockReturnValueOnce('0x0');
+
+        methodOptionsMapperMock.map.mockReturnValueOnce({options: true});
+
+        await expect(methodsProxy.myMethod(true).call({options: false})).resolves.toEqual(true);
+
+        expect(abiModelMock.hasMethod).toHaveBeenCalledWith('myMethod');
+
+        expect(abiModelMock.getMethod).toHaveBeenCalledWith('myMethod');
+
+        expect(abiItemModelMock.contractMethodParameters[0]).toEqual(true);
+
+        expect(methodFactoryMock.createMethodByRequestType).toHaveBeenCalledWith(
+            abiItemModelMock,
+            contractMock,
+            'call'
+        );
+
+        expect(callMethodMock.parameters[0]).toEqual({options: true});
+
+        expect(methodEncoderMock.encode).toHaveBeenCalledWith(abiItemModelMock, contractMock.data);
+
+        expect(methodOptionsMapperMock.map).toHaveBeenCalledWith(contractMock, {data: '0x0'});
+
+        expect(methodOptionsValidatorMock.validate).toHaveBeenCalledWith(abiItemModelMock, callMethodMock);
+    });
+
     it('calls the constructor method over the proxy', async () => {
         abiModelMock.hasMethod.mockReturnValueOnce(true);
 


### PR DESCRIPTION
## Description

After upgrade to Web3 beta 55, the method proxy was failing because some parameters were `null` instead of `undefined`. This change allows receiving `null` parameters.

## Type of change

- [x] Bug fix 

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [x] I have tested my code on an ethereum test network.
