### PR TITLE
Release - 2.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BatchRequest error handling fixed for callbacks (#2993)
 - ``reconnected`` event and reconnection timeout option added to WebsocketProvider (#2994)
 - ``clearSubscriptions`` fixed (#3007)
+
+## [Unreleased]
+
+## [2.0.0-alpha.2]

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-alpha",
+  "version": "2.0.0-alpha.1",
   "lerna": "2.0.0",
   "command": {
     "init": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "web3",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Ethereum JavaScript API wrapper repository",
     "license": "LGPL-3.0",
     "engines": {

--- a/packages/web3-core-helpers/package.json
+++ b/packages/web3-core-helpers/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-core-helpers",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 core tools helper for sub packages. This is an internal package.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-core-helpers",
     "license": "LGPL-3.0",
@@ -21,9 +21,9 @@
     "dependencies": {
         "@babel/runtime": "^7.3.1",
         "lodash": "^4.17.11",
-        "web3-core": "2.0.0-alpha",
-        "web3-eth-iban": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-eth-iban": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -33,5 +33,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-core-method/package.json
+++ b/packages/web3-core-method/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-core-method",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Handles the JSON-RPC methods. This package is also internally used by web3.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-core-method",
     "license": "LGPL-3.0",
@@ -24,19 +24,19 @@
         "eventemitter3": "3.1.0",
         "lodash": "^4.17.11",
         "rxjs": "^6.4.0",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-subscriptions": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-subscriptions": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
         "dtslint": "0.4.2",
-        "web3-providers": "2.0.0-alpha"
+        "web3-providers": "2.0.0-alpha.1"
     },
     "files": [
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-core-subscriptions/package.json
+++ b/packages/web3-core-subscriptions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-core-subscriptions",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Manages web3 subscriptions. This is an internal package.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-core-subscriptions",
     "license": "LGPL-3.0",
@@ -25,11 +25,11 @@
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
         "dtslint": "0.4.2",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "files": [
         "dist"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-core",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 core tools for sub packages. This is an internal package.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-core",
     "license": "LGPL-3.0",
@@ -23,9 +23,9 @@
         "@types/bn.js": "^4.11.4",
         "@types/node": "^12.6.1",
         "lodash": "^4.17.11",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -35,5 +35,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-abi",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module encode and decode EVM in/output.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-abi",
     "license": "LGPL-3.0",
@@ -22,7 +22,7 @@
         "@babel/runtime": "^7.3.1",
         "ethers": "^4.0.27",
         "lodash": "^4.17.11",
-        "web3-utils": "2.0.0-alpha"
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -32,5 +32,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-accounts",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to generate Ethereum accounts and sign data and transactions.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-accounts",
     "license": "LGPL-3.0",
@@ -28,11 +28,11 @@
         "scryptsy": "2.1.0",
         "semver": "6.2.0",
         "uuid": "3.3.2",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -42,5 +42,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-admin/package.json
+++ b/packages/web3-eth-admin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-admin",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-admin",
     "license": "LGPL-3.0",
@@ -20,12 +20,12 @@
     "types": "types/index.d.ts",
     "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -35,5 +35,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-contract",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with Ethereum smart contracts.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-contract",
     "license": "LGPL-3.0",
@@ -22,14 +22,14 @@
         "@babel/runtime": "^7.3.1",
         "@types/bn.js": "^4.11.4",
         "lodash": "^4.17.11",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-core-subscriptions": "2.0.0-alpha",
-        "web3-eth-abi": "2.0.0-alpha",
-        "web3-eth-accounts": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-core-subscriptions": "2.0.0-alpha.1",
+        "web3-eth-abi": "2.0.0-alpha.1",
+        "web3-eth-accounts": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -39,5 +39,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-debug/package.json
+++ b/packages/web3-eth-debug/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-debug",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-debug",
     "license": "LGPL-3.0",
@@ -20,12 +20,12 @@
     "types": "types/index.d.ts",
     "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -35,5 +35,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth-ens",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "ENS support for web3.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-ens",
     "license": "LGPL-3.0",
@@ -21,15 +21,15 @@
         "@babel/runtime": "^7.3.1",
         "eth-ens-namehash": "2.0.8",
         "lodash": "^4.17.11",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-eth-abi": "2.0.0-alpha",
-        "web3-eth-accounts": "2.0.0-alpha",
-        "web3-eth-contract": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-eth-abi": "2.0.0-alpha.1",
+        "web3-eth-accounts": "2.0.0-alpha.1",
+        "web3-eth-contract": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -39,5 +39,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-iban",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "This package converts Ethereum addresses to IBAN addresses a vice versa.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-iban",
     "license": "LGPL-3.0",
@@ -21,7 +21,7 @@
     "dependencies": {
         "@babel/runtime": "^7.3.1",
         "bn.js": "4.11.8",
-        "web3-utils": "2.0.0-alpha"
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -31,5 +31,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-miner/package.json
+++ b/packages/web3-eth-miner/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-miner",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-miner",
     "engines": {
@@ -20,12 +20,12 @@
     "types": "types/index.d.ts",
     "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -35,5 +35,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-personal",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-personal",
     "engines": {
@@ -20,13 +20,13 @@
     "types": "types/index.d.ts",
     "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-eth-accounts": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-eth-accounts": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -36,5 +36,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth-txpool/package.json
+++ b/packages/web3-eth-txpool/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth-txpool",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth-txpool",
     "engines": {
@@ -20,12 +20,12 @@
     "types": "types/index.d.ts",
     "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -35,5 +35,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-eth",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-eth",
     "license": "LGPL-3.0",
@@ -22,19 +22,19 @@
         "@babel/runtime": "^7.3.1",
         "ethereumjs-tx": "^1.3.7",
         "rxjs": "^6.4.0",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-core-subscriptions": "2.0.0-alpha",
-        "web3-eth-abi": "2.0.0-alpha",
-        "web3-eth-accounts": "2.0.0-alpha",
-        "web3-eth-contract": "2.0.0-alpha",
-        "web3-eth-ens": "2.0.0-alpha",
-        "web3-eth-iban": "2.0.0-alpha",
-        "web3-eth-personal": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-core-subscriptions": "2.0.0-alpha.1",
+        "web3-eth-abi": "2.0.0-alpha.1",
+        "web3-eth-accounts": "2.0.0-alpha.1",
+        "web3-eth-contract": "2.0.0-alpha.1",
+        "web3-eth-ens": "2.0.0-alpha.1",
+        "web3-eth-iban": "2.0.0-alpha.1",
+        "web3-eth-personal": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -44,5 +44,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-net",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Ethereum nodes networking properties.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-net",
     "engines": {
@@ -21,11 +21,11 @@
     "dependencies": {
         "@babel/runtime": "^7.3.1",
         "lodash": "^4.17.11",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -35,5 +35,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-providers/lib/providers/AbstractSocketProvider.js
+++ b/packages/web3-providers/lib/providers/AbstractSocketProvider.js
@@ -67,8 +67,7 @@ export default class AbstractSocketProvider extends EventEmitter {
      *
      * @method registerEventListeners
      */
-    registerEventListeners() {
-    }
+    registerEventListeners() {}
 
     /**
      * Removes all socket listeners
@@ -91,8 +90,7 @@ export default class AbstractSocketProvider extends EventEmitter {
      * @param {Number} code
      * @param {String} reason
      */
-    disconnect(code, reason) {
-    }
+    disconnect(code, reason) {}
 
     /**
      * Returns true if the socket is connected
@@ -101,8 +99,7 @@ export default class AbstractSocketProvider extends EventEmitter {
      *
      * @returns {Boolean}
      */
-    get connected() {
-    }
+    get connected() {}
 
     /**
      * Creates the JSON-RPC payload and sends it to the node.

--- a/packages/web3-providers/package.json
+++ b/packages/web3-providers/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-providers",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to handle requests to external providers.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-providers",
     "license": "LGPL-3.0",
@@ -24,10 +24,10 @@
         "eventemitter3": "3.1.0",
         "lodash": "^4.17.11",
         "url-parse": "1.4.4",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha",
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1",
         "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis",
         "xhr2-cookies": "1.1.0"
     },
@@ -39,5 +39,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-shh/package.json
+++ b/packages/web3-shh/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-shh",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Web3 module to interact with the Whisper messaging protocol.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-shh",
     "engines": {
@@ -20,13 +20,13 @@
     },
     "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "web3-core": "2.0.0-alpha",
-        "web3-core-helpers": "2.0.0-alpha",
-        "web3-core-method": "2.0.0-alpha",
-        "web3-core-subscriptions": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-core-helpers": "2.0.0-alpha.1",
+        "web3-core-method": "2.0.0-alpha.1",
+        "web3-core-subscriptions": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -36,5 +36,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3-utils",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Collection of utility functions used in web3.js.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3-utils",
     "license": "LGPL-3.0",
@@ -39,5 +39,5 @@
         "dist",
         "types/index.d.ts"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3/package-lock.json
+++ b/packages/web3/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "2.0.0-alpha",
+	"version": "2.0.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -62,13 +62,13 @@
     "dependencies": {
         "@babel/runtime": "^7.3.1",
         "@types/node": "^12.6.1",
-        "web3-core": "2.0.0-alpha",
-        "web3-eth": "2.0.0-alpha",
-        "web3-eth-personal": "2.0.0-alpha",
-        "web3-net": "2.0.0-alpha",
-        "web3-providers": "2.0.0-alpha",
-        "web3-shh": "2.0.0-alpha",
-        "web3-utils": "2.0.0-alpha"
+        "web3-core": "2.0.0-alpha.1",
+        "web3-eth": "2.0.0-alpha.1",
+        "web3-eth-personal": "2.0.0-alpha.1",
+        "web3-net": "2.0.0-alpha.1",
+        "web3-providers": "2.0.0-alpha.1",
+        "web3-shh": "2.0.0-alpha.1",
+        "web3-utils": "2.0.0-alpha.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
@@ -79,5 +79,5 @@
         "types/index.d.ts",
         "angular-patch.js"
     ],
-    "gitHead": "a09d2cc84c1f08aa673028cc7c517d40a1f72972"
+    "gitHead": "cb266cc298150f4eb1c8cdac4f41551dd8819a81"
 }

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3",
     "namespace": "ethereum",
-    "version": "2.0.0-alpha",
+    "version": "2.0.0-alpha.1",
     "description": "Ethereum JavaScript API",
     "repository": "https://github.com/ethereum/web3.js/tree/1.0/packages/web3",
     "license": "LGPL-3.0",


### PR DESCRIPTION
## Description

#### Added

- Length check of the PK added to the ``fromPrivateKey`` method of the ``Account`` model (#2928)
- WebsocketProvider options extended with ``requestOptions`` and ``origins`` (#2938, #2995)
- ``changed`` listener added to Contract event subscriptions (#2960)

#### Changed

- fsevents bumbed to v1.2.9 (#2951)
- ``websocket`` dependency changed to github fork (#2995)

#### Fixed

- miner.startMining fixed (#2877)
- Subscription type definitions fixed (#2919)
- ``ContractOptions`` type definitions corrected (#2939)
- Scrypt compatibility with older and newer nodejs versions fixed (#2952)
- Encryption of the V3Keystore fixed (#2950)
- Provider timeout fixed and Maps are used now to handle subscriptions (#2955)
- stripHexPrefix fixed (#2989)
- BatchRequest error handling fixed for callbacks (#2993)
- ``reconnected`` event and reconnection delay option added to WebsocketProvider (#2994)
- ``clearSubscriptions`` fixed (#3007)


### Compare View

[v2.0.0-alpha -> v2.0.0-alpha.1](https://github.com/ethereum/web3.js/compare/v2.0.0-alpha...55a6a9f)

## Type of change

- [X] Release

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code. 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no warnings.
- [x] I have updated or added types for all modules I've changed
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` in the root folder with success and extended the tests to cover all changes.
- [x] I ran ```npm run build``` in the root folder and tested it in the browser and with node.
- [x] I have tested my code with an ethereum test network.