### PR TITLE
Callback Context Parameter

### DIFF
--- a/packages/web3-core-method/lib/methods/AbstractMethod.js
+++ b/packages/web3-core-method/lib/methods/AbstractMethod.js
@@ -84,7 +84,7 @@ export default class AbstractMethod {
             );
 
             if (this.callback) {
-                this.callback(error, null);
+                this.callback(error, null, this.context);
 
                 return;
             }
@@ -100,7 +100,7 @@ export default class AbstractMethod {
             }
 
             if (this.callback) {
-                this.callback(false, response);
+                this.callback(false, response, this.context);
 
                 return;
             }
@@ -108,7 +108,7 @@ export default class AbstractMethod {
             return response;
         } catch (error) {
             if (this.callback) {
-                this.callback(error, null);
+                this.callback(error, null, this.context);
 
                 return;
             }
@@ -206,6 +206,28 @@ export default class AbstractMethod {
     }
 
     /**
+     * Getter for the context property
+     *
+     * @property context 
+     *
+     * @returns {any}
+     */
+    get context() {
+        return this._arguments.context;
+    }
+
+    /**
+     * Setter for the context property
+     *
+     * @property context 
+     *
+     * @param {context} value
+     */
+    set context(value) {
+        this._arguments.context = value;
+    }
+
+    /**
      * Setter for the arguments property
      *
      * @method setArguments
@@ -215,16 +237,21 @@ export default class AbstractMethod {
     setArguments(methodArguments) {
         let parameters = cloneDeep([...methodArguments]);
         let callback = null;
+        let context = null;
 
         if (parameters.length > this.parametersAmount) {
-            if (!isFunction(parameters[parameters.length - 1])) {
-                throw new TypeError("The latest parameter should be a function otherwise it can't be used as callback");
+            if (isFunction(parameters[parameters.length - 2])) {
+                context = parameters.pop();
+                callback = parameters.pop();
+            } else if (isFunction(parameters[parameters.length - 1])) {
+                callback = parameters.pop();
+            } else {
+                throw new TypeError("The last parameter should be a function otherwise it can't be used as callback."); // TODO
             }
-
-            callback = parameters.pop();
         }
 
         this._arguments = {
+            context,
             callback,
             parameters
         };

--- a/packages/web3-core-method/tests/lib/methods/AbstractMethodTest.js
+++ b/packages/web3-core-method/tests/lib/methods/AbstractMethodTest.js
@@ -23,6 +23,7 @@ describe('AbstractMethodTest', () => {
 
         abstractMethod = new AbstractMethod('RPC_TEST', 0, Utils, formatters, moduleInstanceMock);
         abstractMethod.callback = false;
+        abstractMethod.context = false;
         abstractMethod.beforeExecution = jest.fn();
     });
 
@@ -40,6 +41,8 @@ describe('AbstractMethodTest', () => {
         expect(abstractMethod.parameters).toEqual([]);
 
         expect(abstractMethod.callback).toEqual(false);
+        
+        expect(abstractMethod.context).toEqual(false);
     });
 
     it('setArguments throws error on missing arguments', () => {
@@ -60,6 +63,12 @@ describe('AbstractMethodTest', () => {
         } catch (error) {
             expect(error).toBeInstanceOf(Error);
         }
+        
+        try {
+            abstractMethod.setArguments([true, true, true]);
+        } catch (error) {
+            expect(error).toBeInstanceOf(Error);
+        }
     });
 
     it('set arguments without callback', () => {
@@ -69,6 +78,8 @@ describe('AbstractMethodTest', () => {
         expect(abstractMethod.parameters).toEqual([true]);
 
         expect(abstractMethod.callback).toEqual(null);
+        
+        expect(abstractMethod.context).toEqual(null);
     });
 
     it('set arguments with callback', () => {
@@ -78,13 +89,26 @@ describe('AbstractMethodTest', () => {
         expect(abstractMethod.parameters).toEqual([true]);
 
         expect(abstractMethod.callback).toBeInstanceOf(Function);
+        
+        expect(abstractMethod.context).toEqual(null);
+    });
+
+    it('set arguments with callback and context', () => {
+        abstractMethod.parametersAmount = 1;
+        abstractMethod.setArguments([true, () => {}, {}]);
+
+        expect(abstractMethod.parameters).toEqual([true]);
+
+        expect(abstractMethod.callback).toBeInstanceOf(Function);
+        
+        expect(abstractMethod.context).toEqual({});
     });
 
     it('get arguments', () => {
         abstractMethod.parametersAmount = 1;
         abstractMethod.setArguments([true]);
 
-        expect(abstractMethod.getArguments()).toEqual({callback: null, parameters: [true]});
+        expect(abstractMethod.getArguments()).toEqual({context: null, callback: null, parameters: [true]});
     });
 
     it('set rpcMethod', () => {
@@ -103,6 +127,12 @@ describe('AbstractMethodTest', () => {
         abstractMethod.callback = () => {};
 
         expect(abstractMethod.callback).toBeInstanceOf(Function);
+    });
+
+    it('set context', () => {
+        abstractMethod.context = {};
+
+        expect(abstractMethod.context).toEqual({});
     });
 
     it('check if execute method exists', () => {


### PR DESCRIPTION
<!-- 

Release PR: 

1. Create the desired compare view 
   (e.g.: https://github.com/ethereum/web3.js/compare/2.x...1.x)

2. Add the template query to the URL "?template=release.md" 
   (e.g.: https://github.com/ethereum/web3.js/compare/2.x...1.x?template=release.md)
   
3. Press "Create pull request"

-->

## Description

The `AbtractMethod` class also carries a `context` parameter which is passed to the callback on execution.

Addresses #2923. 

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix 
- [ ] New feature 
- [ ] Breaking change
- [x] Enhancement

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no warnings.
- [ ] I have updated or added types for all modules I've changed
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run lint``` in the root folder with success and pushed the changes.
- [ ] I ran ```npm run test``` in the root folder with success and extended the tests to cover my changes.
- [ ] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [ ] I ran ```npm run dtslint``` in the root folder and tested that all my types are correct
- [ ] I have tested my code on an ethereum test network.