### PR TITLE
Fix removeAllSocketListeners method in Web3EthereumProvider

### DIFF
--- a/packages/web3-providers/src/providers/MetamaskProvider.js
+++ b/packages/web3-providers/src/providers/MetamaskProvider.js
@@ -83,8 +83,8 @@ export default class MetamaskProvider extends AbstractSocketProvider {
      * @method removeAllSocketListeners
      */
     removeAllSocketListeners() {
-        this.connection.removeListener(this.SOCKET_NETWORK_CHANGED, this.onNetworkChanged);
-        this.connection.removeListener(this.SOCKET_ACCOUNTS_CHANGED, this.onAccountsChanged);
+        this.removeAllListeners(this.SOCKET_ACCOUNTS_CHANGED);
+        this.removeAllListeners(this.SOCKET_NETWORK_CHANGED);
 
         super.removeAllSocketListeners();
     }

--- a/packages/web3-providers/src/providers/Web3EthereumProvider.js
+++ b/packages/web3-providers/src/providers/Web3EthereumProvider.js
@@ -85,7 +85,12 @@ export default class Web3EthereumProvider extends AbstractSocketProvider {
      * @method removeAllSocketListeners
      */
     removeAllSocketListeners() {
-        this.connection.removeAllListeners();
+        this.connection.removeListener('notification', this.onMessage);
+        this.connection.removeListener('connect', this.onConnect);
+        this.connection.removeListener('connect', this.onReady);
+        this.connection.removeListener('close', this.onClose);
+        this.connection.removeListener('networkChanged', this.onNetworkChanged);
+        this.connection.removeListener('accountsChanged', this.onAccountsChanged);
     }
 
     /**

--- a/packages/web3-providers/src/providers/Web3EthereumProvider.js
+++ b/packages/web3-providers/src/providers/Web3EthereumProvider.js
@@ -85,12 +85,10 @@ export default class Web3EthereumProvider extends AbstractSocketProvider {
      * @method removeAllSocketListeners
      */
     removeAllSocketListeners() {
-        this.connection.removeListener('notification', this.onMessage);
-        this.connection.removeListener('connect', this.onConnect);
-        this.connection.removeListener('connect', this.onReady);
-        this.connection.removeListener('close', this.onClose);
-        this.connection.removeListener('networkChanged', this.onNetworkChanged);
-        this.connection.removeListener('accountsChanged', this.onAccountsChanged);
+        this.removeAllListeners(this.SOCKET_ACCOUNTS_CHANGED);
+        this.removeAllListeners(this.SOCKET_NETWORK_CHANGED);
+
+        super.removeAllSocketListeners()
     }
 
     /**

--- a/packages/web3-providers/tests/src/providers/MetamaskProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/MetamaskProviderTest.js
@@ -79,14 +79,14 @@ describe('MetamaskProviderTest', () => {
         metamaskProvider.removeAllSocketListeners();
 
         expect(inpageProvider.removeListener).toHaveBeenNthCalledWith(
-            1,
-            metamaskProvider.SOCKET_NETWORK_CHANGED,
+            2,
+            'networkChanged',
             metamaskProvider.onNetworkChanged
         );
 
         expect(inpageProvider.removeListener).toHaveBeenNthCalledWith(
-            2,
-            metamaskProvider.SOCKET_ACCOUNTS_CHANGED,
+            1,
+            'accountsChanged',
             metamaskProvider.onAccountsChanged
         );
     });

--- a/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
@@ -139,22 +139,10 @@ describe('Web3EthereumProviderTest', () => {
         ethereumProvider.removeAllSocketListeners();
 
         expect(socketMock.removeListener).toHaveBeenNthCalledWith(
-            1, 'notification', ethereumProvider.onMessage
+            1, 'accountsChanged', ethereumProvider.onAccountsChanged
         );
         expect(socketMock.removeListener).toHaveBeenNthCalledWith(
-            2, 'connect', ethereumProvider.onConnect
-        );
-        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
-            3, 'connect', ethereumProvider.onReady
-        );
-        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
-            4, 'close', ethereumProvider.onClose
-        );
-        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
-            5, 'networkChanged', ethereumProvider.onNetworkChanged
-        );
-        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
-            6, 'accountsChanged', ethereumProvider.onAccountsChanged
+            2, 'networkChanged', ethereumProvider.onNetworkChanged
         );
     });
 

--- a/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
+++ b/packages/web3-providers/tests/src/providers/Web3EthereumProviderTest.js
@@ -134,11 +134,28 @@ describe('Web3EthereumProviderTest', () => {
     });
 
     it('calls removeAllSocketListeners', () => {
-        socketMock.removeAllListeners = jest.fn();
+        socketMock.removeListener = jest.fn();
 
         ethereumProvider.removeAllSocketListeners();
 
-        expect(socketMock.removeAllListeners).toHaveBeenCalled();
+        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
+            1, 'notification', ethereumProvider.onMessage
+        );
+        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
+            2, 'connect', ethereumProvider.onConnect
+        );
+        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
+            3, 'connect', ethereumProvider.onReady
+        );
+        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
+            4, 'close', ethereumProvider.onClose
+        );
+        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
+            5, 'networkChanged', ethereumProvider.onNetworkChanged
+        );
+        expect(socketMock.removeListener).toHaveBeenNthCalledWith(
+            6, 'accountsChanged', ethereumProvider.onAccountsChanged
+        );
     });
 
     it('calls onNetworkChanged and emits the "networkChanged" event', (done) => {


### PR DESCRIPTION
This fix prevents removing listeners which are not be added by Web3.