### PR TITLE
Add eth.getChainId method to 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Released with 1.0.0-beta.37 code base.
 - localStorage support detection added (#3031)
 - getNetworkType method extended with Görli testnet (#3095)
 - supportsSubscriptions method added to providers (#3116)
+- Add `eth.getChainId` method (#3113)
 
 ### Fixed
 

--- a/docs/web3-eth-net.rst
+++ b/docs/web3-eth-net.rst
@@ -25,7 +25,7 @@ getNetworkType
 
 Guesses the chain the node is connected by comparing the genesis hashes.
 
-.. note:: This is not a 100% accurate guess as any private network could use testnet and mainnet genesis blocks and network IDs.
+.. note:: It's recommended to use the :ref:`web3.eth.getChainId <eth-chainId>` method to detect the currently connected chain.
 
 -------
 Returns

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -1467,3 +1467,31 @@ Example
 
 
 ------------------------------------------------------------------------------
+
+.. _eth-chainId:
+
+getChainId
+==========
+
+.. code-block:: javascript
+
+    web3.eth.getChainId([callback])
+
+Returns the chain ID of the current connected node as described in the `EIP-695 <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-695.md>`_.
+
+-------
+Returns
+-------
+
+``Promise<Number>`` - Returns chain ID.
+
+-------
+Example
+-------
+
+.. code-block:: javascript
+
+    web3.eth.getChainId().then(console.log);
+    > 61
+
+------------------------------------------------------------------------------

--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -368,6 +368,12 @@ var Eth = function Eth() {
             inputFormatter: [formatter.inputLogFormatter],
             outputFormatter: formatter.outputLogFormatter
         }),
+        new Method({
+            name: 'getChainId',
+            call: 'eth_chainId',
+            params: 0,
+            outputFormatter: utils.hexToNumber
+        }),
 
         // subscriptions
         new Subscriptions({

--- a/test/eth.getChainId.js
+++ b/test/eth.getChainId.js
@@ -1,0 +1,14 @@
+var testMethod = require('./helpers/test.method.js');
+
+var method = 'getChainId';
+var methodCall = 'eth_chainId';
+
+var tests = [{
+    result: '0x01',
+    formattedResult: 1,
+    call: methodCall
+}];
+
+
+testMethod.runTests('eth', method, tests);
+

--- a/test/eth_methods.js
+++ b/test/eth_methods.js
@@ -22,7 +22,7 @@ describe('eth', function() {
         u.methodExists(eth, 'subscribe');
         u.methodExists(eth, 'Contract');
         u.methodExists(eth, 'Iban');
-
+        u.methodExists(eth, 'getChainId')
 
         u.methodExists(eth, 'isMining');
         u.methodExists(eth, 'getCoinbase');


### PR DESCRIPTION
This method was added to the branch 2.x in d98cef20. This change is to support the method in the 1.x line.

Worth considering this PR in the discussion at #3070 .