### PR TITLE
fix: patch the angular `browser.js` to allow `{crypto: true, stream: true}`

### DIFF
--- a/packages/web3/angular-patch.js
+++ b/packages/web3/angular-patch.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const f = '../../node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser.js';
+
+// This is because we have to replace the `node:false` in the `/angular-cli-files/models/webpack-configs/browser.js`
+// with `node: {crypto: true, stream: true}` to allow web3 to work with angular (as they enforce node: false.)
+// as explained here - https://github.com/ethereum/web3.js/issues/2260#issuecomment-458519127
+if (fs.existsSync(f)) {
+    fs.readFile(f, 'utf8', function(err, data) {
+        if (err) {
+            return console.log(err);
+        }
+        var result = data.replace(/node: false/g, 'node: {crypto: true, stream: true}');
+        fs.writeFile(f, result, 'utf8', function(err) {
+            if (err) return console.log(err);
+        });
+    });
+}

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -20,7 +20,8 @@
     "author": "ethereum.org",
     "types": "types/index.d.ts",
     "scripts": {
-        "dtslint": "dtslint types --onlyTestTsNext"
+        "dtslint": "dtslint types --onlyTestTsNext",
+        "postinstall": "node angular-patch.js"
     },
     "authors": [
         {


### PR DESCRIPTION
fix 2 issues which are in the list for stabilize Web3 1.x - https://github.com/ethereum/web3.js/issues/3070

This fixes:

https://github.com/ethereum/web3.js/pull/2262

It also knocks out this issue - https://github.com/ethereum/web3.js/pull/2336 as its not relevant in 1.x.

without this on apps like angular web3 1.x wont work without you going into the node_modules of angulars and changing this file yourself. 