### PR TITLE
Minified file added to web3 package 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ bower_components
 .npm/
 .vscode/
 dist/
+packages/web3/dist/
 !./dist/web3.min.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Released with 1.0.0-beta.37 code base.
 - getNetworkType method extended with Görli testnet (#3095)
 - supportsSubscriptions method added to providers (#3116)
 - Add `eth.getChainId` method (#3113)
+- Minified file added to web3 package (#3131)
 
 ### Fixed
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ var replace = require('gulp-replace');
 var exec = require('child_process').exec;
 
 var DEST = path.join(__dirname, 'dist/');
+var WEB3_PACKAGE_DEST = path.join(__dirname, 'packages/web3/dist');
 
 var packages = [{
     fileName: 'web3',
@@ -189,6 +190,7 @@ packages.forEach(function (pckg, i) {
             .pipe(streamify(uglify(ugliyOptions)))
             .on('error', function (err) { console.error(err); })
             .pipe(rename(pckg.fileName + '.min.js'))
+            .pipe(gulp.dest(WEB3_PACKAGE_DEST))
             .pipe(gulp.dest(DEST));
     }));
 });

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -8,6 +8,7 @@
         "node": ">=8.0.0"
     },
     "main": "src/index.js",
+    "browser": "dist/web3.min.js",
     "bugs": {
         "url": "https://github.com/ethereum/web3.js/issues"
     },


### PR DESCRIPTION
The minified file which is located in the root folder of the 1.x branch will now also be published on npm. The minified file got defined as the entry file for browsers in ``packages/web3/package.json``. I've also added this file to the ``.gitignore`` for not having it duplicated on GitHub. (We can probably later anyways remove the minified file from Git)

Fixes #1041 