### PR TITLE
Use eth_chainId when signing transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
-- Fix incorrectly populating chainId param with `net_version` when signing txs (#3097)
+- Fix incorrectly populating chainId param with `net_version` when signing txs (#2378)
 - regeneratorRuntime error fixed (#3058)
 - Fix accessing event.name where event is undefined (#3014)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,5 +56,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix incorrectly populating chainId param with `net_version` when signing txs (#3097)
 - regeneratorRuntime error fixed (#3058)
 - Fix accessing event.name where event is undefined (#3014)

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -69,7 +69,7 @@ var Accounts = function Accounts() {
     var _ethereumCall = [
         new Method({
             name: 'getId',
-            call: 'net_version',
+            call: 'eth_chainId',
             params: 0,
             outputFormatter: utils.hexToNumber
         }),

--- a/test/eth.accounts.signTransaction.js
+++ b/test/eth.accounts.signTransaction.js
@@ -495,7 +495,7 @@ describe("eth", function () {
                     provider.injectResult(1);
                     provider.injectValidation(function (payload) {
                         assert.equal(payload.jsonrpc, '2.0');
-                        assert.equal(payload.method, 'net_version');
+                        assert.equal(payload.method, 'eth_chainId');
                         assert.deepEqual(payload.params, []);
                     });
 
@@ -522,7 +522,7 @@ describe("eth", function () {
                     provider.injectResult(1);
                     provider.injectValidation(function (payload) {
                         assert.equal(payload.jsonrpc, '2.0');
-                        assert.equal(payload.method, 'net_version');
+                        assert.equal(payload.method, 'eth_chainId');
                         assert.deepEqual(payload.params, []);
                     });
                     provider.injectResult(1);

--- a/test/helpers/test.method.js
+++ b/test/helpers/test.method.js
@@ -10,10 +10,10 @@ var useLocalWallet = function (test, provider, web3) {
 
     test.useLocalWallet(web3);
 
-    provider.injectResult(1);
+    provider.injectResult("0x1");
     provider.injectValidation(function (payload) {
         assert.equal(payload.jsonrpc, '2.0');
-        assert.equal(payload.method, 'net_version');
+        assert.equal(payload.method, 'eth_chainId');
         assert.deepEqual(payload.params, []);
     });
 


### PR DESCRIPTION
Addresses #2378 and #1169 for the 1.x branch. Makes web3 conform to [EIP 155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md) and fetch chainId via `eth_chainId` instead of `net_version`. For ethereum public nets there's no problem here because network id == chain id. For ganache, ETC and possibly others - the two values are different. 

Note: these endpoints return their ids in different formats:

| Client       | net_version     | eth_chainId |
|--------------|-----------------|-------------|
| geth --dev   | "1337"          | "0x539"     |
| parity --dev | "17"            | "0x11"      |
| ganache-cli  | "1570135120814" | "0x539"     |

`eth_chainId` is not documented in the JSON_RPC spec. This is a case where it would be nice to have E2E tests vs the three main clients to be sure Web3's mocked responses correspond to reality. 

