### PR TITLE
correct getPendingTransactions for Typescript

### DIFF
--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -114,6 +114,8 @@ export class Eth extends AbstractWeb3Module {
 
     getTransaction(transactionHash: string, callback?: (error: Error, transaction: Transaction) => void): Promise<Transaction>;
 
+    getPendingTransactions(callback?: (error: Error, result: []) => void): Promise<[]>;
+
     getTransactionFromBlock(hashStringOrNumber: string | number, indexNumber: number, callback?: (error: Error, transaction: Transaction) => void): Promise<Transaction>;
 
     getTransactionReceipt(hash: string, callback?: (error: Error, transactionReceipt: TransactionReceipt) => void): Promise<TransactionReceipt>;
@@ -145,8 +147,6 @@ export class Eth extends AbstractWeb3Module {
     getWork(callback?: (error: Error, result: string[]) => void): Promise<string[]>;
 
     submitWork(data: [string, string, string], callback?: (error: Error, result: boolean) => void): Promise<boolean>;
-
-    pendingTransactions(callback?: (error: Error, result: []) => void): Promise<[]>;
 
     getProof(address: string, storageKey: string[], blockNumber: number | string | "latest" | "earliest", callback?: (error: Error, result: GetProof) => void): Promise<GetProof>;
 }

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -114,7 +114,7 @@ export class Eth extends AbstractWeb3Module {
 
     getTransaction(transactionHash: string, callback?: (error: Error, transaction: Transaction) => void): Promise<Transaction>;
 
-    getPendingTransactions(callback?: (error: Error, result: []) => void): Promise<[]>;
+    getPendingTransactions(callback?: (error: Error, result: Transaction[]) => void): Promise<Transaction[]>;
 
     getTransactionFromBlock(hashStringOrNumber: string | number, indexNumber: number, callback?: (error: Error, transaction: Transaction) => void): Promise<Transaction>;
 

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -457,10 +457,10 @@ eth.submitWork(
 );
 
 // $ExpectType Promise<[]>
-eth.pendingTransactions();
+eth.getPendingTransactions();
 
 // $ExpectType Promise<[]>
-eth.pendingTransactions((error: Error, result: []) => {});
+eth.getPendingTransactions((error: Error, result: []) => {});
 
 // $ExpectType Promise<GetProof>
 eth.getProof(

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -456,11 +456,11 @@ eth.submitWork(
     (error: Error, result: boolean) => {}
 );
 
-// $ExpectType Promise<[]>
+// $ExpectType Promise<Transaction[]>
 eth.getPendingTransactions();
 
-// $ExpectType Promise<[]>
-eth.getPendingTransactions((error: Error, result: []) => {});
+// $ExpectType Promise<Transaction[]>
+eth.getPendingTransactions((error: Error, result: Transaction[]) => {});
 
 // $ExpectType Promise<GetProof>
 eth.getProof(


### PR DESCRIPTION
There is no function called `pendingTransactions ` but `getPendingTransactions` according to https://github.com/ethereum/web3.js/blob/2.x/packages/web3-eth/src/factories/MethodFactory.js#L90