### PR TITLE
pickup latest fsevents (v1.2.9) for Node 12 compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5192,9 +5192,9 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
-            "integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
             "dev": true,
             "optional": true,
             "requires": {


### PR DESCRIPTION
fsevents is a transitive dependency by way of jest. `package-lock.json` was doing its job and preventing a bump to fsevents v1.2.9, i.e. even though the caret ranges for that dependency would allow for it.

Older versions of `fsevents` are not compatible with Node.js 12, so for this commit `package-lock.json` was manually bumped (resolved fsevents was removed from the file and then `npm install` was rerun).