### PR TITLE
Assign correct JSON-RPC response to validate on Web3EthereumProvider.send method

### DIFF
--- a/packages/web3-providers/src/providers/Web3EthereumProvider.js
+++ b/packages/web3-providers/src/providers/Web3EthereumProvider.js
@@ -129,7 +129,7 @@ export default class Web3EthereumProvider extends AbstractSocketProvider {
      * @returns {Promise<Object>}
      */
     async send(method, parameters) {
-        const response = this.connection.send(method, parameters);
+        const response = await this.connection.send(method, parameters);
         const validationResult = JsonRpcResponseValidator.validate(response);
 
         if (validationResult instanceof Error) {


### PR DESCRIPTION
## Description

await connection.send method call to assign a right JSON-RPC response before its validation.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
