### PR TITLE
adding FUNDING.yml through Unlock

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://donate.unlock-protocol.com/?r=ethereum/web3.js

--- a/.unlock-protocol.config.json
+++ b/.unlock-protocol.config.json
@@ -1,0 +1,14 @@
+{
+   "persistentCheckout": true,
+   "icon": "https://raw.githubusercontent.com/ethereum/web3.js/2.x/assets/web3js.jpg",
+   "callToAction": {
+     "default": "Please, support our work by purchasing a key to our supporters lock. You will receive a unique Web3.js Non Fungible Token!",
+     "pending": "Thank you for your support. It means a lot to us!",
+     "confirmed": "Thank you for your support. It means a lot to us!"
+   },
+   "locks": {
+     "0xe8846DE6aAF1B50A3e300cc2AB568D544709385B": {
+       "name": "Web3.js Supporters"
+     }
+   }
+ }


### PR DESCRIPTION
Hello!

First of all, thanks for your (hard) work!

As an OpenSource project, I believe Web3.js should have a `FUNDING.yml` file which lets people make donations if they enjoy the software.

This pull requests adds donation thru an [Unlock](https://unlock-protocol.com/) lock. Locks are smart contract which let people become members by purchasing a key. The key itself is a non fungible token: 🗝 . (you can view the NFT on [OpenSea](https://opensea.io/assets/0x0364c5d9c268a1870f49ad2819801624d8ce0ff0/1) for example)

This specific lock is at [`0xe8846de6aaf1b50a3e300cc2ab568d544709385b`](https://etherscan.io/address/0xe8846de6aaf1b50a3e300cc2ab568d544709385b). The current key price is 1 DAI. I currently own the lock but I'll happily transfer its ownership to you if you can send me an address ;) Keys are valid for 1 month and there can be an infinite number of keys.

The pull-request adds 2 files: `FUNDING.yml` which is a github standard file to add a "donation button" with the right links when people click on it and a file which includes the configuration for the donation page.

Here is what it looks like 
<img width="814" alt="image" src="https://user-images.githubusercontent.com/17735/63722140-940e8900-c820-11e9-9c1d-0372b122e76e.png">

You can try this on another project which already uses the donation button such as [Unlock](https://github.com/unlock-protocol/unlock/), [MyCrypto](https://github.com/mycryptohq/mycrypto), or [WalletConnect](https://github.com/WalletConnect/walletconnect-monorepo/)...

When/if you merge this you also need to enable donations in the settings (see https://github.com/ethereum/web3.js/settings): 

<img width="747" alt="image" src="https://user-images.githubusercontent.com/17735/63268593-88d8bd80-c262-11e9-92f7-2d458c07e74f.png">





