### PR TITLE
fix to export isBigNumber

### DIFF
--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -311,3 +311,4 @@ export const isTopic = utils.isTopic;
 export const bytesToHex = utils.bytesToHex;
 export const hexToBytes = utils.hexToBytes;
 export const stripHexPrefix = utils.stripHexPrefix;
+export const isBigNumber = utils.isBigNumber;


### PR DESCRIPTION
## Description

Please include a summary of the change.
Added an export for isBigNumber so that it is available as
```
import { isBigNumber } from 'web3-utils'
```

Fixes the following [issue](https://github.com/ethereum/web3.js/issues/2835)

## Type of change

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
