### PR TITLE
Allow 0 fromBlock, toBlock values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,5 +56,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix allow `0` as a valid `fromBlock` or `toBlock` filter param (#1100)
 - regeneratorRuntime error fixed (#3058)
 - Fix accessing event.name where event is undefined (#3014)

--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -279,10 +279,10 @@ var inputLogFormatter = function(options) {
             return utils.fromUtf8(value);
     };
 
-    if (options.fromBlock)
+    if (options.fromBlock || options.fromBlock === 0)
         options.fromBlock = inputBlockNumberFormatter(options.fromBlock);
 
-    if (options.toBlock)
+    if (options.toBlock || options.toBlock === 0)
         options.toBlock = inputBlockNumberFormatter(options.toBlock);
 
 

--- a/test/formatters.inputLogFormatter.js
+++ b/test/formatters.inputLogFormatter.js
@@ -1,0 +1,108 @@
+var chai = require('chai');
+var assert = chai.assert;
+var formatters = require('../packages/web3-core-helpers/src/formatters.js');
+
+describe('InputLogFormatterTest', function() {
+
+    it('call inputLogFormatter with a valid log', function() {
+        var log = {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: ['0x0'],
+            address: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+        };
+
+        assert.deepEqual(formatters.inputLogFormatter(log), {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: ['0x0'],
+            address: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        });
+    });
+
+    it('call inputLogFormatter with numerical from/to blocks', function() {
+        var log = {
+            fromBlock: 1,
+            toBlock: 2,
+            topics: ['0x0'],
+            address: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+        };
+
+        assert.deepEqual(formatters.inputLogFormatter(log), {
+            fromBlock: '0x1',
+            toBlock: '0x2',
+            topics: ['0x0'],
+            address: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        });
+    });
+
+    it('call inputLogFormatter with zero valued from/to blocks', function() {
+        var log = {
+            fromBlock: 0,
+            toBlock: 0,
+            topics: ['0x0'],
+            address: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+        };
+
+        assert.deepEqual(formatters.inputLogFormatter(log), {
+            fromBlock: '0x0',
+            toBlock: '0x0',
+            topics: ['0x0'],
+            address: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        });
+    });
+
+    it('call inputLogFormatter with a array of addresses in the log', function() {
+        var log = {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: ['0x0'],
+            address: [
+                '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078',
+                '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+            ]
+        };
+
+        assert.deepEqual(formatters.inputLogFormatter(log), {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: ['0x0'],
+            address: [
+                '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+                '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+            ]
+        });
+    });
+
+    it('call inputLogFormatter with an topic item of null', function() {
+        var log = {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: [null],
+            address: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+        };
+
+        assert.deepEqual(formatters.inputLogFormatter(log), {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: [null],
+            address: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        });
+    });
+
+    it('call inputLogFormatter with an topic item that does not start with "0x"', function() {
+        var log = {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: ['00'],
+            address: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+        };
+
+        assert.deepEqual(formatters.inputLogFormatter(log), {
+            fromBlock: 'earliest',
+            toBlock: 'latest',
+            topics: ['0x3030'],
+            address: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1100 for the 1.x branch. Also

+ Back-ports inputLogFormatter tests from the 2.x branch, 
+ Adds cases for zero valued `fromBlock`, `toBlock` filters.

If this PR looks correct, the 2.x branch will need also this fix plus these additional tests ported forward to [here](https://github.com/ethereum/web3.js/blob/2.x/packages/web3-core-helpers/src/Formatters.js#L361-L367)