### PR TITLE
Fix JSON-RPC response validation

### DIFF
--- a/packages/web3-providers/src/providers/Web3EthereumProvider.js
+++ b/packages/web3-providers/src/providers/Web3EthereumProvider.js
@@ -17,7 +17,6 @@
  * @date 2018
  */
 
-import JsonRpcResponseValidator from '../validators/JsonRpcResponseValidator';
 import AbstractSocketProvider from '../../lib/providers/AbstractSocketProvider';
 
 export default class Web3EthereumProvider extends AbstractSocketProvider {
@@ -137,7 +136,7 @@ export default class Web3EthereumProvider extends AbstractSocketProvider {
         }
 
         if (result === undefined) {
-            throw new Error(`Validation error: Undefined JSON-RPC result`);
+            throw new Error('Validation error: Undefined JSON-RPC result');
         }
 
         return result;

--- a/packages/web3-providers/src/providers/Web3EthereumProvider.js
+++ b/packages/web3-providers/src/providers/Web3EthereumProvider.js
@@ -128,18 +128,11 @@ export default class Web3EthereumProvider extends AbstractSocketProvider {
      * @returns {Promise<Object>}
      */
     async send(method, parameters) {
-        let result;
         try {
-            result = await this.connection.send(method, parameters);
+            return await this.connection.send(method, parameters);
         } catch (error) {
             throw new Error(`Node error: ${error.message}`);
         }
-
-        if (result === undefined) {
-            throw new Error('Validation error: Undefined JSON-RPC result');
-        }
-
-        return result;
     }
 
     /**

--- a/packages/web3-providers/src/providers/Web3EthereumProvider.js
+++ b/packages/web3-providers/src/providers/Web3EthereumProvider.js
@@ -136,7 +136,7 @@ export default class Web3EthereumProvider extends AbstractSocketProvider {
             throw validationResult;
         }
 
-        return response;
+        return response.result;
     }
 
     /**

--- a/packages/web3-providers/src/providers/Web3EthereumProvider.js
+++ b/packages/web3-providers/src/providers/Web3EthereumProvider.js
@@ -129,14 +129,18 @@ export default class Web3EthereumProvider extends AbstractSocketProvider {
      * @returns {Promise<Object>}
      */
     async send(method, parameters) {
-        const response = await this.connection.send(method, parameters);
-        const validationResult = JsonRpcResponseValidator.validate(response);
-
-        if (validationResult instanceof Error) {
-            throw validationResult;
+        let result;
+        try {
+            result = await this.connection.send(method, parameters);
+        } catch (error) {
+            throw new Error(`Node error: ${error.message}`);
         }
 
-        return response.result;
+        if (result === undefined) {
+            throw new Error(`Validation error: Undefined JSON-RPC result`);
+        }
+
+        return result;
     }
 
     /**

--- a/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
@@ -173,7 +173,7 @@ describe('Web3EthereumProviderTest', () => {
         ethereumProvider.onMessage({subscription: '0x0'});
     });
 
-    it('calls send and returns a resolved promise with the response result', async () => {
+    it('calls send and returns a resolved promise with the response', async () => {
         socketMock.send = jest.fn((method, parameters) => {
             expect(method).toEqual('method');
 

--- a/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
@@ -1,5 +1,4 @@
 import Web3EthereumProvider from '../../../src/providers/Web3EthereumProvider';
-import JsonRpcResponseValidator from '../../../src/validators/JsonRpcResponseValidator';
 import AbstractMethod from '../../__mocks__/AbstractMethod';
 import AbstractWeb3Module from '../../__mocks__/AbstractWeb3Module';
 import AbstractSocketProvider from '../../../lib/providers/AbstractSocketProvider';
@@ -188,7 +187,7 @@ describe('Web3EthereumProviderTest', () => {
         expect(response).toEqual(true);
     });
 
-    it ('callse send and returns a rejected promise becase of an undefined response result', async () => {
+    it('callse send and returns a rejected promise becase of an undefined response result', async () => {
         socketMock.send = jest.fn((method, parameters) => {
             expect(method).toEqual('method');
 
@@ -197,7 +196,9 @@ describe('Web3EthereumProviderTest', () => {
             return Promise.resolve();
         });
 
-        await expect(ethereumProvider.send('method', [])).rejects.toThrow('Validation error: Undefined JSON-RPC result');
+        await expect(ethereumProvider.send('method', [])).rejects.toThrow(
+            'Validation error: Undefined JSON-RPC result'
+        );
     });
 
     it('calls send and returns a rejected promise because of an error response', async () => {

--- a/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
@@ -187,20 +187,6 @@ describe('Web3EthereumProviderTest', () => {
         expect(response).toEqual(true);
     });
 
-    it('callse send and returns a rejected promise becase of an undefined response result', async () => {
-        socketMock.send = jest.fn((method, parameters) => {
-            expect(method).toEqual('method');
-
-            expect(parameters).toEqual([]);
-
-            return Promise.resolve();
-        });
-
-        await expect(ethereumProvider.send('method', [])).rejects.toThrow(
-            'Validation error: Undefined JSON-RPC result'
-        );
-    });
-
     it('calls send and returns a rejected promise because of an error response', async () => {
         socketMock.send = jest.fn((method, parameters) => {
             expect(method).toEqual('method');

--- a/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
@@ -175,41 +175,41 @@ describe('Web3EthereumProviderTest', () => {
     });
 
     it('calls send and returns a resolved promise with the response result', async () => {
-        JsonRpcResponseValidator.validate = jest.fn(() => {
-            return true;
-        });
-
         socketMock.send = jest.fn((method, parameters) => {
             expect(method).toEqual('method');
 
             expect(parameters).toEqual([]);
 
-            return Promise.resolve({result: true});
+            return Promise.resolve(true);
         });
 
         const response = await ethereumProvider.send('method', []);
 
         expect(response).toEqual(true);
-
-        expect(JsonRpcResponseValidator.validate).toHaveBeenCalled();
     });
 
-    it('calls send and returns a rejected promise because of a invalid response', async () => {
-        JsonRpcResponseValidator.validate = jest.fn(() => {
-            return new Error('invalid');
-        });
-
+    it ('callse send and returns a rejected promise becase of an undefined response result', async () => {
         socketMock.send = jest.fn((method, parameters) => {
             expect(method).toEqual('method');
 
             expect(parameters).toEqual([]);
 
-            return Promise.resolve(false);
+            return Promise.resolve();
         });
 
-        await expect(ethereumProvider.send('method', [])).rejects.toThrow('invalid');
+        await expect(ethereumProvider.send('method', [])).rejects.toThrow('Validation error: Undefined JSON-RPC result');
+    });
 
-        expect(JsonRpcResponseValidator.validate).toHaveBeenCalled();
+    it('calls send and returns a rejected promise because of an error response', async () => {
+        socketMock.send = jest.fn((method, parameters) => {
+            expect(method).toEqual('method');
+
+            expect(parameters).toEqual([]);
+
+            return Promise.reject(new Error('invalid'));
+        });
+
+        await expect(ethereumProvider.send('method', [])).rejects.toThrow('Node error: invalid');
     });
 
     it('calls sendBatch and returns a resolved promise with the response', async () => {

--- a/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
@@ -174,7 +174,7 @@ describe('Web3EthereumProviderTest', () => {
         ethereumProvider.onMessage({subscription: '0x0'});
     });
 
-    it('calls send and returns a resolved promise with the response', async () => {
+    it('calls send and returns a resolved promise with the response result', async () => {
         JsonRpcResponseValidator.validate = jest.fn(() => {
             return true;
         });
@@ -184,7 +184,7 @@ describe('Web3EthereumProviderTest', () => {
 
             expect(parameters).toEqual([]);
 
-            return Promise.resolve(true);
+            return Promise.resolve({result: true});
         });
 
         const response = await ethereumProvider.send('method', []);


### PR DESCRIPTION
## Description

Fixed the send method on Web3EthereumProvider to return response result, not response object itself otherwise [GetAccountsMethod.js#L47](https://github.com/ethereum/web3.js/blob/1.0/packages/web3-core-method/src/methods/account/GetAccountsMethod.js#L47) throws an error.

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [ ] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests if necessary.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.
