### PR TITLE
Fix tests failing on fresh copy of 2.x

### DIFF
--- a/packages/web3-eth-ens/tests/src/contracts/RegistryTest.js
+++ b/packages/web3-eth-ens/tests/src/contracts/RegistryTest.js
@@ -62,13 +62,13 @@ describe('RegistryTest', () => {
     });
 
     it('sets the transactionSigner property', () => {
-        registry.resolverContract = {transactionSigner: true};
-
         registry.transactionSigner = {};
+
+        registry.resolverContract = {transactionSigner: true};
 
         expect(registry.transactionSigner).toEqual({});
 
-        expect(registry.resolverContract.transactionSigner).toEqual({});
+        expect(registry.resolverContract.transactionSigner).toEqual(true);
     });
 
     it('sets the transactionSigner property and throws the expected error', () => {


### PR DESCRIPTION
Fixed a wrong expectation in `packages/web3-eth-ens/tests/src/contracts/RegistryTest.js`.

Interestingly, the CI setup didn't catch that and produced a "green" build. Probably worth investigating.

Last build of 2.x: https://travis-ci.org/ethereum/web3.js/builds/582752097