### PR TITLE
fix/subscription_rpc_after_get_logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,4 +71,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - miner.startMining fixed (#2877)
 - Subscription type definitions fixed (#2919)
+- ``LogSubscription`` sent parameters fixed (#2947)
 

--- a/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
+++ b/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
@@ -66,6 +66,7 @@ export default class LogSubscription extends AbstractSubscription {
                     });
 
                     delete this.options.fromBlock;
+                    delete this.options.toBlock;
                     super.subscribe(callback);
                 })
                 .catch((error) => {

--- a/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
+++ b/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
@@ -20,8 +20,14 @@
  * @date 2018
  */
 
-import AbstractSubscription from '../../../lib/subscriptions/AbstractSubscription';
-import isFunction from 'lodash/isFunction';
+import AbstractSubscription from '../../../lib/subscriptions/AbstractSubscription'
+import isFunction from 'lodash/isFunction'
+import reject from 'lodash/reject'
+import isUndefined from 'lodash/isUndefined'
+import isObject from 'lodash/isObject'
+import isArray from 'lodash/isArray'
+import pickBy from 'lodash/pickBy'
+import isString from 'lodash/isString'
 
 // TODO: Move the past logs logic to the eth module
 export default class LogSubscription extends AbstractSubscription {
@@ -35,8 +41,106 @@ export default class LogSubscription extends AbstractSubscription {
      * @constructor
      */
     constructor(options, utils, formatters, moduleInstance, getPastLogsMethod) {
-        super('eth_subscribe', 'logs', options, utils, formatters, moduleInstance);
-        this.getPastLogsMethod = getPastLogsMethod;
+        super('eth_subscribe', 'logs', options, utils, formatters, moduleInstance)
+        this.getPastLogsMethod = getPastLogsMethod
+        this.logSubscriptionOptions = ['address', 'topics']
+    }
+
+    /**
+     * Validate options
+     *
+     * @method validate
+     *
+     * @param {Object} options
+     *
+     * @returns {Error | Boolean } if find an invalid option will throw an error
+     */
+    validate(options) {
+        if (isObject(options)) {
+            let rejectedOptions = reject(Object.keys(options), option => {
+                return this.logSubscriptionOptions.some(
+                    parameter => parameter == option
+                )
+            })
+
+            if (rejectedOptions.length > 0) {
+                return new Error(
+                    `Validation error: This option(s) are not valid <${rejectedOptions}>`
+                )
+            }
+
+            if (!isUndefined(options.topics)) {
+                if (!isArray(options.topics)) {
+                    return new Error('Validation error: topics need to be an array')
+                } else {
+                    const topics = options.topics
+                    for (let i = 0; i < topics.length; i++) {
+                        if (!this.utils.isTopic(topics[i])) {
+                            return new Error(
+                                `Validation error: Provided Topic ${topics[i]} is invalid`
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (!isUndefined(options.address)) {
+                const addresses = isString(options.address) ?
+                    [options.address] :
+                    options.address
+                for (let i = 0; i < addresses.length; i++) {
+                    if (!this.utils.isAddress(addresses[i])) {
+                        return new Error(
+                            `Validation error: Provided address ${addresses[i]} is invalid`
+                        )
+                    }
+                }
+            }
+
+            return true
+        }
+        return new Error('Validation error: Options should be of type Object')
+    }
+
+    /**
+     * Validate get past logs filters
+     *
+     * @method validateGetPastLogsFilters
+     *
+     * @param {Object} options
+     *
+     * @returns {Object}
+     */
+    validateGetPastLogsFilters(filters) {
+        if (!isUndefined(filters.toBlock)) {
+            if (!isUndefined(filters.blockHash)) {
+                return new Error(
+                    'Validation error: BlockHash is present in the filter criteria, then neither fromBlock or toBlock are allowed.'
+                )
+            }
+
+            if (filters.fromBlock == 'latest' && filters.toBlock == 'latest') {
+                return new Error(
+                    'Validation error: fromBlock and toBlock are set to latest, consider to remove filters'
+                )
+            }
+        }
+        return true
+    }
+
+    /**
+     * Reject invalid options
+     *
+     * @method rejectInvalidLogSubscriptions
+     *
+     * @param {Object} options
+     *
+     * @returns {Object}
+     */
+    rejectInvalidLogSubscriptions(options) {
+        return pickBy(options, (_, option) =>
+            this.logSubscriptionOptions.some(logOption => logOption == option)
+        )
     }
 
     /**
@@ -50,39 +154,62 @@ export default class LogSubscription extends AbstractSubscription {
      * @returns {Subscription} Subscription
      */
     subscribe(callback) {
-        if ((this.options.fromBlock && this.options.fromBlock !== 'latest') || this.options.fromBlock === 0) {
-            this.getPastLogsMethod.parameters = [this.formatters.inputLogFormatter(this.options)];
-            this.getPastLogsMethod
-                .execute()
-                .then((logs) => {
-                    logs.forEach((log) => {
-                        const formattedLog = this.onNewSubscriptionItem(log);
+        if (
+            (this.options.fromBlock && this.options.fromBlock !== 'latest') ||
+            this.options.fromBlock === 0
+        ) {
+            this.options = this.formatters.inputLogFormatter(this.options)
 
+            const getPastLogsFiltersResult = this.validateGetPastLogsFilters(
+                this.options
+            )
+            if (getPastLogsFiltersResult instanceof Error) {
+                if (isFunction(callback)) {
+                    callback(getPastLogsFiltersResult, null)
+                }
+                this.emit('error', getPastLogsFiltersResult)
+            } else {
+                this.getPastLogsMethod.parameters = [this.options]
+                this.getPastLogsMethod
+                    .execute()
+                    .then(logs => {
+                        logs.forEach(log => {
+                            const formattedLog = this.onNewSubscriptionItem(log)
+
+                            if (isFunction(callback)) {
+                                callback(false, formattedLog)
+                            }
+
+                            this.emit('data', formattedLog)
+                        })
+
+                        this.options = this.rejectInvalidLogSubscriptions(this.options)
+                        super.subscribe(callback)
+                    })
+                    .catch(error => {
                         if (isFunction(callback)) {
-                            callback(false, formattedLog);
+                            callback(error, null)
                         }
 
-                        this.emit('data', formattedLog);
-                    });
+                        this.emit('error', error)
+                    })
+            }
 
-                    delete this.options.fromBlock;
-                    delete this.options.toBlock;
-                    super.subscribe(callback);
-                })
-                .catch((error) => {
-                    if (isFunction(callback)) {
-                        callback(error, null);
-                    }
-
-                    this.emit('error', error);
-                });
-
-            return this;
+            return this
         }
 
-        super.subscribe(callback);
+        const validationResult = this.validate(this.options)
 
-        return this;
+        if (validationResult instanceof Error) {
+            if (isFunction(callback)) {
+                callback(validationResult, null)
+            }
+            this.emit('error', validationResult)
+        } else {
+            super.subscribe(callback)
+        }
+
+        return this
     }
 
     /**
@@ -95,12 +222,12 @@ export default class LogSubscription extends AbstractSubscription {
      * @returns {Object}
      */
     onNewSubscriptionItem(subscriptionItem) {
-        const log = this.formatters.outputLogFormatter(subscriptionItem);
+        const log = this.formatters.outputLogFormatter(subscriptionItem)
 
         if (log.removed) {
-            this.emit('changed', log);
+            this.emit('changed', log)
         }
 
-        return log;
+        return log
     }
 }

--- a/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
+++ b/packages/web3-core-subscriptions/src/subscriptions/eth/LogSubscription.js
@@ -59,7 +59,7 @@ export default class LogSubscription extends AbstractSubscription {
         if (isObject(options)) {
             let rejectedOptions = reject(Object.keys(options), option => {
                 return this.logSubscriptionOptions.some(
-                    parameter => parameter == option
+                    parameter => parameter === option
                 )
             })
 
@@ -119,7 +119,7 @@ export default class LogSubscription extends AbstractSubscription {
                 )
             }
 
-            if (filters.fromBlock == 'latest' && filters.toBlock == 'latest') {
+            if (filters.fromBlock === 'latest' && filters.toBlock === 'latest') {
                 return new Error(
                     'Validation error: fromBlock and toBlock are set to latest, consider to remove filters'
                 )
@@ -139,7 +139,7 @@ export default class LogSubscription extends AbstractSubscription {
      */
     rejectInvalidLogSubscriptions(options) {
         return pickBy(options, (_, option) =>
-            this.logSubscriptionOptions.some(logOption => logOption == option)
+            this.logSubscriptionOptions.some(logOption => logOption === option)
         )
     }
 

--- a/packages/web3-core-subscriptions/tests/src/subscriptions/eth/LogSubscriptionTest.js
+++ b/packages/web3-core-subscriptions/tests/src/subscriptions/eth/LogSubscriptionTest.js
@@ -65,6 +65,8 @@ describe('LogSubscriptionTest', () => {
 
         let second = false;
         logSubscription.options.fromBlock = 0;
+        logSubscription.options.toBlock = 0;
+
         const subscription = logSubscription.subscribe((error, response) => {
             let expectedResponse = 0;
             let expectedId = null;
@@ -72,6 +74,10 @@ describe('LogSubscriptionTest', () => {
             if (second) {
                 expectedResponse = 'ITEM';
                 expectedId = 'MY_ID';
+
+                expect(logSubscription.options.toBlock).toBeUndefined();
+
+                expect(logSubscription.options.fromBlock).toBeUndefined();
             }
 
             expect(error).toEqual(false);

--- a/packages/web3-core-subscriptions/tests/src/subscriptions/eth/LogSubscriptionTest.js
+++ b/packages/web3-core-subscriptions/tests/src/subscriptions/eth/LogSubscriptionTest.js
@@ -1,12 +1,13 @@
 import * as Utils from 'web3-utils';
-import {formatters} from 'web3-core-helpers';
+import {
+    formatters
+} from 'web3-core-helpers';
 import LogSubscription from '../../../../src/subscriptions/eth/LogSubscription';
 import AbstractWeb3Module from '../../../__mocks__/AbstractWeb3Module';
 import GetPastLogsMethod from '../../../__mocks__/GetPastLogsMethod';
 import SocketProvider from '../../../__mocks__/SocketProvider';
 
 // Mocks
-jest.mock('web3-utils');
 jest.mock('web3-core-helpers');
 
 /**
@@ -14,6 +15,7 @@ jest.mock('web3-core-helpers');
  */
 describe('LogSubscriptionTest', () => {
     let logSubscription, moduleInstanceMock, getPastLogsMethodMock, socketProviderMock;
+    const logSubscriptionOptions = ['address', 'topics'];
 
     beforeEach(() => {
         moduleInstanceMock = new AbstractWeb3Module();
@@ -31,6 +33,8 @@ describe('LogSubscriptionTest', () => {
 
         expect(logSubscription.options).toEqual({});
 
+        expect(logSubscription.logSubscriptionOptions).toEqual(logSubscriptionOptions);
+
         expect(logSubscription.utils).toEqual(Utils);
 
         expect(logSubscription.moduleInstance).toEqual(moduleInstanceMock);
@@ -38,7 +42,13 @@ describe('LogSubscriptionTest', () => {
         expect(logSubscription.getPastLogsMethod).toEqual(getPastLogsMethodMock);
     });
 
+
     it('calls subscribe executes GetPastLogsMethod and calls the callback twice because of the past logs', (done) => {
+        const filters = {
+            fromBlock: 0,
+            toBlock: 1
+        };
+
         formatters.inputLogFormatter.mockReturnValueOnce({});
 
         formatters.outputLogFormatter.mockReturnValueOnce(0).mockReturnValueOnce('ITEM');
@@ -65,7 +75,7 @@ describe('LogSubscriptionTest', () => {
 
         let second = false;
         logSubscription.options.fromBlock = 0;
-        logSubscription.options.toBlock = 0;
+        logSubscription.options.toBlock = 1;
 
         const subscription = logSubscription.subscribe((error, response) => {
             let expectedResponse = 0;
@@ -76,17 +86,16 @@ describe('LogSubscriptionTest', () => {
                 expectedId = 'MY_ID';
 
                 expect(logSubscription.options.toBlock).toBeUndefined();
-
                 expect(logSubscription.options.fromBlock).toBeUndefined();
-            }
+            } else {}
 
             expect(error).toEqual(false);
 
             expect(response).toEqual(expectedResponse);
 
-            expect(formatters.inputLogFormatter).toHaveBeenCalledWith(logSubscription.options);
+            expect(formatters.inputLogFormatter).toHaveBeenCalledWith(filters);
 
-            expect(getPastLogsMethodMock.parameters).toEqual([{}]);
+            expect(getPastLogsMethodMock.parameters).toEqual([logSubscription.options]);
 
             expect(getPastLogsMethodMock.execute).toHaveBeenCalled();
 
@@ -102,13 +111,238 @@ describe('LogSubscriptionTest', () => {
         expect(subscription).toBeInstanceOf(LogSubscription);
     });
 
-    it('calls subscribe executes GetPastLogsMethod and the method throws an error', (done) => {
+    it('reject any extra parameter not valid for subscriptions after getPastLogsMethod call', (done) => {
+        const invalidOptionsForSubscriptions = {
+            blockHash: '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46',
+            fromBlock: 0,
+            toBlock: 10,
+            address: '0x161F8f25fa8132C572b234a5e19730d579A470fa',
+            topics: ['0xfd43ade1c09fade1c0d57a7af66ab4ead7c2c2eb7b11a91ffdd57a7af66ab4ead7']
+        }
+
+        const expectedOptions = {
+            address: '0x161F8f25fa8132C572b234a5e19730d579A470fa',
+            topics: ['0xfd43ade1c09fade1c0d57a7af66ab4ead7c2c2eb7b11a91ffdd57a7af66ab4ead7']
+        }
+
+        const optionsForLogs = logSubscription.rejectInvalidLogSubscriptions(invalidOptionsForSubscriptions)
+
+        expect(optionsForLogs).toEqual(expectedOptions);
+        done()
+    });
+
+
+    it('calling subscribe with ranges of blocks and blockHash should throws an error', (done) => {
+        logSubscription.options = {
+            blockHash: '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46',
+            fromBlock: 0,
+            toBlock: 10,
+            address: '0x161F8f25fa8132C572b234a5e19730d579A470fa',
+            topics: ['0xfd43ade1c09fade1c0d57a7af66ab4ead7c2c2eb7b11a91ffdd57a7af66ab4ead7']
+        }
+        const mockedResult = logSubscription.options;
+        formatters.inputLogFormatter.mockReturnValueOnce(mockedResult);
+        formatters.outputLogFormatter.mockReturnValueOnce('ITEM');
+
+        socketProviderMock.subscribe = jest.fn((type, method, parameters) => {
+            expect(type).toEqual('eth_subscribe');
+            expect(method).toEqual('logs');
+            expect(parameters).toEqual([logSubscription.options]);
+            return Promise.resolve('MY_ID');
+        });
+
+        socketProviderMock.on = jest.fn((subscriptionId, callback) => {
+            if (subscriptionId === 'MY_ID') {
+                callback('SUBSCRIPTION_ITEM');
+            }
+        });
+
+        moduleInstanceMock.currentProvider = socketProviderMock;
+        const errorMessage = "Validation error: BlockHash is present in the filter criteria, then neither fromBlock or toBlock are allowed."
+        const subscription = logSubscription.subscribe((error, response) => {
+            expect(error).toEqual(new Error(errorMessage));
+            expect(response).toEqual(null);
+            done();
+        });
+
+        expect(subscription).toBeInstanceOf(LogSubscription);
+
+    });
+
+    it('calling subscribe with array of addresses aren\'t valid should throws an error', (done) => {
+        const invalidAddresses = [
+            '0x000000000000000000000000000000000000000X',
+            '0x000000000000000000000000000000000000000Z'
+        ]
+        logSubscription.options.address = invalidAddresses
+        formatters.outputLogFormatter.mockReturnValueOnce('ITEM');
+
+        socketProviderMock.subscribe = jest.fn((type, method, parameters) => {
+            expect(type).toEqual('eth_subscribe');
+            expect(method).toEqual('logs');
+            expect(parameters).toEqual([logSubscription.options]);
+            return Promise.resolve('MY_ID');
+        });
+
+        socketProviderMock.on = jest.fn((subscriptionId, callback) => {
+            if (subscriptionId === 'MY_ID') {
+                callback('SUBSCRIPTION_ITEM');
+            }
+        });
+
+        moduleInstanceMock.currentProvider = socketProviderMock;
+        const errorMessage = `Validation error: Provided address ${invalidAddresses[0]} is invalid`
+        const subscription = logSubscription.subscribe((error, response) => {
+            expect(error).toEqual(new Error(errorMessage));
+            expect(response).toEqual(null);
+            done();
+        });
+
+        expect(subscription).toBeInstanceOf(LogSubscription);
+    });
+
+
+    it('calling subscribe with address invalid should throws an error', (done) => {
+        const invalidAddress = "0x7b2e64486cef2670c8a123ba87ab36941bc7XXXX";
+        logSubscription.options.address = invalidAddress
+        formatters.outputLogFormatter.mockReturnValueOnce('ITEM');
+
+        socketProviderMock.subscribe = jest.fn((type, method, parameters) => {
+            expect(type).toEqual('eth_subscribe');
+            expect(method).toEqual('logs');
+            expect(parameters).toEqual([logSubscription.options]);
+            return Promise.resolve('MY_ID');
+
+        });
+
+        socketProviderMock.on = jest.fn((subscriptionId, callback) => {
+            if (subscriptionId === 'MY_ID') {
+                callback('SUBSCRIPTION_ITEM');
+            }
+        });
+
+        moduleInstanceMock.currentProvider = socketProviderMock;
+
+        const errorMessage = `Validation error: Provided address ${invalidAddress} is invalid`
+        const subscription = logSubscription.subscribe((error, response) => {
+            expect(error).toEqual(new Error(errorMessage));
+            expect(response).toEqual(null);
+            done();
+        });
+
+        expect(subscription).toBeInstanceOf(LogSubscription);
+    });
+
+
+    it('should fail when calling subscribe with topics as string and not array', (done) => {
+        formatters.outputLogFormatter.mockReturnValueOnce('ITEM');
+
+        socketProviderMock.subscribe = jest.fn((type, method, parameters) => {
+            expect(type).toEqual('eth_subscribe');
+            expect(method).toEqual('logs');
+            expect(parameters).toEqual([logSubscription.options]);
+            return Promise.resolve('MY_ID');
+        });
+
+        socketProviderMock.on = jest.fn((subscriptionId, callback) => {
+            if (subscriptionId === 'MY_ID') {
+                callback('SUBSCRIPTION_ITEM');
+            }
+        });
+
+        moduleInstanceMock.currentProvider = socketProviderMock;
+
+        const topics = '0xfd43ade1c09fade1c0d57a7af66ab4ead7c2c2eb7b11a91ffdd57a7af66ab4ead7'
+        logSubscription.options = {
+            topics
+        }
+        const subscription = logSubscription.subscribe((error, response) => {
+            expect(error).toEqual(new Error('Validation error: topics need to be an array'));
+            expect(response).toEqual(null);
+            done();
+        });
+
+        expect(subscription).toBeInstanceOf(LogSubscription);
+    });
+
+    it('should fail when calling subscribe with topics not invalid', (done) => {
+        formatters.outputLogFormatter.mockReturnValueOnce('ITEM');
+
+        socketProviderMock.subscribe = jest.fn((type, method, parameters) => {
+            expect(type).toEqual('eth_subscribe');
+            expect(method).toEqual('logs');
+            expect(parameters).toEqual([logSubscription.options]);
+            return Promise.resolve('MY_ID');
+        });
+
+        socketProviderMock.on = jest.fn((subscriptionId, callback) => {
+            if (subscriptionId === 'MY_ID') {
+                callback('SUBSCRIPTION_ITEM');
+            }
+        });
+
+        moduleInstanceMock.currentProvider = socketProviderMock;
+        const invalidTopic = ['0xfd43ade1c09fade1c0d57a7af66ab4ead7c2c2eb7b11a91ffdd57a7af66ab4ead7XXX']
+        logSubscription.options = {
+            topics: invalidTopic
+        }
+        const errorMessage = `Validation error: Provided Topic ${invalidTopic} is invalid`
+        const subscription = logSubscription.subscribe((error, response) => {
+            expect(error).toEqual(new Error(errorMessage));
+            expect(response).toEqual(null);
+            done();
+            done()
+        });
+
+        expect(subscription).toBeInstanceOf(LogSubscription);
+    });
+
+    it('calling subscribe with only toBlock filter parameter should throws an error', (done) => {
+        formatters.inputLogFormatter.mockReturnValueOnce({});
+
+        logSubscription.options.toBlock = 1;
+        logSubscription.options.address = "0xb60e8dd61c5d32be8058bb8eb970870f07233155";
+
+        formatters.outputLogFormatter.mockReturnValueOnce('ITEM');
+
+        getPastLogsMethodMock.execute = jest.fn(() => {
+            return Promise.resolve([0]);
+        });
+
+        socketProviderMock.subscribe = jest.fn((type, method, parameters) => {
+            expect(type).toEqual('eth_subscribe');
+            expect(method).toEqual('logs');
+            expect(parameters).toEqual([logSubscription.options]);
+            return Promise.resolve('MY_ID');
+        });
+
+        socketProviderMock.on = jest.fn((subscriptionId, callback) => {
+            if (subscriptionId === 'MY_ID') {
+                callback('SUBSCRIPTION_ITEM');
+            }
+        });
+
+        moduleInstanceMock.currentProvider = socketProviderMock;
+        const errorMessage = 'Validation error: This option(s) are not valid <toBlock>'
+        const subscription = logSubscription.subscribe((error, response) => {
+            expect(error).toEqual(new Error(errorMessage));
+            expect(response).toEqual(null);
+            done();
+        });
+
+        expect(subscription).toBeInstanceOf(LogSubscription);
+
+    });
+
+    it('calls subscribe executes getPastLogsMethod and the method throws an error', (done) => {
+        const filters = {
+            fromBlock: 0
+        }
         formatters.inputLogFormatter.mockReturnValueOnce({});
 
         getPastLogsMethodMock.execute = jest.fn(() => {
             return Promise.reject(new Error('ERROR'));
         });
-
         logSubscription.options.fromBlock = 0;
         expect(
             logSubscription.subscribe((error, response) => {
@@ -116,7 +350,7 @@ describe('LogSubscriptionTest', () => {
 
                 expect(response).toEqual(null);
 
-                expect(formatters.inputLogFormatter).toHaveBeenCalledWith(logSubscription.options);
+                expect(formatters.inputLogFormatter).toHaveBeenCalledWith(filters);
 
                 expect(getPastLogsMethodMock.parameters).toEqual([{}]);
 
@@ -128,6 +362,10 @@ describe('LogSubscriptionTest', () => {
     });
 
     it('calls subscribe executes GetPastLogsMethod and emits the error event', (done) => {
+        const filters = {
+            fromBlock: 0
+        }
+
         formatters.inputLogFormatter.mockReturnValueOnce({});
 
         getPastLogsMethodMock.execute = jest.fn(() => {
@@ -141,7 +379,7 @@ describe('LogSubscriptionTest', () => {
         subscription.on('error', (error) => {
             expect(error).toEqual(new Error('ERROR'));
 
-            expect(formatters.inputLogFormatter).toHaveBeenCalledWith(logSubscription.options);
+            expect(formatters.inputLogFormatter).toHaveBeenCalledWith(filters);
 
             expect(getPastLogsMethodMock.parameters).toEqual([{}]);
 
@@ -210,24 +448,42 @@ describe('LogSubscriptionTest', () => {
     });
 
     it('calls onNewSubscriptionItem with removed set to true', (done) => {
-        formatters.outputLogFormatter.mockReturnValueOnce({removed: true});
+        formatters.outputLogFormatter.mockReturnValueOnce({
+            removed: true
+        });
 
         logSubscription.on('changed', (response) => {
-            expect(response).toEqual({removed: true});
+            expect(response).toEqual({
+                removed: true
+            });
 
-            expect(formatters.outputLogFormatter).toHaveBeenCalledWith({removed: false});
+            expect(formatters.outputLogFormatter).toHaveBeenCalledWith({
+                removed: false
+            });
 
             done();
         });
 
-        expect(logSubscription.onNewSubscriptionItem({removed: false})).toEqual({removed: true});
+        expect(logSubscription.onNewSubscriptionItem({
+            removed: false
+        })).toEqual({
+            removed: true
+        });
     });
 
     it('calls onNewSubscriptionItem with removed set to false', () => {
-        formatters.outputLogFormatter.mockReturnValueOnce({removed: true});
+        formatters.outputLogFormatter.mockReturnValueOnce({
+            removed: true
+        });
 
-        expect(logSubscription.onNewSubscriptionItem({removed: false})).toEqual({removed: true});
+        expect(logSubscription.onNewSubscriptionItem({
+            removed: false
+        })).toEqual({
+            removed: true
+        });
 
-        expect(formatters.outputLogFormatter).toHaveBeenCalledWith({removed: false});
+        expect(formatters.outputLogFormatter).toHaveBeenCalledWith({
+            removed: false
+        });
     });
 });


### PR DESCRIPTION
If we make and `get_logs` rpc,
 `myContract.events.allEvents({
        fromBlock: xBlock
        toBlock: yBlock 
    },
` 

After resolving events given this ranges of blocks, web3 only remove fromBlock property and send this as subscription for latest events `{"jsonrpc":"2.0","id":2,"method":"eth_subscribe","params":["logs",{"toBlock":"yBlock","topics":[],"address":"0x123...."}]} `, 
This request in many blockchains like Pantheon will rise an Invalid filter parameter, this filters need to be removed to be ok for all.

I tested this in Rinkeby test network And Pantheon from Pegasys, Geth, Ganache.
