### PR TITLE
Update web3.py link to active repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ npm run clean # removes all the node_modules folders in all modules
 
 
 ### Similar libraries in other languages
- - Python [Web3.py](https://github.com/pipermerriam/web3.py)
+ - Python [Web3.py](https://github.com/ethereum/web3.py)
  - Haskell [hs-web3](https://github.com/airalab/hs-web3)
  - Java [web3j](https://github.com/web3j/web3j)
  - Scala [web3j-scala](https://github.com/mslinn/web3j-scala)


### PR DESCRIPTION
`web3.py` link in Readme was linking to an outdated repository (`github.com/pipermerriam/web3.py`) - I updated the link to point to the active `web3.py` repository. 