### PR TITLE
web3js dependency on webpack to run on browser

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -29,6 +29,7 @@ For  web3.js, check ``Web3.givenProvider``. If this property is ``null`` you sho
 .. code-block:: javascript
 
     // in node.js use: const Web3 = require('web3');
+    // for a frontend app, you must be using webpack, otherwise you need to bundle the modules externally.
 
     // use the given Provider, e.g in the browser with Metamask, or instantiate a new websocket provider
     const web3 = new Web3(Web3.givenProvider || 'ws://localhost:8546', null, {});


### PR DESCRIPTION
This would have saved me a few days of struggling. CDN bundles likes [this](https://cdn.jsdelivr.net/npm/web3@1.0.0-beta.55/dist/web3.esm.min.js) are not browser compatible neither!