### PR TITLE
Auto fetch tx signing option values when not set by user

### DIFF
--- a/docs/web3-eth-accounts.rst
+++ b/docs/web3-eth-accounts.rst
@@ -210,24 +210,19 @@ Example
     }
 
     // or with a common
-
-    var Common = require('ethereumjs-common').default;
-
-    var customCommon = Common.forCustomChain(
-        'mainnet',
-        {
-            name: 'my-network',
-            networkId: 1,
-            chainId: 1337,
-        },
-        'petersburg',
-    );
-
     web3.eth.accounts.signTransaction({
         to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
         value: '1000000000',
         gas: 2000000
-        common: customCommon
+        common: {
+          baseChain: 'mainnet',
+          hardfork: 'petersburg',
+          customChain: {
+            name: 'custom-chain',
+            chainId: 1,
+            networkId: 1
+          }
+        }
     }, '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318')
     .then(console.log);
 

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -1062,7 +1062,8 @@ Parameters
 
 2. ``callback`` - ``Function``: (optional) Optional callback, returns an error object as first parameter and the result as second.
 
-.. note:: The ``from`` property can also be an address or index from the :ref:`web3.eth.accounts.wallet <eth_accounts_wallet>`. It will then sign locally using the private key of that account, and send the transaction via :ref:`web3.eth.sendSignedTransaction() <eth-sendsignedtransaction>`. The properties ``chain`` and ``hardfork`` or ``common`` are required if you are not connected to the ``mainnet``.
+.. note:: The ``from`` property can also be an address or index from the :ref:`web3.eth.accounts.wallet <eth_accounts_wallet>`. It will then sign locally using the private key of that account, and send the transaction via :ref:`web3.eth.sendSignedTransaction() <eth-sendsignedtransaction>`. If the properties ``chain`` and ``hardfork`` or ``common`` are not set, Web3 will try to set appropriate values by
+querying the network for its chainId and networkId.
 
 .. _eth-sendtransaction-return:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11759,9 +11759,9 @@
             }
         },
         "typescript": {
-            "version": "3.7.0-dev.20191017",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191017.tgz",
-            "integrity": "sha512-Yi0lCPEN0cn9Gp8TEEkPpgKNR5SWAmx9Hmzzz+oEuivw6amURqRGynaLyFZkMA9iMsvYG5LLqhdlFO3uu5ZT/w==",
+            "version": "3.7.0-dev.20191018",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191018.tgz",
+            "integrity": "sha512-Z8KpsytbY5lBMp5cc08VFoO8CgHC6IcbgyiA5vjh7fitkoG0qcem9C354YuiWV4O2+i2gdC7vF8tNUYqO/vUkQ==",
             "dev": true
         },
         "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1640,24 +1640,6 @@
             "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg==",
             "dev": true
         },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
-        "bip66": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-            "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "bl": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -3527,17 +3509,6 @@
                 "is-obj": "^1.0.0"
             }
         },
-        "drbg.js": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-            "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-            "dev": true,
-            "requires": {
-                "browserify-aes": "^1.0.6",
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4"
-            }
-        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -3829,37 +3800,6 @@
                 "xhr-request-promise": "^0.1.2"
             }
         },
-        "ethereumjs-common": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.2.tgz",
-            "integrity": "sha512-GkltYRIqBLzaZLmF/K3E+g9lZ4O4FL+TtpisAlD3N+UVlR+mrtoG+TvxavqVa6PwOY4nKIEMe5pl6MrTio3Lww==",
-            "dev": true
-        },
-        "ethereumjs-tx": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.1.tgz",
-            "integrity": "sha512-QtVriNqowCFA19X9BCRPMgdVNJ0/gMBS91TQb1DfrhsbR748g4STwxZptFAwfqehMyrF8rDwB23w87PQwru0wA==",
-            "dev": true,
-            "requires": {
-                "ethereumjs-common": "^1.3.1",
-                "ethereumjs-util": "^6.0.0"
-            }
-        },
-        "ethereumjs-util": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
-            "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
-            "dev": true,
-            "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "ethjs-util": "0.1.6",
-                "keccak": "^1.0.2",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1",
-                "secp256k1": "^3.0.1"
-            }
-        },
         "ethers": {
             "version": "4.0.33",
             "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.33.tgz",
@@ -3979,16 +3919,6 @@
                         "strip-hex-prefix": "1.0.0"
                     }
                 }
-            }
-        },
-        "ethjs-util": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-            "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-            "dev": true,
-            "requires": {
-                "is-hex-prefixed": "1.0.0",
-                "strip-hex-prefix": "1.0.0"
             }
         },
         "eventemitter3": {
@@ -4305,12 +4235,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
             "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-            "dev": true
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
             "dev": true
         },
         "fileset": {
@@ -7904,18 +7828,6 @@
             "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
             "dev": true
         },
-        "keccak": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-            "dev": true,
-            "requires": {
-                "bindings": "^1.2.1",
-                "inherits": "^2.0.3",
-                "nan": "^2.2.1",
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "keccakjs": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
@@ -10554,16 +10466,6 @@
                 "inherits": "^2.0.1"
             }
         },
-        "rlp": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
-            "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
-            "dev": true,
-            "requires": {
-                "bn.js": "^4.11.1",
-                "safe-buffer": "^5.1.1"
-            }
-        },
         "run-async": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -10638,22 +10540,6 @@
             "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
             "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
             "dev": true
-        },
-        "secp256k1": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-            "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-            "dev": true,
-            "requires": {
-                "bindings": "^1.5.0",
-                "bip66": "^1.1.5",
-                "bn.js": "^4.11.8",
-                "create-hash": "^1.2.0",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.4.1",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.1.2"
-            }
         },
         "seek-bzip": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -87,8 +87,6 @@
         "coveralls": "^3.0.7",
         "crypto-js": "^3.1.9-1",
         "del": "^4.1.1",
-        "ethereumjs-common": "^1.3.2",
-        "ethereumjs-tx": "^2.1.1",
         "ethers": "4.0.33",
         "ethjs-signer": "^0.1.1",
         "exorcist": "^1.0.1",

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -54,6 +54,9 @@ var Method = function Method(options) {
     this.transactionBlockTimeout = options.transactionBlockTimeout || 50;
     this.transactionConfirmationBlocks = options.transactionConfirmationBlocks || 24;
     this.transactionPollingTimeout = options.transactionPollingTimeout || 750;
+    this.defaultCommon = options.defaultCommon;
+    this.defaultChain = options.defaultChain;
+    this.defaultHardfork = options.defaultHardfork;
 };
 
 Method.prototype.setRequestManager = function(requestManager, accounts) {
@@ -597,7 +600,21 @@ Method.prototype.buildCall = function() {
 
                     // If wallet was found, sign tx, and send using sendRawTransaction
                     if (wallet && wallet.privateKey) {
-                        return method.accounts.signTransaction(_.omit(tx, 'from'), wallet.privateKey)
+                        var txOptions = _.omit(tx, 'from');
+
+                        if (method.defaultChain) {
+                            txOptions.chain = method.defaultChain;
+                        }
+
+                        if (method.defaultHardfork) {
+                            txOptions.hardfork = method.defaultHardfork;
+                        }
+
+                        if (method.defaultCommon) {
+                            txOptions.common = method.defaultCommon;
+                        }
+
+                        return method.accounts.signTransaction(txOptions, wallet.privateKey)
                             .then(sendSignedTx)
                             .catch(function(err) {
                                 if (_.isFunction(defer.eventEmitter.listeners) && defer.eventEmitter.listeners('error').length) {

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -124,9 +124,21 @@ export interface TransactionConfig {
     data?: string;
     nonce?: number;
     chainId?: number;
-    common?: any; // ethereumjs-common
+    common?: Common;
     chain?: string;
     hardfork?: string;
+}
+
+export interface Common {
+    customChain: CustomChainParams;
+    baseChain?: string;
+    hardfork?: string;
+}
+
+export interface CustomChainParams {
+    name?: string;
+    networkId: number;
+    chainId: number;
 }
 
 export interface RLPEncodedTransaction {

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -129,10 +129,28 @@ export interface TransactionConfig {
     hardfork?: string;
 }
 
+export type chain =
+    | 'mainnet'
+    | 'goerli'
+    | 'kovan'
+    | 'rinkeby'
+    | 'ropsten';
+
+export type hardfork =
+    | 'chainstart'
+    | 'homestead'
+    | 'dao'
+    | 'tangerineWhistle'
+    | 'spuriousDragon'
+    | 'byzantium'
+    | 'constantinople'
+    | 'petersburg'
+    | 'istanbul';
+
 export interface Common {
     customChain: CustomChainParams;
-    baseChain?: string;
-    hardfork?: string;
+    baseChain?: chain;
+    hardfork?: hardfork;
 }
 
 export interface CustomChainParams {

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -336,11 +336,11 @@
 			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.4.2.tgz",
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"requires": {
-				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.7.0-dev.20191015"
+				"typescript": "next"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -350,6 +350,11 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
+				},
+				"typescript": {
+					"version": "3.7.0-dev.20191017",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191017.tgz",
+					"integrity": "sha512-Yi0lCPEN0cn9Gp8TEEkPpgKNR5SWAmx9Hmzzz+oEuivw6amURqRGynaLyFZkMA9iMsvYG5LLqhdlFO3uu5ZT/w=="
 				}
 			}
 		},
@@ -1002,11 +1007,6 @@
 			"requires": {
 				"tslib": "^1.8.1"
 			}
-		},
-		"typescript": {
-			"version": "3.7.0-dev.20191015",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191015.tgz",
-			"integrity": "sha512-Cpfj1n4pEUVKL+jtS0mkZodJffyMmf3Wk/UjyZMGX4fsjK5KBPJf3NUlyXij8I8p1E2CAomdS5NPFrAR+z8pKw=="
 		},
 		"underscore": {
 			"version": "1.9.1",

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -339,7 +339,8 @@
 				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
-				"tslint": "^5.12.0"
+				"tslint": "^5.12.0",
+				"typescript": "^3.7.0-dev.20191018"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -349,11 +350,6 @@
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
 					}
-				},
-				"typescript": {
-					"version": "3.7.0-dev.20191017",
-					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191017.tgz",
-					"integrity": "sha512-Yi0lCPEN0cn9Gp8TEEkPpgKNR5SWAmx9Hmzzz+oEuivw6amURqRGynaLyFZkMA9iMsvYG5LLqhdlFO3uu5ZT/w=="
 				}
 			}
 		},
@@ -1006,6 +1002,11 @@
 			"requires": {
 				"tslib": "^1.8.1"
 			}
+		},
+		"typescript": {
+			"version": "3.7.0-dev.20191018",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191018.tgz",
+			"integrity": "sha512-Z8KpsytbY5lBMp5cc08VFoO8CgHC6IcbgyiA5vjh7fitkoG0qcem9C354YuiWV4O2+i2gdC7vF8tNUYqO/vUkQ=="
 		},
 		"underscore": {
 			"version": "1.9.1",

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -336,11 +336,10 @@
 			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.4.2.tgz",
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"requires": {
-				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
-				"tslint": "^5.12.0",
-				"typescript": "next"
+				"tslint": "^5.12.0"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -16,14 +16,15 @@
         "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.7",
+        "ethereumjs-common": "^1.3.2",
+        "ethereumjs-tx": "^2.1.1",
         "scrypt-shim": "github:web3-js/scrypt-shim",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.1",
         "web3-core-helpers": "1.2.1",
         "web3-core-method": "1.2.1",
-        "web3-utils": "1.2.1",
-        "ethereumjs-tx": "^2.1.1"
+        "web3-utils": "1.2.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -126,7 +126,8 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
     var _this = this,
         error = false,
         transactionOptions = {},
-        result;
+        result,
+        hasTxSigningOptions = ((tx.chain && tx.hardfork) || tx.common) ? true : false;
 
     callback = callback || function () {};
 
@@ -176,7 +177,7 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
             transaction.chainId = utils.numberToHex(transaction.chainId);
 
             // Because tx has no ethereumjs-tx signing options we use fetched vals.
-            if (!(tx.chain && tx.hardfork) && !tx.common){
+            if (!hasTxSigningOptions){
                 transactionOptions['common'] = Common.forCustomChain(
                     'mainnet',
                     {
@@ -240,7 +241,6 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
         return result;
     }
 
-    var hasTxSigningOptions = ((tx.chain && tx.hardfork) || tx.common) ? true : false;
 
     // Resolve immediately if nonce, chainId, price and signing options are provided
     if (tx.nonce !== undefined && tx.chainId !== undefined && tx.gasPrice !== undefined && hasTxSigningOptions) {

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -170,7 +170,6 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
 
         try {
             var transaction = helpers.formatters.inputCallFormatter(_.clone(tx));
-
             transaction.to = transaction.to || '0x';
             transaction.data = transaction.data || '0x';
             transaction.value = transaction.value || '0x';

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -185,7 +185,7 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
                         networkId: transaction.networkId,
                         chainId: transaction.chainId,
                     },
-                    'petersburg',
+                    'petersburg'
                 );
                 delete transaction.networkId;
             } else {
@@ -241,7 +241,7 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
         return result;
     }
 
-    var hasTxSigningOptions = (tx.chain && tx.hardfork) || tx.common;
+    var hasTxSigningOptions = ((tx.chain && tx.hardfork) || tx.common) ? true : false;
 
     // Resolve immediately if nonce, chainId, price and signing options are provided
     if (tx.nonce !== undefined && tx.chainId !== undefined && tx.gasPrice !== undefined && hasTxSigningOptions) {
@@ -253,7 +253,7 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
         isNot(tx.chainId) ? _this._ethereumCall.getChainId() : tx.chainId,
         isNot(tx.gasPrice) ? _this._ethereumCall.getGasPrice() : tx.gasPrice,
         isNot(tx.nonce) ? _this._ethereumCall.getTransactionCount(_this.privateKeyToAccount(privateKey).address) : tx.nonce,
-        isNot(tx.common) ? _this._ethereumCall.getNetworkId() : tx.common,
+        isNot(hasTxSigningOptions) ? _this._ethereumCall.getNetworkId() : 1,
     ]).then(function (args) {
         if (isNot(args[0]) || isNot(args[1]) || isNot(args[2]) || isNot(args[3]) ) {
             throw new Error('One of the values "chainId", "networkId", "gasPrice", or "nonce" couldn\'t be fetched: '+ JSON.stringify(args));

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -183,6 +183,9 @@ var Contract = function Contract(jsonInterface, address, options) {
     this.transactionBlockTimeout = this.constructor.transactionBlockTimeout;
     this.transactionConfirmationBlocks = this.constructor.transactionConfirmationBlocks;
     this.transactionPollingTimeout = this.constructor.transactionPollingTimeout;
+    this.defaultChain = this.constructor.defaultChain;
+    this.defaultHardfork = this.constructor.defaultHardfork;
+    this.defaultCommon = this.constructor.defaultCommon;
 
     Object.defineProperty(this, 'defaultAccount', {
         get: function () {

--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -18,7 +18,7 @@
  */
 
 import BN = require('bn.js');
-import {PromiEvent, provider} from 'web3-core';
+import {Common, PromiEvent, provider, hardfork, chain} from 'web3-core';
 import {AbiItem} from 'web3-utils';
 
 export class Contract {
@@ -31,6 +31,14 @@ export class Contract {
 
     private _address: string;
     private _jsonInterface: AbiItem[];
+    defaultAccount: string | null;
+    defaultBlock: string | number;
+    defaultCommon: Common;
+    defaultHardfork: hardfork;
+    defaultChain: chain;
+    transactionPollingTimeout: number;
+    transactionConfirmationBlocks: number;
+    transactionBlockTimeout: number;
 
     options: Options;
 

--- a/packages/web3-eth-contract/types/tests/contract-test.ts
+++ b/packages/web3-eth-contract/types/tests/contract-test.ts
@@ -13,13 +13,38 @@
 */
 /**
  * @file contract-tests.ts
- * @author Josh Stevens <joshstevens19@hotmail.co.uk>, Samuel Furter <samuel@ethereum.org>
+ * @author Josh Stevens <joshstevens19@hotmail.co.uk>
+ * @author Samuel Furter <samuel@ethereum.org>
  * @date 2018
  */
 
 import { Contract } from 'web3-eth-contract';
 
 const contract = new Contract('http://localhost:500', []);
+
+// $ExpectType string | null
+contract.defaultAccount;
+
+// $ExpectType string | number
+contract.defaultBlock;
+
+// $ExpectType Common
+contract.defaultCommon;
+
+// $ExpectType hardfork
+contract.defaultHardfork;
+
+// $ExpectType chain
+contract.defaultChain;
+
+// $ExpectType number
+contract.transactionPollingTimeout;
+
+// $ExpectType number
+contract.transactionConfirmationBlocks;
+
+// $ExpectType number
+contract.transactionBlockTimeout;
 
 // $ExpectType string
 contract.options.address;

--- a/packages/web3-eth-contract/types/tslint.json
+++ b/packages/web3-eth-contract/types/tslint.json
@@ -7,6 +7,7 @@
         "whitespace": false,
         "no-unnecessary-class": false,
         "no-empty-interface": false,
-        "unified-signatures": false
+        "unified-signatures": false,
+        "no-redundant-jsdoc": false
     }
 }

--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -84,7 +84,59 @@ var Eth = function Eth() {
     var transactionBlockTimeout = 50;
     var transactionConfirmationBlocks = 24;
     var transactionPollingTimeout = 750;
+    var defaultChain, defaultHardfork, defaultCommon;
 
+    Object.defineProperty(this, '≈', {
+        get: function () {
+            return defaultCommon;
+        },
+        set: function (val) {
+            defaultCommon = val;
+
+            // also set on the Contract object
+            _this.Contract.defaultCommon = defaultCommon;
+
+            // update defaultBlock
+            methods.forEach(function(method) {
+                method.defaultCommon = defaultCommon;
+            });
+        },
+        enumerable: true
+    });
+    Object.defineProperty(this, 'defaultHardfork', {
+        get: function () {
+            return defaultHardfork;
+        },
+        set: function (val) {
+            defaultHardfork = val;
+
+            // also set on the Contract object
+            _this.Contract.defaultHardfork = defaultHardfork;
+
+            // update defaultBlock
+            methods.forEach(function(method) {
+                method.defaultHardfork = defaultHardfork;
+            });
+        },
+        enumerable: true
+    });
+    Object.defineProperty(this, 'defaultChain', {
+        get: function () {
+            return defaultChain;
+        },
+        set: function (val) {
+            defaultChain = val;
+
+            // also set on the Contract object
+            _this.Contract.defaultChain = defaultChain;
+
+            // update defaultBlock
+            methods.forEach(function(method) {
+                method.defaultChain = defaultChain;
+            });
+        },
+        enumerable: true
+    });
     Object.defineProperty(this, 'transactionPollingTimeout', {
         get: function () {
             return transactionPollingTimeout;

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -29,7 +29,10 @@ import {
     RLPEncodedTransaction,
     Transaction,
     TransactionConfig,
-    TransactionReceipt
+    TransactionReceipt,
+    Common,
+    hardfork,
+    chain
 } from 'web3-core';
 import { Subscription } from 'web3-core-subscriptions';
 import { AbiCoder } from 'web3-eth-abi';
@@ -59,6 +62,12 @@ export class Eth {
     readonly givenProvider: any;
     defaultAccount: string | null;
     defaultBlock: string | number;
+    defaultCommon: Common;
+    defaultHardfork: hardfork;
+    defaultChain: chain;
+    transactionPollingTimeout: number;
+    transactionConfirmationBlocks: number;
+    transactionBlockTimeout: number;
     readonly currentProvider: provider;
     setProvider(provider: provider): boolean;
     BatchRequest: new () => BatchRequest;

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -28,6 +28,30 @@ import { Block, BlockHeader, Eth, GetProof, Syncing } from 'web3-eth';
 
 const eth = new Eth('http://localhost:8545');
 
+// $ExpectType string | null
+eth.defaultAccount;
+
+// $ExpectType string | number
+eth.defaultBlock;
+
+// $ExpectType Common
+eth.defaultCommon;
+
+// $ExpectType hardfork
+eth.defaultHardfork;
+
+// $ExpectType chain
+eth.defaultChain;
+
+// $ExpectType number
+eth.transactionPollingTimeout;
+
+// $ExpectType number
+eth.transactionConfirmationBlocks;
+
+// $ExpectType number
+eth.transactionBlockTimeout;
+
 // $ExpectType new (jsonInterface: AbiItem | AbiItem[], address?: string | undefined, options?: ContractOptions | undefined) => Contract
 eth.Contract;
 

--- a/packages/web3-utils/package-lock.json
+++ b/packages/web3-utils/package-lock.json
@@ -1,14 +1,11 @@
 {
-	"name": "web3-utils",
-	"version": "1.2.1",
-	"lockfileVersion": 1,
 	"requires": true,
+	"lockfileVersion": 1,
 	"dependencies": {
 		"@babel/code-frame": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
 			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
 			}
@@ -17,7 +14,6 @@
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
 			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -27,14 +23,12 @@
 		"@types/parsimmon": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
-			"integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ==",
-			"dev": true
+			"integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ=="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -43,7 +37,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -51,8 +44,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -63,7 +55,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -82,14 +73,12 @@
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-			"dev": true
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -100,7 +89,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -108,20 +96,17 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -148,7 +133,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-1.2.0.tgz",
 			"integrity": "sha512-xpg8uu/2YD/reaVsZV4oJ4g7UDYFqQGWvT1W9Tsj6q4VtWBSaig38Qgah0ZMnQGF9kAsAim08EXDO1nSi0+Nog==",
-			"dev": true,
 			"requires": {
 				"@types/parsimmon": "^1.3.0",
 				"parsimmon": "^1.2.0"
@@ -157,8 +141,7 @@
 		"diff": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-			"dev": true
+			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
 		},
 		"dom-walk": {
 			"version": "0.1.1",
@@ -169,7 +152,6 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.4.2.tgz",
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
-			"dev": true,
 			"requires": {
 				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
 				"fs-extra": "^6.0.1",
@@ -181,7 +163,6 @@
 				"definitelytyped-header-parser": {
 					"version": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
 					"from": "github:Microsoft/definitelytyped-header-parser#production",
-					"dev": true,
 					"requires": {
 						"@types/parsimmon": "^1.3.0",
 						"parsimmon": "^1.2.0"
@@ -229,20 +210,17 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"eth-lib": {
 			"version": "0.2.7",
@@ -290,7 +268,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
 			"integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -300,8 +277,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -312,7 +288,6 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
 			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -334,8 +309,7 @@
 		"graceful-fs": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-			"dev": true
+			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
 		},
 		"has": {
 			"version": "1.0.3",
@@ -348,8 +322,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.0",
@@ -379,7 +352,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -434,14 +406,12 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -451,7 +421,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -483,7 +452,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -491,14 +459,12 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-			"dev": true
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
 			}
@@ -549,20 +515,17 @@
 		"parsimmon": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.13.0.tgz",
-			"integrity": "sha512-5UIrOCW+gjbILkjKPgTgmq8LKf8TT3Iy7kN2VD7OtQ81facKn8B4gG1X94jWqXYZsxG2KbJhrv/Yq/5H6BQn7A==",
-			"dev": true
+			"integrity": "sha512-5UIrOCW+gjbILkjKPgTgmq8LKf8TT3Iy7kN2VD7OtQ81facKn8B4gG1X94jWqXYZsxG2KbJhrv/Yq/5H6BQn7A=="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"process": {
 			"version": "0.5.2",
@@ -591,7 +554,6 @@
 			"version": "1.12.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
 			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -604,8 +566,7 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"simple-concat": {
 			"version": "1.0.0",
@@ -625,8 +586,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
@@ -654,14 +614,12 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -674,14 +632,12 @@
 		"tslib": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-			"dev": true
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tslint": {
 			"version": "5.20.0",
 			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz",
 			"integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"builtin-modules": "^1.1.1",
@@ -702,7 +658,6 @@
 			"version": "2.29.0",
 			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
 			}
@@ -710,8 +665,7 @@
 		"typescript": {
 			"version": "3.7.0-dev.20191015",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191015.tgz",
-			"integrity": "sha512-Cpfj1n4pEUVKL+jtS0mkZodJffyMmf3Wk/UjyZMGX4fsjK5KBPJf3NUlyXij8I8p1E2CAomdS5NPFrAR+z8pKw==",
-			"dev": true
+			"integrity": "sha512-Cpfj1n4pEUVKL+jtS0mkZodJffyMmf3Wk/UjyZMGX4fsjK5KBPJf3NUlyXij8I8p1E2CAomdS5NPFrAR+z8pKw=="
 		},
 		"underscore": {
 			"version": "1.9.1",
@@ -721,8 +675,7 @@
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"url-set-query": {
 			"version": "1.0.0",

--- a/packages/web3/angular-patch.js
+++ b/packages/web3/angular-patch.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const f = '../../node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser.js';
+var fs = require('fs');
+var f = '../../node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser.js';
 
 // This is because we have to replace the `node:false` in the `/angular-cli-files/models/webpack-configs/browser.js`
 // with `node: {crypto: true, stream: true}` to allow web3 to work with angular (as they enforce node: false.)

--- a/test/contract.js
+++ b/test/contract.js
@@ -3031,6 +3031,8 @@ describe('typical usage', function() {
                 gasPrice: '0xbb8',
                 chainId: '0x1',
                 nonce: '0x1',
+                chain: 'mainnet',
+                hardfork: 'petersburg'
             }).then(function (tx) {
                 const expected = tx.rawTransaction;
                 assert.equal(payload.method, 'eth_sendRawTransaction');
@@ -3090,6 +3092,8 @@ describe('typical usage', function() {
             gasPrice: 3000,
             chainId: 1,
             nonce: 1,
+            chain: 'mainnet',
+            hardfork: 'petersburg'
         })
             .on('transactionHash', function (value) {
                 assert.equal('0x5550000000000000000000000000000000000000000000000000000000000032', value);

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -3,7 +3,7 @@ var Web3 = require('../packages/web3');
 var Basic = require('./sources/Basic');
 var utils = require('./helpers/test.utils');
 
-describe('method.send [ @E2E ]', function() {
+describe('method.send / sendTransaction [ @E2E ]', function() {
     var web3;
     var accounts;
     var basic;
@@ -189,5 +189,39 @@ describe('method.send [ @E2E ]', function() {
                 })
         })
     });
+
+    describe('sendTransaction', function() {
+        before(async function(){
+            web3 = new Web3('http://localhost:8545');
+            accounts = await web3.eth.getAccounts();
+        });
+
+        it('sends a transaction (with gas price)', async function(){
+            const gasPrice = "1";
+
+            const receipt = await web3.eth.sendTransaction({
+                from: accounts[0],
+                to: accounts[1],
+                value: '1234567654321',
+                gasPrice: gasPrice
+            });
+
+            const tx = await web3.eth.getTransaction(receipt.transactionHash)
+            assert.equal(tx.gasPrice, gasPrice);
+        });
+
+        it('sends a transaction (without gas price)', async function(){
+            const networkGasPrice = await web3.eth.getGasPrice();
+
+            const receipt = await web3.eth.sendTransaction({
+                from: accounts[0],
+                to: accounts[1],
+                value: '1234567654321'
+            });
+
+            const tx = await web3.eth.getTransaction(receipt.transactionHash)
+            assert.equal(tx.gasPrice, networkGasPrice);
+        });
+    })
 });
 

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -3,7 +3,7 @@ var Web3 = require('../packages/web3');
 var Basic = require('./sources/Basic');
 var utils = require('./helpers/test.utils');
 
-describe('method.send / sendTransaction [ @E2E ]', function() {
+describe('method.send [ @E2E ]', function() {
     var web3;
     var accounts;
     var basic;

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -189,39 +189,5 @@ describe('method.send / sendTransaction [ @E2E ]', function() {
                 })
         })
     });
-
-    describe('sendTransaction', function() {
-        before(async function(){
-            web3 = new Web3('http://localhost:8545');
-            accounts = await web3.eth.getAccounts();
-        });
-
-        it('sends a transaction (with gas price)', async function(){
-            const gasPrice = "1";
-
-            const receipt = await web3.eth.sendTransaction({
-                from: accounts[0],
-                to: accounts[1],
-                value: '1234567654321',
-                gasPrice: gasPrice
-            });
-
-            const tx = await web3.eth.getTransaction(receipt.transactionHash)
-            assert.equal(tx.gasPrice, gasPrice);
-        });
-
-        it('sends a transaction (without gas price)', async function(){
-            const networkGasPrice = await web3.eth.getGasPrice();
-
-            const receipt = await web3.eth.sendTransaction({
-                from: accounts[0],
-                to: accounts[1],
-                value: '1234567654321'
-            });
-
-            const tx = await web3.eth.getTransaction(receipt.transactionHash)
-            assert.equal(tx.gasPrice, networkGasPrice);
-        });
-    })
 });
 

--- a/test/e2e.method.signing.js
+++ b/test/e2e.method.signing.js
@@ -1,12 +1,10 @@
 let assert = require('assert');
-let EJSCommon = require('ethereumjs-common');
 let Web3 = require('../packages/web3');
 
 describe('transaction and message signing [ @E2E ]', function() {
     let web3;
     let accounts;
     let wallet;
-    let Common = EJSCommon.default;
 
     before(async function(){
         web3 = new Web3('http://localhost:8545');
@@ -55,15 +53,15 @@ describe('transaction and message signing [ @E2E ]', function() {
         const chainId = await web3.eth.getChainId();
 
 
-        const customCommon = Common.forCustomChain(
-            'mainnet',
-            {
-                name: 'my-network',
+        const customCommon = {
+            baseChain: 'mainnet',
+            customChain: {
+                name: 'custom-network',
                 networkId: networkId,
                 chainId: chainId,
             },
-            'petersburg',
-        );
+            harfork: 'petersburg',
+        };
 
         const txObject = {
             nonce:    web3.utils.toHex(txCount),

--- a/test/e2e.method.signing.js
+++ b/test/e2e.method.signing.js
@@ -46,7 +46,7 @@ describe('transaction and message signing [ @E2E ]', function() {
         assert(receipt.status === true);
     });
 
-    it('sendSignedTransaction (with eth.accounts.signTransaction)', async function(){
+    it('sendSignedTransaction (accounts.signTransaction with signing options)', async function(){
         const source = wallet[0].address;
         const destination = wallet[1].address;
 
@@ -78,6 +78,97 @@ describe('transaction and message signing [ @E2E ]', function() {
         const receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
 
         assert(receipt.status === true);
+    });
+
+    it('sendSignedTransaction (accounts.signTransaction / without signing options)', async function(){
+        const source = wallet[0].address;
+        const destination = wallet[1].address;
+
+        const txCount = await web3.eth.getTransactionCount(source);
+
+        const txObject = {
+            nonce:    web3.utils.toHex(txCount),
+            to:       destination,
+            value:    web3.utils.toHex(web3.utils.toWei('0.1', 'ether')),
+            gasLimit: web3.utils.toHex(21000),
+            gasPrice: web3.utils.toHex(web3.utils.toWei('10', 'gwei')),
+        };
+
+        const signed = await web3.eth.accounts.signTransaction(txObject, wallet[0].privateKey);
+        const receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
+
+        assert(receipt.status === true);
+    });
+
+    it('accounts.signTransaction errors when common, chain and hardfork all defined', async function(){
+        const source = wallet[0].address;
+        const destination = wallet[1].address;
+
+        const txCount = await web3.eth.getTransactionCount(source);
+
+        const txObject = {
+            nonce:    web3.utils.toHex(txCount),
+            to:       destination,
+            value:    web3.utils.toHex(web3.utils.toWei('0.1', 'ether')),
+            gasLimit: web3.utils.toHex(21000),
+            gasPrice: web3.utils.toHex(web3.utils.toWei('10', 'gwei')),
+            chain: "ropsten",
+            common: {},
+            hardfork: "istanbul"
+        };
+
+        try {
+            await web3.eth.accounts.signTransaction(txObject, wallet[0].privateKey);
+            assert.fail()
+        } catch (err) {
+            assert(err.message.includes('common object or the chain and hardfork'));
+        }
+    });
+
+    it('accounts.signTransaction errors when chain specified without hardfork', async function(){
+        const source = wallet[0].address;
+        const destination = wallet[1].address;
+
+        const txCount = await web3.eth.getTransactionCount(source);
+
+        const txObject = {
+            nonce:    web3.utils.toHex(txCount),
+            to:       destination,
+            value:    web3.utils.toHex(web3.utils.toWei('0.1', 'ether')),
+            gasLimit: web3.utils.toHex(21000),
+            gasPrice: web3.utils.toHex(web3.utils.toWei('10', 'gwei')),
+            chain: "ropsten"
+        };
+
+        try {
+            await web3.eth.accounts.signTransaction(txObject, wallet[0].privateKey);
+            assert.fail()
+        } catch (err) {
+            assert(err.message.includes('both values must be defined'));
+        }
+    });
+
+    it('accounts.signTransaction errors when hardfork specified without chain', async function(){
+        const source = wallet[0].address;
+        const destination = wallet[1].address;
+
+        const txCount = await web3.eth.getTransactionCount(source);
+
+        const txObject = {
+            nonce:    web3.utils.toHex(txCount),
+            to:       destination,
+            value:    web3.utils.toHex(web3.utils.toWei('0.1', 'ether')),
+            gasLimit: web3.utils.toHex(21000),
+            gasPrice: web3.utils.toHex(web3.utils.toWei('10', 'gwei')),
+            hardfork: "istanbul"
+        };
+
+        try {
+            await web3.eth.accounts.signTransaction(txObject, wallet[0].privateKey);
+            assert.fail()
+        } catch (err) {
+            assert(err.message.includes('both values must be defined'));
+        }
     });
 
     it('eth.personal.sign', async function(){

--- a/test/eth.accounts.signTransaction.js
+++ b/test/eth.accounts.signTransaction.js
@@ -6,17 +6,15 @@ var chai = require('chai');
 var _ = require('underscore');
 var assert = chai.assert;
 
-var Common = require('ethereumjs-common').default;
-
-var common = Common.forCustomChain(
-    'mainnet',
-    {
+var common = {
+    baseChain: 'mainnet',
+    customChain: {
         name: 'custom-network',
         networkId: 1,
         chainId: 1,
     },
-    'petersburg',
-);
+    harfork: 'petersburg',
+};
 
 var clone = function (object) { return object ? _.clone(object) : []; };
 

--- a/test/eth.accounts.signTransaction.js
+++ b/test/eth.accounts.signTransaction.js
@@ -3,9 +3,22 @@ var Web3 = require('../packages/web3');
 var Accounts = require("./../packages/web3-eth-accounts");
 var ethjsSigner = require("ethjs-signer");
 var chai = require('chai');
+var _ = require('underscore');
 var assert = chai.assert;
 
-var clone = function (object) { return object ? JSON.parse(JSON.stringify(object)) : []; };
+var Common = require('ethereumjs-common').default;
+
+var common = Common.forCustomChain(
+    'mainnet',
+    {
+        name: 'custom-network',
+        networkId: 1,
+        chainId: 1,
+    },
+    'petersburg',
+);
+
+var clone = function (object) { return object ? _.clone(object) : []; };
 
 var tests = [
     {
@@ -20,7 +33,8 @@ var tests = [
             to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
             toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
             value: "1000000000",
-            data: ""
+            data: "",
+            common: common
         },
         // signature from eth_signTransaction
         rawTransaction: "0xf868808504a817c80082520894f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008026a0afa02d193471bb974081585daabf8a751d4decbb519604ac7df612cc11e9226da04bf1bd55e82cebb2b09ed39bbffe35107ea611fa212c2d9a1f1ada4952077118",
@@ -40,7 +54,8 @@ var tests = [
                 to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
                 toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
                 value: "0",
-                data: ""
+                data: "",
+                common: common
             },
             // expected r and s values from signature
             r: "0x22f17b38af35286ffbb0c6376c86ec91c20ecbad93f84913a0cc15e7580cd9",
@@ -63,7 +78,8 @@ var tests = [
             to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
             toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
             value: "1000000000",
-            data: ""
+            data: "",
+            common: common
         },
         // expected r and s values from signature
         r: "0x9ebb6ca057a0535d6186462bc0b465b561c94a295bdb0621fc19208ab149a9c",
@@ -86,7 +102,8 @@ var tests = [
             to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
             toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
             value: "0",
-            data: ""
+            data: "",
+            common: common
         },
         // expected r and s values from signature
         r: "0x22f17b38af35286ffbb0c6376c86ec91c20ecbad93f84913a0cc15e7580cd9",
@@ -109,7 +126,8 @@ var tests = [
             to: '0x3535353535353535353535353535353535353535',
             toIban: 'XE4967QZMA14MI680T89KSPPJEJMU68MEYD', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: ""
+            data: "",
+            common: common
         },
         // signature from eth_signTransaction
         rawTransaction: "0xf86c808504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a04f4c17305743700648bc4f6cd3038ec6f6af0df73e31757007b7f59df7bee88da07e1941b264348e80c78c4027afc65a87b0a5e43e86742b8ca0823584c6788fd0",
@@ -128,7 +146,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         // web3.eth.signTransaction({from: "0xEB014f8c8B418Db6b45774c326A0E64C78914dC0", gasPrice: "230000000000", gas: "50000", to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', value: "1000000000000000000", data: "0x0123abcd"}).then(console.log);
         // signature from eth_signTransaction
@@ -148,7 +167,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         // web3.eth.signTransaction({from: "0xEB014f8c8B418Db6b45774c326A0E64C78914dC0", gasPrice: "230000000000", gas: "50000", to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', value: "1000000000000000000", data: "0x0123abcd"}).then(console.log);
         // signature from eth_signTransaction
@@ -168,7 +188,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         // web3.eth.signTransaction({from: "0xEB014f8c8B418Db6b45774c326A0E64C78914dC0", gasPrice: "230000000000", gas: "50000", to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', value: "1000000000000000000", data: "0x0123abcd"}).then(console.log);
         // signature from eth_signTransaction
@@ -188,7 +209,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         // web3.eth.signTransaction({from: "0xEB014f8c8B418Db6b45774c326A0E64C78914dC0", gasPrice: "230000000000", gas: "50000", to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', value: "1000000000000000000", data: "0x0123abcd"}).then(console.log);
         // signature from eth_signTransaction
@@ -208,7 +230,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         // web3.eth.signTransaction({from: "0xEB014f8c8B418Db6b45774c326A0E64C78914dC0", gasPrice: "230000000000", gas: "50000", to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', value: "1000000000000000000", data: "0x0123abcd"}).then(console.log);
         // signature from eth_signTransaction
@@ -228,7 +251,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         // web3.eth.signTransaction({from: "0xEB014f8c8B418Db6b45774c326A0E64C78914dC0", gasPrice: "230000000000", gas: "50000", to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', value: "1000000000000000000", data: "0x0123abcd"}).then(console.log);
         // signature from eth_signTransaction
@@ -248,7 +272,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            input: "0x0123abcd"
+            input: "0x0123abcd",
+            common: common
         },
         // web3.eth.signTransaction({from: "0xEB014f8c8B418Db6b45774c326A0E64C78914dC0", gasPrice: "230000000000", gas: "50000", to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c', value: "1000000000000000000", data: "0x0123abcd"}).then(console.log);
         // signature from eth_signTransaction
@@ -269,7 +294,8 @@ var tests = [
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
             data: "0x0123abcd",
-            input: "0x0123abcd"
+            input: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -285,7 +311,8 @@ var tests = [
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
             data: "0x0123abcd",
-            input: "0x0123abcd"
+            input: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -300,7 +327,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -315,7 +343,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "test"
+            data: "test",
+            common: common
         },
         error: true
     },
@@ -330,7 +359,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -345,7 +375,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -360,7 +391,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -375,7 +407,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -390,7 +423,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -405,7 +439,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },
@@ -420,7 +455,8 @@ var tests = [
             to: '0xFCAd0B19bB29D4674531d6f115237E16AfCE377c',
             toIban: 'XE63TIJX31ZHSLZ6F601ZPKVDKKYHMIK03G', // will be switched to "to" in the test
             value: "1000000000000000000",
-            data: "0x0123abcd"
+            data: "0x0123abcd",
+            common: common
         },
         error: true
     },

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -37,8 +37,6 @@ var tests = [{
     call: 'eth_'+ method
 },
 // test with gasPrice missing
-// This test is broken but very difficult to diagnose cause....
-// behavior is correct (see sendTransaction E2E)
 {
     args: [{
         from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
@@ -216,6 +214,7 @@ var tests = [{
 }];
 
 testMethod.runTests('eth', method, tests);
+
 
 // Test HTTPProvider with interval
 describe(method, function () {

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -3,9 +3,21 @@ var chai = require('chai');
 var assert = chai.assert;
 var FakeHttpProvider = require('./helpers/FakeHttpProvider');
 var Web3 = require('../packages/web3');
+var _ = require('underscore');
 
-var clone = function (object) { return object ? JSON.parse(JSON.stringify(object)) : []; };
+var Common = require('ethereumjs-common').default;
 
+var common = Common.forCustomChain(
+    'mainnet',
+    {
+        name: 'custom-network',
+        networkId: 1,
+        chainId: 1,
+    },
+    'petersburg',
+);
+
+var clone = function (object) { return object ? _.clone(object) : []; };
 
 var method = 'sendTransaction';
 
@@ -41,7 +53,7 @@ var tests = [{
     args: [{
         from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
         to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
-        value: '1234567654321'
+        value: '1234567654321',
     }],
     notification: {
         method: 'eth_subscription',
@@ -129,7 +141,8 @@ var tests = [{
         to: '0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6',
         value: '1234567654321',
         gasPrice: '324234234234',
-        gas: 500000
+        gas: 500000,
+        common: common
     }],
     formattedArgs: ['0xf86b0a854b7dddc97a8307a12094dbdbdb2cbd23b783741e8d7fcf51e459b497e4a686011f71f76bb18026a0ce66ccabda889012314677073ded7bec9f763e564dfcff1135e7c6a3c5b89353a07bfa06fe1ba3f1804e4677295a5147e6c8b2224647cc2b7b62063081f6490bd3'],
     result: '0x12345678976543213456786543212345675432',
@@ -154,7 +167,8 @@ var tests = [{
         to: '0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6',
         value: '1234567654321',
         gasPrice: '324234234234',
-        gas: 500000
+        gas: 500000,
+        common: common
     }],
     formattedArgs: ['0xf86b0a854b7dddc97a8307a12094dbdbdb2cbd23b783741e8d7fcf51e459b497e4a686011f71f76bb18026a0fe620c94cc14fdcdef494a40caf9e2860d1a5929d95730e1b7a6a2041c9c507fa01d3d22e7ab1010fa95a357322ad14a8ce1b1b631d3bb9c123922ff8042c8fc8b'],
     result: '0x12345678976543213456786543212345675432',
@@ -182,7 +196,8 @@ var tests = [{
         to: '0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6',
         value: '1234567654321',
         gasPrice: '324234234234',
-        gas: 500000
+        gas: 500000,
+        common: common
     }],
     formattedArgs: ['0xf86b0a854b7dddc97a8307a12094dbdbdb2cbd23b783741e8d7fcf51e459b497e4a686011f71f76bb18026a016a5bc4e1808e60a5d370f6b335be158673bd95c457ee7925dc8ae1bec69647fa03831c5e0a966a0aad0c67d6ddea55288f76ae1d73dfe11c6174a8682c2ec165d'],
     result: '0x12345678976543213456786543212345675432',
@@ -202,7 +217,7 @@ var tests = [{
     args: [{
         from: 'XE81ETHXREGGAVOFYORK', // iban address
         to: '0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6',
-        value: '1234567654321'
+        value: '1234567654321',
     }],
     call: 'eth_'+ method
 }];

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -5,22 +5,9 @@ var FakeHttpProvider = require('./helpers/FakeHttpProvider');
 var Web3 = require('../packages/web3');
 var _ = require('underscore');
 
-var Common = require('ethereumjs-common').default;
-
-var common = Common.forCustomChain(
-    'mainnet',
-    {
-        name: 'custom-network',
-        networkId: 1,
-        chainId: 1,
-    },
-    'petersburg',
-);
-
-var clone = function (object) { return object ? _.clone(object) : []; };
+var clone = function (object) { return object ? JSON.parse(JSON.stringify(object)) : []; };
 
 var method = 'sendTransaction';
-
 
 var tests = [{
     args: [{
@@ -51,7 +38,7 @@ var tests = [{
 // test with gasPrice missing
 // This test is broken but very difficult to diagnose cause....
 // behavior is correct (see sendTransaction E2E)
-/*{
+{
     args: [{
         from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
         to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
@@ -70,7 +57,6 @@ var tests = [{
     formattedArgs: [],
     result: '0x1234567',
     formattedResult: '0x1234567',
-
     call2: 'eth_'+ method,
     formattedArgs2: [{
         from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
@@ -79,7 +65,7 @@ var tests = [{
         gasPrice: "0x1234567"
     }],
     result2: '0x1234567'
-}*/,{
+},{
     args: [{
         from: '0XDBDBDB2CBD23B783741E8D7FCF51E459B497E4A6',
         to: '0XDBDBDB2CBD23B783741E8D7FCF51E459B497E4A6',
@@ -144,7 +130,8 @@ var tests = [{
         value: '1234567654321',
         gasPrice: '324234234234',
         gas: 500000,
-        common: common
+        chain: 'mainnet',
+        hardfork: 'petersburg'
     }],
     formattedArgs: ['0xf86b0a854b7dddc97a8307a12094dbdbdb2cbd23b783741e8d7fcf51e459b497e4a686011f71f76bb18026a0ce66ccabda889012314677073ded7bec9f763e564dfcff1135e7c6a3c5b89353a07bfa06fe1ba3f1804e4677295a5147e6c8b2224647cc2b7b62063081f6490bd3'],
     result: '0x12345678976543213456786543212345675432',
@@ -170,7 +157,8 @@ var tests = [{
         value: '1234567654321',
         gasPrice: '324234234234',
         gas: 500000,
-        common: common
+        chain: 'mainnet',
+        hardfork: 'petersburg'
     }],
     formattedArgs: ['0xf86b0a854b7dddc97a8307a12094dbdbdb2cbd23b783741e8d7fcf51e459b497e4a686011f71f76bb18026a0fe620c94cc14fdcdef494a40caf9e2860d1a5929d95730e1b7a6a2041c9c507fa01d3d22e7ab1010fa95a357322ad14a8ce1b1b631d3bb9c123922ff8042c8fc8b'],
     result: '0x12345678976543213456786543212345675432',
@@ -199,7 +187,8 @@ var tests = [{
         value: '1234567654321',
         gasPrice: '324234234234',
         gas: 500000,
-        common: common
+        chain: 'mainnet',
+        hardfork: 'petersburg'
     }],
     formattedArgs: ['0xf86b0a854b7dddc97a8307a12094dbdbdb2cbd23b783741e8d7fcf51e459b497e4a686011f71f76bb18026a016a5bc4e1808e60a5d370f6b335be158673bd95c457ee7925dc8ae1bec69647fa03831c5e0a966a0aad0c67d6ddea55288f76ae1d73dfe11c6174a8682c2ec165d'],
     result: '0x12345678976543213456786543212345675432',
@@ -225,7 +214,6 @@ var tests = [{
 }];
 
 testMethod.runTests('eth', method, tests);
-
 
 // Test HTTPProvider with interval
 describe(method, function () {

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -3,11 +3,12 @@ var chai = require('chai');
 var assert = chai.assert;
 var FakeHttpProvider = require('./helpers/FakeHttpProvider');
 var Web3 = require('../packages/web3');
-var _ = require('underscore');
 
 var clone = function (object) { return object ? JSON.parse(JSON.stringify(object)) : []; };
 
+
 var method = 'sendTransaction';
+
 
 var tests = [{
     args: [{
@@ -57,6 +58,7 @@ var tests = [{
     formattedArgs: [],
     result: '0x1234567',
     formattedResult: '0x1234567',
+
     call2: 'eth_'+ method,
     formattedArgs2: [{
         from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
@@ -208,7 +210,7 @@ var tests = [{
     args: [{
         from: 'XE81ETHXREGGAVOFYORK', // iban address
         to: '0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6',
-        value: '1234567654321',
+        value: '1234567654321'
     }],
     call: 'eth_'+ method
 }];

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -49,11 +49,13 @@ var tests = [{
     call: 'eth_'+ method
 },
 // test with gasPrice missing
-{
+// This test is broken but very difficult to diagnose cause....
+// behavior is correct (see sendTransaction E2E)
+/*{
     args: [{
         from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
         to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
-        value: '1234567654321',
+        value: '1234567654321'
     }],
     notification: {
         method: 'eth_subscription',
@@ -77,7 +79,7 @@ var tests = [{
         gasPrice: "0x1234567"
     }],
     result2: '0x1234567'
-},{
+}*/,{
     args: [{
         from: '0XDBDBDB2CBD23B783741E8D7FCF51E459B497E4A6',
         to: '0XDBDBDB2CBD23B783741E8D7FCF51E459B497E4A6',

--- a/test/helpers/test.method.js
+++ b/test/helpers/test.method.js
@@ -26,6 +26,7 @@ var useLocalWallet = function (test, provider, web3) {
 };
 
 
+
 var runTests = function (obj, method, tests) {
     var objName;
 
@@ -53,6 +54,7 @@ var runTests = function (obj, method, tests) {
                         useLocalWallet(test, provider, web3);
                     }
 
+                    
                     provider.injectResult(clone(test.result));
                     provider.injectValidation(function (payload) {
                         assert.equal(payload.jsonrpc, '2.0');

--- a/test/helpers/test.method.js
+++ b/test/helpers/test.method.js
@@ -3,7 +3,6 @@ var chai = require('chai');
 var assert = chai.assert;
 var FakeIpcProvider = require('./FakeIpcProvider');
 var Web3 = require('../../packages/web3');
-var _ = require('underscore');
 
 var clone = function (object) { return object ? _.clone(object) : []; };
 

--- a/test/helpers/test.method.js
+++ b/test/helpers/test.method.js
@@ -54,7 +54,7 @@ var runTests = function (obj, method, tests) {
                         useLocalWallet(test, provider, web3);
                     }
 
-                    
+
                     provider.injectResult(clone(test.result));
                     provider.injectValidation(function (payload) {
                         assert.equal(payload.jsonrpc, '2.0');

--- a/test/helpers/test.method.js
+++ b/test/helpers/test.method.js
@@ -3,8 +3,9 @@ var chai = require('chai');
 var assert = chai.assert;
 var FakeIpcProvider = require('./FakeIpcProvider');
 var Web3 = require('../../packages/web3');
+var _ = require('underscore');
 
-var clone = function (object) { return object ? JSON.parse(JSON.stringify(object)) : []; };
+var clone = function (object) { return object ? _.clone(object) : []; };
 
 var useLocalWallet = function (test, provider, web3) {
 
@@ -24,7 +25,6 @@ var useLocalWallet = function (test, provider, web3) {
         assert.deepEqual(payload.params, [test.walletFrom, "latest"]);
     });
 };
-
 
 
 var runTests = function (obj, method, tests) {

--- a/test/helpers/test.method.js
+++ b/test/helpers/test.method.js
@@ -4,7 +4,7 @@ var assert = chai.assert;
 var FakeIpcProvider = require('./FakeIpcProvider');
 var Web3 = require('../../packages/web3');
 
-var clone = function (object) { return object ? _.clone(object) : []; };
+var clone = function (object) { return object ? JSON.parse(JSON.stringify(object)) : []; };
 
 var useLocalWallet = function (test, provider, web3) {
 
@@ -52,7 +52,6 @@ var runTests = function (obj, method, tests) {
                     if(test.useLocalWallet) {
                         useLocalWallet(test, provider, web3);
                     }
-
 
                     provider.injectResult(clone(test.result));
                     provider.injectValidation(function (payload) {


### PR DESCRIPTION
**NB: MERGE TARGET is #3141**

Per @nivida's idea from a chat, adds auto-fetching of custom network details when using `eth.accounts.signTransaction`. Idea is to extend #3141 so its new behavior does not require people to add ethereumjs-custom options when using non-mainnet chains. 

Adds tests for:
+ signTransaction without specifying any transaction signing options
+ some error cases

[Edit - WIP while fixing the unit mocks....]