### PR TITLE
Replace method names of mining operation in doc

### DIFF
--- a/docs/web3-eth-miner.rst
+++ b/docs/web3-eth-miner.rst
@@ -146,12 +146,12 @@ Example
 ------------------------------------------------------------------------------
 
 
-start
+startMining
 =====
 
 .. code-block:: javascript
 
-    miner.start(miningThread, [, callback])
+    miner.startMining(miningThread, [, callback])
 
 Start the CPU mining process with the given number of threads.
 The RPC method used is ``miner_start``.
@@ -180,21 +180,21 @@ Example
 
 .. code-block:: javascript
 
-    miner.start('0x1').then(console.log);
+    miner.startMining('0x1').then(console.log);
     > true
 
-    miner.start(1).then(console.log);
+    miner.startMining(1).then(console.log);
     > true
 
 ------------------------------------------------------------------------------
 
 
-stop
+stopMining
 ====
 
 .. code-block:: javascript
 
-    miner.stop([callback])
+    miner.stopMining([callback])
 
 Stop the CPU mining process.
 The RPC method used is ``miner_stop``.
@@ -222,7 +222,7 @@ Example
 
 .. code-block:: javascript
 
-    miner.stop().then(console.log);
+    miner.stopMining().then(console.log);
     > true
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Currently, some method names in documentation are not same with [implementation](https://github.com/ethereum/web3.js/blob/1.0/packages/web3-eth-miner/types/index.d.ts#L42).

These two methods are related to RPC method `miner_start` and `miner_stop`.

## Type of change

- [x] Documentation

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.