### PR TITLE
stripHexPrefix fixed

### DIFF
--- a/packages/web3-utils/src/Utils.js
+++ b/packages/web3-utils/src/Utils.js
@@ -118,12 +118,12 @@ export const isAddress = (address, chainId = null) => {
  *
  * @method stripHexPrefix
  *
- * @param {string} address
+ * @param {string} string
  *
  * @returns {string} address without prefix
  */
 export const stripHexPrefix = (string) => {
-    return string.slice(0, 2) === '0x' ? string.slice(2) : string;
+    return string.startsWith('0x') || string.startsWith('0X') ? string.slice(2) : string;
 };
 
 /**


### PR DESCRIPTION
If the hex prefix (``0x``) was given as upper case chars did ``stripHexPrefix`` return it without the removed prefix.