### PR TITLE
EIP-1193 updates

### DIFF
--- a/packages/web3-providers/src/resolvers/ProviderResolver.js
+++ b/packages/web3-providers/src/resolvers/ProviderResolver.js
@@ -75,7 +75,7 @@ export default class ProviderResolver {
             return provider;
         }
 
-        if (provider instanceof Web3EthereumProvider) {
+        if (provider.host === 'Web3EthereumProvider') {
             return provider;
         }
 

--- a/packages/web3-providers/src/resolvers/ProviderResolver.js
+++ b/packages/web3-providers/src/resolvers/ProviderResolver.js
@@ -22,7 +22,6 @@
 
 import isFunction from 'lodash/isFunction';
 import isObject from 'lodash/isObject';
-import Web3EthereumProvider from '../providers/Web3EthereumProvider';
 
 const global =
     (function() {

--- a/packages/web3-providers/src/resolvers/ProviderResolver.js
+++ b/packages/web3-providers/src/resolvers/ProviderResolver.js
@@ -22,6 +22,7 @@
 
 import isFunction from 'lodash/isFunction';
 import isObject from 'lodash/isObject';
+import Web3EthereumProvider from '../providers/Web3EthereumProvider';
 
 const global =
     (function() {
@@ -71,6 +72,10 @@ export default class ProviderResolver {
         }
 
         if (provider.sendPayload && provider.subscribe) {
+            return provider;
+        }
+
+        if (provider instanceof Web3EthereumProvider) {
             return provider;
         }
 

--- a/packages/web3-providers/tests/src/resolvers/ProviderResolverTest.js
+++ b/packages/web3-providers/tests/src/resolvers/ProviderResolverTest.js
@@ -3,6 +3,7 @@ import ProvidersModuleFactory from '../../../src/factories/ProvidersModuleFactor
 import HttpProvider from '../../../src/providers/HttpProvider';
 import WebsocketProvider from '../../../src/providers/WebsocketProvider';
 import IpcProvider from '../../../src/providers/IpcProvider';
+import Web3EthereumProvider from '../../../src/providers/Web3EthereumProvider';
 import MetamaskProvider from '../../../src/providers/MetamaskProvider';
 import CustomProvider from '../../../src/providers/CustomProvider';
 
@@ -11,7 +12,6 @@ jest.mock('../../../src/factories/ProvidersModuleFactory');
 jest.mock('../../../src/providers/HttpProvider');
 jest.mock('../../../src/providers/WebsocketProvider');
 jest.mock('../../../src/providers/IpcProvider');
-jest.mock('../../../src/providers/Web3EthereumProvider');
 jest.mock('../../../src/providers/MetamaskProvider');
 jest.mock('../../../src/providers/CustomProvider');
 
@@ -83,6 +83,16 @@ describe('ProviderResolverTest', () => {
         expect(providerResolver.resolve(ethereumProviderMock)).toEqual(ethereumProviderMock);
 
         expect(providersModuleFactoryMock.createWeb3EthereumProvider).toHaveBeenCalledWith(ethereumProviderMock);
+    });
+
+    it('calls resolve with the Web3EthereumProvider', () => {
+        const ethereumProviderMock = {
+            isEIP1193: true,
+            on: () => {}
+        };
+        const web3EthereumProvider = new Web3EthereumProvider(ethereumProviderMock);
+
+        expect(providerResolver.resolve(web3EthereumProvider)).toBeInstanceOf(Web3EthereumProvider);
     });
 
     it('calls resolve with the WebsocketProvider', () => {


### PR DESCRIPTION
## Description

Currently, if we instantiate Web3 with EIP1193 compatible provider, the provider resolver resolves CustomProvider for Eth and Shh module. This causes that the provider's send method receives payload as the first argument and callback function as the second argument when a dapp calls `web3.eth.getAccounts()` for example.

### Code to reproduce
```
const Web3 = require('web3')
const EventEmitter = require('events')

class Provider extends EventEmitter {
  constructor() {
    super()
    this.isEIP1193 = true
  }
}

const provider = new Provider()
const web3 = new Web3(provider)

console.log(web3.currentProvider.constructor.name)
// -> Web3EthereumProvider

console.log(web3.eth._currentProvider.constructor.name)
// -> CustomProvider
```

I added another condition for the resolver to check if the provider is Web3EthereumProvider then return the provider itself.

I hope this helps.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
