### PR TITLE
feat(Network): add support for net id of Goerli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ``automine`` and ``Instant Seal`` support added (#2940)
 - Public API layer added to ``web3-core`` module (#3013)
+- getNetworkType method extended with Görli testnet (#3096)
 
 ### Changed
 

--- a/docs/web3-eth-net.rst
+++ b/docs/web3-eth-net.rst
@@ -38,6 +38,7 @@ Returns
     - ``"morden"`` for the morden test network
     - ``"rinkeby"`` for the rinkeby test network
     - ``"ropsten"`` for the ropsten test network
+    - ``"goerli"`` for the goerli test network
     - ``"kovan"`` for the kovan test network
     - ``"private"`` for undetectable networks.
 

--- a/packages/web3-net/src/Network.js
+++ b/packages/web3-net/src/Network.js
@@ -69,6 +69,9 @@ export default class Network extends AbstractWeb3Module {
                 case 4:
                     networkType = 'rinkeby';
                     break;
+                case 5:
+                    networkType = 'goerli';
+                    break;
                 case 42:
                     networkType = 'kovan';
                     break;

--- a/packages/web3-net/tests/src/NetworkTest.js
+++ b/packages/web3-net/tests/src/NetworkTest.js
@@ -102,6 +102,20 @@ describe('NetworkTest', () => {
         expect(network.getId).toHaveBeenCalled();
     });
 
+    it('calls getNetworkType and resolves to the network name "goerli', async () => {
+        const callback = jest.fn();
+
+        network.getId = jest.fn(() => {
+            return Promise.resolve(5);
+        });
+
+        await expect(network.getNetworkType(callback)).resolves.toEqual('goerli');
+
+        expect(callback).toHaveBeenCalledWith(null, 'goerli');
+
+        expect(network.getId).toHaveBeenCalled();
+    });
+
     it('calls getNetworkType and resolves to the network name "kovan', async () => {
         const callback = jest.fn();
 

--- a/packages/web3-net/tests/src/NetworkTest.js
+++ b/packages/web3-net/tests/src/NetworkTest.js
@@ -32,7 +32,7 @@ describe('NetworkTest', () => {
         expect(network).toBeInstanceOf(AbstractWeb3Module);
     });
 
-    it('calls getNetworkType and resolves to the network name "private', async () => {
+    it('calls getNetworkType and resolves to the network name "private"', async () => {
         const callback = jest.fn();
 
         network.getId = jest.fn(() => {
@@ -46,7 +46,7 @@ describe('NetworkTest', () => {
         expect(network.getId).toHaveBeenCalled();
     });
 
-    it('calls getNetworkType and resolves to the network name "main', async () => {
+    it('calls getNetworkType and resolves to the network name "main"', async () => {
         const callback = jest.fn();
 
         network.getId = jest.fn(() => {
@@ -60,7 +60,7 @@ describe('NetworkTest', () => {
         expect(network.getId).toHaveBeenCalled();
     });
 
-    it('calls getNetworkType and resolves to the network name "morden', async () => {
+    it('calls getNetworkType and resolves to the network name "morden"', async () => {
         const callback = jest.fn();
 
         network.getId = jest.fn(() => {
@@ -74,7 +74,7 @@ describe('NetworkTest', () => {
         expect(network.getId).toHaveBeenCalled();
     });
 
-    it('calls getNetworkType and resolves to the network name "ropsten', async () => {
+    it('calls getNetworkType and resolves to the network name "ropsten"', async () => {
         const callback = jest.fn();
 
         network.getId = jest.fn(() => {
@@ -88,7 +88,7 @@ describe('NetworkTest', () => {
         expect(network.getId).toHaveBeenCalled();
     });
 
-    it('calls getNetworkType and resolves to the network name "rinkeby', async () => {
+    it('calls getNetworkType and resolves to the network name "rinkeby"', async () => {
         const callback = jest.fn();
 
         network.getId = jest.fn(() => {
@@ -102,7 +102,7 @@ describe('NetworkTest', () => {
         expect(network.getId).toHaveBeenCalled();
     });
 
-    it('calls getNetworkType and resolves to the network name "goerli', async () => {
+    it('calls getNetworkType and resolves to the network name "goerli"', async () => {
         const callback = jest.fn();
 
         network.getId = jest.fn(() => {
@@ -116,7 +116,7 @@ describe('NetworkTest', () => {
         expect(network.getId).toHaveBeenCalled();
     });
 
-    it('calls getNetworkType and resolves to the network name "kovan', async () => {
+    it('calls getNetworkType and resolves to the network name "kovan"', async () => {
         const callback = jest.fn();
 
         network.getId = jest.fn(() => {


### PR DESCRIPTION
2.x Support for identification of Goerli test net via getNetworkType function and updated test case