### PR TITLE
Fix TypeScript 'ContractOptions' interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - miner.startMining fixed (#2877)
 - Subscription type definitions fixed (#2919)
+- ``ContractOptions`` type definitions corrected (#2939)
 

--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -95,10 +95,16 @@ export interface EstimateGasOptions {
 }
 
 export interface ContractOptions {
-    from: string;
-    gasPrice: string;
-    gas: number;
-    data: string;
+    // Sender to use for contract calls
+    from?: string;
+    // Gas price to use for contract calls
+    gasPrice?: string;
+    // Gas to use for contract calls
+    gas?: number;
+    // Contract code
+    data?: string;
+    // Number of blocks until a contract call transaction is considered confirmed
+    transactionConfirmationBlocks?: number
 }
 
 export interface EventOptions {

--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -20,7 +20,7 @@
 import BN = require('bn.js');
 import {provider} from 'web3-providers';
 import {AbiInput, AbiOutput, AbiItem} from 'web3-utils';
-import {PromiEvent} from 'web3-core';
+import {PromiEvent, Web3ModuleOptions} from 'web3-core';
 
 export class Contract {
     constructor(
@@ -94,7 +94,7 @@ export interface EstimateGasOptions {
     value?: number | string | BN;
 }
 
-export interface ContractOptions {
+export interface ContractOptions extends Web3ModuleOptions {
     // Sender to use for contract calls
     from?: string;
     // Gas price to use for contract calls
@@ -103,8 +103,6 @@ export interface ContractOptions {
     gas?: number;
     // Contract code
     data?: string;
-    // Number of blocks until a contract call transaction is considered confirmed
-    transactionConfirmationBlocks?: number
 }
 
 export interface EventOptions {


### PR DESCRIPTION
* Make all fields optional
* Add `transactionConfirmationBlocks` field
* Document all fields

Note that the list of options is still not exhaustive but I was unable to confidently determine the types of the other options.