### PR TITLE
convert salt to Buffer instance before encrypting

### DIFF
--- a/packages/web3-eth-accounts/src/models/Account.js
+++ b/packages/web3-eth-accounts/src/models/Account.js
@@ -160,13 +160,13 @@ export default class Account {
         if (kdf === 'pbkdf2') {
             kdfparams.c = options.c || 262144;
             kdfparams.prf = 'hmac-sha256';
-            derivedKey = pbkdf2Sync(Buffer.from(password), salt, kdfparams.c, kdfparams.dklen, 'sha256');
+            derivedKey = pbkdf2Sync(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.c, kdfparams.dklen, 'sha256');
         } else if (kdf === 'scrypt') {
             // FIXME: support progress reporting callback
             kdfparams.n = options.n || 8192; // 2048 4096 8192 16384
             kdfparams.r = options.r || 8;
             kdfparams.p = options.p || 1;
-            derivedKey = scrypt(Buffer.from(password), salt, kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
+            derivedKey = scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
         } else {
             throw new Error('Unsupported kdf');
         }


### PR DESCRIPTION
Previously, if a `salt` option was supplied it would be passed to `pbkdf2Sync`/`scrypt` as a string, but during decryption it was always converted to a Buffer instance such that supplying a `salt` option resulted in output that could not be decrypted.

This commit fixes the bug, and also makes encrypted output match up with the output of other wallet libraries, e.g.  `ethers`, whenever the equivalent encryption options are used consistently across libraries.