### PR TITLE
Fix constructor name checking when reconnect websocket with options

### DIFF
--- a/packages/web3-providers/src/providers/WebsocketProvider.js
+++ b/packages/web3-providers/src/providers/WebsocketProvider.js
@@ -91,7 +91,7 @@ export default class WebsocketProvider extends AbstractSocketProvider {
 
             let connection = [];
 
-            if (this.connection.constructor.name === 'W3CWebsocket') {
+            if (this.connection.constructor.name === 'W3CWebSocket') {
                 connection = new this.connection.constructor(
                     this.host,
                     this.connection._client.protocol,


### PR DESCRIPTION
When the websocket provider has options attached they should be reattached again when reconnection the websocket. 

This is currently implemented in the websocket provider but the check in the provider checks the wrong constructor name. The constructor of the W3CWebSocket name is "W3CWebSocket" and the check checks for "W3CWebsocket"

This pull request fixes this.