### PR TITLE
Fix Web3 image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-<img src="https://github.com/ethereum/web3.js/raw/1.0/web3js.jpg" width=200 />
+<img src="https://github.com/ethereum/web3.js/raw/1.x/web3js.jpg" width=200 />
 
 # web3.js - Ethereum JavaScript API
 


### PR DESCRIPTION
The image in README previously pointed to `1.0` branch which doesn't exist anymore. I updated it to `1.x` which is now correct.