### PR TITLE
Allow 'null' receipt.status values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,5 +56,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix error incorrectly thrown when receipt.status is `null` (#2183)
 - regeneratorRuntime error fixed (#3058)
 - Fix accessing event.name where event is undefined (#3014)

--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -216,7 +216,7 @@ var outputTransactionReceiptFormatter = function (receipt){
         receipt.contractAddress = utils.toChecksumAddress(receipt.contractAddress);
     }
 
-    if(typeof receipt.status !== 'undefined') {
+    if(typeof receipt.status !== 'undefined' && receipt.status !== null) {
         receipt.status = Boolean(parseInt(receipt.status));
     }
 

--- a/test/formatters.outputTransactionReceiptFormatter.js
+++ b/test/formatters.outputTransactionReceiptFormatter.js
@@ -104,4 +104,19 @@ describe('outputTransactionReceiptFormatter', function() {
 
         assert.equal(formatters.outputTransactionReceiptFormatter(receipt).status, undefined)
     });
+
+    it('call outputTransactionReceiptFormatter when status is "null"', function() {
+        var receipt = {
+            status: null,
+            cumulativeGasUsed: '0x100',
+            gasUsed: '0x100',
+            blockNumber: '0x100',
+            transactionIndex: '0xa',
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        };
+
+        assert.equal(formatters.outputTransactionReceiptFormatter(receipt).status, null)
+    });
 });

--- a/test/formatters.outputTransactionReceiptFormatter.js
+++ b/test/formatters.outputTransactionReceiptFormatter.js
@@ -1,0 +1,107 @@
+var assert = require('assert');
+var formatters = require('../packages/web3-core-helpers/src/formatters.js');
+
+describe('outputTransactionReceiptFormatter', function() {
+
+    it('call outputTransactionReceiptFormatter with a valid receipt', function() {
+        var receipt = {
+            status: '0x0',
+            cumulativeGasUsed: '0x100',
+            gasUsed: '0x100',
+            blockNumber: '0x100',
+            transactionIndex: '0xa',
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        };
+
+        assert.deepEqual(formatters.outputTransactionReceiptFormatter(receipt), {
+            status: false,
+            cumulativeGasUsed: 256,
+            gasUsed: 256,
+            blockNumber: 256,
+            transactionIndex: 10,
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078'
+        });
+    });
+
+    it('call outputTransactionReceiptFormatter with a valid receipt and logs', function() {
+        var receipt = {
+            status: '0x0',
+            cumulativeGasUsed: '0x100',
+            gasUsed: '0x100',
+            blockNumber: '0x100',
+            transactionIndex: '0xa',
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            logs: [{}]
+        };
+
+        assert.deepEqual(formatters.outputTransactionReceiptFormatter(receipt), {
+            status: false,
+            cumulativeGasUsed: 256,
+            gasUsed: 256,
+            blockNumber: 256,
+            transactionIndex: 10,
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03C9A938fF7f54090d0d99e2c6f80380510Ea078',
+            logs: [
+                {
+                    blockNumber: undefined,
+                    id: null,
+                    logIndex: undefined,
+                    transactionIndex: undefined
+                }
+            ]
+        });
+    });
+
+    it('call outputTransactionReceiptFormatter when status is "0x1"', function() {
+        var receipt = {
+            status: '0x1',
+            cumulativeGasUsed: '0x100',
+            gasUsed: '0x100',
+            blockNumber: '0x100',
+            transactionIndex: '0xa',
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        };
+
+        assert.equal(formatters.outputTransactionReceiptFormatter(receipt).status, true)
+    });
+
+    it('call outputTransactionReceiptFormatter when status is "0x01"', function() {
+        var receipt = {
+            status: '0x01',
+            cumulativeGasUsed: '0x100',
+            gasUsed: '0x100',
+            blockNumber: '0x100',
+            transactionIndex: '0xa',
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        };
+
+        assert.equal(formatters.outputTransactionReceiptFormatter(receipt).status, true)
+    });
+
+    it('call outputTransactionReceiptFormatter when status is "undefined"', function() {
+        var receipt = {
+            status: undefined,
+            cumulativeGasUsed: '0x100',
+            gasUsed: '0x100',
+            blockNumber: '0x100',
+            transactionIndex: '0xa',
+            to: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            from: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078',
+            contractAddress: '0x03c9a938ff7f54090d0d99e2c6f80380510ea078'
+        };
+
+        assert.equal(formatters.outputTransactionReceiptFormatter(receipt).status, undefined)
+    });
+});


### PR DESCRIPTION
Fixes #2183 and verifies that #2401 is fixed on 1.x.  

Back-ports 2.x `outputTransactionReceiptFormatter` tests and adding cases for statuses: 
+ `0x1`, 
+ `0x01` 
+ `undefined`
+ `null`

NB: `null` and `undefined` are passed through uninterpreted & unmodified. 
