### PR TITLE
implement fallback from built-in scrypt to scryptsy/scrypt packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pull request & issue templates updated
 - Supported node versions changed (#2820)
+- fsevents bumbed to v1.2.9 (#2951)
 
 ### Fixed
 
@@ -72,4 +73,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - miner.startMining fixed (#2877)
 - Subscription type definitions fixed (#2919)
 - ``ContractOptions`` type definitions corrected (#2939)
+- Scrypt compatibility with older and newer nodejs versions fixed (#2952)
+- Encryption of the V3Keystore fixed (#2950)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pull request & issue templates updated
 - Supported node versions changed (#2820)
-- fsevents bumbed to v1.2.9 (#2951)
 
 ### Fixed
 
@@ -67,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Length check of the PK added to the ``fromPrivateKey`` method of the ``Account`` model (#2928)
+
+### Changed
+
+- fsevents bumbed to v1.2.9 (#2951)
 
 ### Fixed
 

--- a/packages/web3-eth-accounts/src/crypto/Scrypt.js
+++ b/packages/web3-eth-accounts/src/crypto/Scrypt.js
@@ -5,26 +5,64 @@ let scrypt;
 const isNode = Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
 if (isNode) {
     const NODE_MIN_VER_WITH_BUILTIN_SCRYPT = '10.5.0';
+    const NODE_MIN_VER_INCOMPAT_SCRYPT_PKG = '12.0.0';
     const semver = require('semver');
     const useNodeBuiltin = isNode && semver.Range('>=' + NODE_MIN_VER_WITH_BUILTIN_SCRYPT).test(process.version);
 
+    const tryScryptPackage = (function() {
+        let scryptPackage;
+        return function() {
+            if (scryptPackage !== undefined) {
+                return scryptPackage;
+            }
+            try {
+                scryptPackage = require('scrypt');
+            } catch (error) {
+                if (/was compiled against a different/.test(error.message)) {
+                    throw error;
+                }
+                scryptPackage = null;
+            }
+            return scryptPackage;
+        };
+    })();
+
+    const canImprove = function(nodeVer) {
+        return `can improve web3's peformance when running Node.js versions older than ${nodeVer} by installing the (deprecated) scrypt package in your project`;
+    };
+
     if (useNodeBuiltin) {
         const crypto = require('crypto');
+        let fallbackCount = 0;
         scrypt = function(key, salt, N, r, p, dkLength) {
-            return crypto.scryptSync(key, salt, dkLength, {N, r, p});
+            try {
+                return crypto.scryptSync(key, salt, dkLength, {N, r, p});
+            } catch (error) {
+                if (/scrypt:memory limit exceeded/.test(error.message)) {
+                    const scryptPackage = tryScryptPackage();
+                    if (scryptPackage) {
+                        return scryptPackage.hashSync(key, {N: N, r: r, p: p}, dkLength, salt);
+                    }
+                    fallbackCount += 1;
+                    console.warn(
+                        '\u001B[33m%s\u001B[0m',
+                        `Memory limit exceeded for Node's built-in crypto.scrypt, falling back to scryptsy (times: ${fallbackCount}), if this happens frequently you ${canImprove(
+                            NODE_MIN_VER_INCOMPAT_SCRYPT_PKG
+                        )}`
+                    );
+                    return scryptsy(key, salt, N, r, p, dkLength);
+                }
+                throw error;
+            }
         };
     } else {
-        let scryptPackage;
-        try {
-            scryptPackage = require('scrypt');
+        const scryptPackage = tryScryptPackage();
+        if (scryptPackage) {
             scrypt = function(key, salt, N, r, p, dkLength) {
                 return scryptPackage.hashSync(key, {N, r, p}, dkLength, salt);
             };
-        } catch (error) {
-            console.warn(
-                '\u001B[33m%s\u001B[0m',
-                `You can improve web3's peformance when running Node.js versions older than ${NODE_MIN_VER_WITH_BUILTIN_SCRYPT} by installing the (deprecated) scrypt package in your project`
-            );
+        } else {
+            console.warn('\u001B[33m%s\u001B[0m', `You ${canImprove(NODE_MIN_VER_WITH_BUILTIN_SCRYPT)}`);
         }
     }
 }


### PR DESCRIPTION
This commit introduces an additional fallback behavior and console warning in the case that Node's built-in scrypt experiences memory exhaustion, as was discovered in the 1.x test suite with the static tests (see #2938). A large `n` parameter is the culprit, but that's not the case when using the 3rd party (deprecated) scrypt package. The `scryptsy` package can handle a large `n`, but performance does suffer considerably.