### PR TITLE
Add karma & chrome/firefox headless browser fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     - node_js: 12
       env: TEST=unit
     - node_js: 10
+      env: TEST=build_and_lint
+    - node_js: 10
       env: TEST=unit_and_e2e_clients
     - node_js: 10
       env: TEST=e2e_browsers

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,12 @@ matrix:
     - node_js: 12
       env: TEST=unit
     - node_js: 10
-      env: TEST=unit_and_e2e
+      env: TEST=unit_and_e2e_clients
+    - node_js: 10
+      env: TEST=e2e_browsers
+      addons:
+        chrome: stable
+        firefox: latest
 addons:
   apt:
     sources:
@@ -26,6 +31,7 @@ before_install:
       export LINK="gcc-5";
       export LINKXX="g++-5";
     fi
+  - "export DISPLAY=:99.0"
 install:
     - npm install
 script:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,40 @@
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+process.env.MOZ_HEADLESS = 1;
+
+module.exports = function (config) {
+    config.set({
+        frameworks: [
+            'mocha',
+            'browserify'
+        ],
+        files: [
+            'node_modules/@babel/polyfill/dist/polyfill.js', // For async/await in tests
+            'test/**/e2e*.js'
+        ],
+        preprocessors: {
+            'test/**/e2e*.js': [ 'browserify' ]
+        },
+        plugins: [
+            'karma-chrome-launcher',
+            'karma-firefox-launcher',
+            'karma-mocha',
+            'karma-browserify',
+            'karma-spec-reporter'
+        ],
+        reporters: ['spec'],
+        port: 9876,  // karma web server port
+        colors: true,
+        logLevel: config.LOG_INFO,
+        autoWatch: false,
+        browsers: [
+            'ChromeHeadless',
+            'FirefoxHeadless'
+        ],
+        customLaunchers: {
+            FirefoxHeadless: {
+                base: 'Firefox',
+                flags: ['-headless'],
+            },
+        },
+    });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -699,6 +699,16 @@
                 "regexpu-core": "^4.6.0"
             }
         },
+        "@babel/polyfill": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
+            "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
+            "dev": true,
+            "requires": {
+                "core-js": "^2.6.5",
+                "regenerator-runtime": "^0.13.2"
+            }
+        },
         "@babel/preset-env": {
             "version": "7.6.3",
             "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.3.tgz",
@@ -946,6 +956,21 @@
             "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
             "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
             "dev": true
+        },
+        "after": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+            "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
         },
         "ajv": {
             "version": "6.10.0",
@@ -1235,6 +1260,12 @@
             "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
+        "arraybuffer.slice": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+            "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+            "dev": true
+        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -1463,6 +1494,14 @@
             "requires": {
                 "core-js": "^2.4.0",
                 "regenerator-runtime": "^0.11.0"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+                    "dev": true
+                }
             }
         },
         "babel-template": {
@@ -1546,6 +1585,12 @@
                 "now-and-later": "^2.0.0"
             }
         },
+        "backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+            "dev": true
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1607,10 +1652,22 @@
                 }
             }
         },
+        "base64-arraybuffer": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+            "dev": true
+        },
         "base64-js": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
             "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "dev": true
+        },
+        "base64id": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+            "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
             "dev": true
         },
         "bcrypt-pbkdf": {
@@ -1620,6 +1677,15 @@
             "dev": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
+            }
+        },
+        "better-assert": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+            "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+            "dev": true,
+            "requires": {
+                "callsite": "1.0.0"
             }
         },
         "bignumber.js": {
@@ -1649,6 +1715,12 @@
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
             }
+        },
+        "blob": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+            "dev": true
         },
         "bluebird": {
             "version": "3.3.1",
@@ -2097,6 +2169,12 @@
             "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
             "dev": true
         },
+        "callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+            "dev": true
+        },
         "camelcase": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -2441,10 +2519,22 @@
                 "dot-prop": "^3.0.0"
             }
         },
+        "component-bind": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+            "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+            "dev": true
+        },
         "component-emitter": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
             "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
+        },
+        "component-inherit": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+            "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
             "dev": true
         },
         "concat-map": {
@@ -2490,6 +2580,18 @@
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
                     "dev": true
                 }
+            }
+        },
+        "connect": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+            "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "finalhandler": "1.1.2",
+                "parseurl": "~1.3.3",
+                "utils-merge": "1.0.1"
             }
         },
         "console-browserify": {
@@ -2989,6 +3091,12 @@
                 "array-find-index": "^1.0.1"
             }
         },
+        "custom-event": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+            "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+            "dev": true
+        },
         "d": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -3022,6 +3130,12 @@
             "requires": {
                 "assert-plus": "^1.0.0"
             }
+        },
+        "date-format": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+            "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+            "dev": true
         },
         "date-now": {
             "version": "0.1.4",
@@ -3428,6 +3542,12 @@
                 "minimist": "^1.1.1"
             }
         },
+        "di": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+            "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+            "dev": true
+        },
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -3443,6 +3563,18 @@
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
                 "randombytes": "^2.0.0"
+            }
+        },
+        "dom-serialize": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+            "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+            "dev": true,
+            "requires": {
+                "custom-event": "~1.0.0",
+                "ent": "~2.2.0",
+                "extend": "^3.0.0",
+                "void-elements": "^2.0.0"
             }
         },
         "dom-serializer": {
@@ -3616,6 +3748,92 @@
                 "once": "^1.4.0"
             }
         },
+        "engine.io": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+            "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.4",
+                "base64id": "1.0.0",
+                "cookie": "0.3.1",
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.0",
+                "ws": "~3.3.1"
+            },
+            "dependencies": {
+                "cookie": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                    "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "engine.io-client": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+            "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "1.2.1",
+                "component-inherit": "0.0.3",
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.1",
+                "has-cors": "1.1.0",
+                "indexof": "0.0.1",
+                "parseqs": "0.0.5",
+                "parseuri": "0.0.5",
+                "ws": "~3.3.1",
+                "xmlhttprequest-ssl": "~1.5.4",
+                "yeast": "0.1.2"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "engine.io-parser": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+            "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+            "dev": true,
+            "requires": {
+                "after": "0.8.2",
+                "arraybuffer.slice": "~0.0.7",
+                "base64-arraybuffer": "0.1.5",
+                "blob": "0.0.5",
+                "has-binary2": "~1.0.2"
+            }
+        },
+        "ent": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+            "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+            "dev": true
+        },
         "entities": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -3676,6 +3894,21 @@
                 "d": "1",
                 "es5-ext": "^0.10.35",
                 "es6-symbol": "^3.1.1"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
             }
         },
         "es6-symbol": {
@@ -4177,6 +4410,50 @@
                 }
             }
         },
+        "extract-zip": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+            "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "1.6.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1",
+                "yauzl": "2.4.1"
+            },
+            "dependencies": {
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
+                    }
+                },
+                "fd-slicer": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                    "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+                    "dev": true,
+                    "requires": {
+                        "pend": "~1.2.0"
+                    }
+                },
+                "yauzl": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+                    "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+                    "dev": true,
+                    "requires": {
+                        "fd-slicer": "~1.0.1"
+                    }
+                }
+            }
+        },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4343,6 +4620,12 @@
                 }
             }
         },
+        "flatted": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+            "dev": true
+        },
         "flush-write-stream": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -4351,6 +4634,32 @@
             "requires": {
                 "inherits": "^2.0.3",
                 "readable-stream": "^2.3.6"
+            }
+        },
+        "follow-redirects": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+            "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
             }
         },
         "for-each": {
@@ -4479,8 +4788,7 @@
                     "version": "2.1.1",
                     "resolved": false,
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -4504,15 +4812,13 @@
                     "version": "1.0.0",
                     "resolved": false,
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": false,
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -4529,22 +4835,19 @@
                     "version": "1.1.0",
                     "resolved": false,
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": false,
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": false,
                     "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -4675,8 +4978,7 @@
                     "version": "2.0.3",
                     "resolved": false,
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -4690,7 +4992,6 @@
                     "resolved": false,
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -4707,7 +5008,6 @@
                     "resolved": false,
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -4716,15 +5016,13 @@
                     "version": "0.0.8",
                     "resolved": false,
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "resolved": false,
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -4745,7 +5043,6 @@
                     "resolved": false,
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -4834,8 +5131,7 @@
                     "version": "1.0.1",
                     "resolved": false,
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -4849,7 +5145,6 @@
                     "resolved": false,
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -4945,8 +5240,7 @@
                     "version": "5.1.2",
                     "resolved": false,
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -4988,7 +5282,6 @@
                     "resolved": false,
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -5010,7 +5303,6 @@
                     "resolved": false,
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -5059,15 +5351,13 @@
                     "version": "1.0.2",
                     "resolved": false,
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "resolved": false,
                     "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },
@@ -6636,6 +6926,29 @@
                 "ansi-regex": "^2.0.0"
             }
         },
+        "has-binary2": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+            "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+            "dev": true,
+            "requires": {
+                "isarray": "2.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+                    "dev": true
+                }
+            }
+        },
+        "has-cors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+            "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+            "dev": true
+        },
         "has-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -6729,6 +7042,12 @@
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
             }
+        },
+        "hat": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+            "integrity": "sha1-uwFKnmSzeIrtgAWRdBPU/z1QLYo=",
+            "dev": true
         },
         "he": {
             "version": "1.2.0",
@@ -6832,6 +7151,25 @@
             "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
             "dev": true
         },
+        "http-proxy": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+            "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+            "dev": true,
+            "requires": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            },
+            "dependencies": {
+                "eventemitter3": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+                    "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+                    "dev": true
+                }
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -6848,6 +7186,33 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
+        },
+        "https-proxy-agent": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
         },
         "iconv-lite": {
             "version": "0.4.24",
@@ -6891,6 +7256,12 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
             "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+            "dev": true
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
             "dev": true
         },
         "inflight": {
@@ -7426,11 +7797,26 @@
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
+        "is-wsl": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+            "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+            "dev": true
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
             "dev": true
+        },
+        "isbinaryfile": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+            "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+            "dev": true,
+            "requires": {
+                "buffer-alloc": "^1.2.0"
+            }
         },
         "isexe": {
             "version": "2.0.0",
@@ -7691,6 +8077,12 @@
             "integrity": "sha1-uvDA6MVK1ZA0R9+Wreekobynmko=",
             "dev": true
         },
+        "js-string-escape": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+            "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
+            "dev": true
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7827,6 +8219,209 @@
             "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
             "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
             "dev": true
+        },
+        "karma": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz",
+            "integrity": "sha512-L5SIaXEYqzrh6b1wqYC42tNsFMx2PWuxky84pK9coK09MvmL7mxii3G3bZBh/0rvD27lqDd0le9jyhzvwif73A==",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.3.0",
+                "body-parser": "^1.16.1",
+                "braces": "^3.0.2",
+                "chokidar": "^3.0.0",
+                "colors": "^1.1.0",
+                "connect": "^3.6.0",
+                "di": "^0.0.1",
+                "dom-serialize": "^2.2.0",
+                "flatted": "^2.0.0",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.1.2",
+                "http-proxy": "^1.13.0",
+                "isbinaryfile": "^3.0.0",
+                "lodash": "^4.17.14",
+                "log4js": "^4.0.0",
+                "mime": "^2.3.1",
+                "minimatch": "^3.0.2",
+                "optimist": "^0.6.1",
+                "qjobs": "^1.1.4",
+                "range-parser": "^1.2.0",
+                "rimraf": "^2.6.0",
+                "safe-buffer": "^5.0.1",
+                "socket.io": "2.1.1",
+                "source-map": "^0.6.1",
+                "tmp": "0.0.33",
+                "useragent": "2.3.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "dev": true,
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+                    "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.2.tgz",
+                    "integrity": "sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "~3.1.1",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.1.1",
+                        "glob-parent": "~5.1.0",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.2.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.1.tgz",
+                    "integrity": "sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==",
+                    "dev": true,
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+                    "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "mime": {
+                    "version": "2.4.4",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+                    "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+                    "dev": true
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
+                },
+                "readdirp": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+                    "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+                    "dev": true,
+                    "requires": {
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "karma-browserify": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/karma-browserify/-/karma-browserify-6.1.0.tgz",
+            "integrity": "sha512-FWOuATeil6dbm2nwWIbSFG0Ad8w3PcuBNs05zcqnMiuXEdwos/o6B26HF+NcYwTt3o7LTOGWiuXK9cuuhoPeaw==",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "^1.1.3",
+                "hat": "^0.0.3",
+                "js-string-escape": "^1.0.0",
+                "lodash": "^4.17.14",
+                "minimatch": "^3.0.0",
+                "os-shim": "^0.1.3"
+            }
+        },
+        "karma-chrome-launcher": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
+            "integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
+            "dev": true,
+            "requires": {
+                "which": "^1.2.1"
+            }
+        },
+        "karma-firefox-launcher": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.2.0.tgz",
+            "integrity": "sha512-j9Zp8M8+VLq1nI/5xZGfzeaEPtGQ/vk3G+Y8vpmFWLvKLNZ2TDjD6cu2dUu7lDbu1HXNgatsAX4jgCZTkR9qhQ==",
+            "dev": true,
+            "requires": {
+                "is-wsl": "^2.1.0"
+            }
+        },
+        "karma-mocha": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
+            "integrity": "sha1-7qrH/8DiAetjxGdEDStpx883eL8=",
+            "dev": true,
+            "requires": {
+                "minimist": "1.2.0"
+            }
+        },
+        "karma-spec-reporter": {
+            "version": "0.0.32",
+            "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.32.tgz",
+            "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
+            "dev": true,
+            "requires": {
+                "colors": "^1.1.2"
+            }
         },
         "keccakjs": {
             "version": "0.2.3",
@@ -8358,6 +8953,36 @@
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1"
+            }
+        },
+        "log4js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.5.1.tgz",
+            "integrity": "sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==",
+            "dev": true,
+            "requires": {
+                "date-format": "^2.0.0",
+                "debug": "^4.1.1",
+                "flatted": "^2.0.0",
+                "rfdc": "^1.1.4",
+                "streamroller": "^1.0.6"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
             }
         },
         "loose-envify": {
@@ -9315,6 +9940,12 @@
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
+        "object-component": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+            "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+            "dev": true
+        },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -9522,6 +10153,12 @@
                 "lcid": "^1.0.0"
             }
         },
+        "os-shim": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+            "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
+            "dev": true
+        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -9668,6 +10305,24 @@
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
             "dev": true
         },
+        "parseqs": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+            "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+            "dev": true,
+            "requires": {
+                "better-assert": "~1.0.0"
+            }
+        },
+        "parseuri": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+            "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+            "dev": true,
+            "requires": {
+                "better-assert": "~1.0.0"
+            }
+        },
         "parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9802,6 +10457,12 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
             "dev": true
         },
+        "picomatch": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+            "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+            "dev": true
+        },
         "pify": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -9887,6 +10548,12 @@
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
             "dev": true
         },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
         "proxy-addr": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -9896,6 +10563,12 @@
                 "forwarded": "~0.1.2",
                 "ipaddr.js": "1.9.0"
             }
+        },
+        "proxy-from-env": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+            "dev": true
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -9950,10 +10623,64 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
             "dev": true
         },
+        "puppeteer": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz",
+            "integrity": "sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "extract-zip": "^1.6.6",
+                "https-proxy-agent": "^2.2.1",
+                "mime": "^2.0.3",
+                "progress": "^2.0.1",
+                "proxy-from-env": "^1.0.0",
+                "rimraf": "^2.6.1",
+                "ws": "^6.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "mime": {
+                    "version": "2.4.4",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+                    "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "ws": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+                    "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+                    "dev": true,
+                    "requires": {
+                        "async-limiter": "~1.0.0"
+                    }
+                }
+            }
+        },
         "q": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
+        "qjobs": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+            "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
             "dev": true
         },
         "qs": {
@@ -10186,9 +10913,9 @@
             }
         },
         "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+            "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
             "dev": true
         },
         "regenerator-transform": {
@@ -10388,6 +11115,12 @@
             "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
             "dev": true
         },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
         "resolve": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
@@ -10445,6 +11178,12 @@
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "rfdc": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+            "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
             "dev": true
         },
         "rimraf": {
@@ -10871,6 +11610,110 @@
                 }
             }
         },
+        "socket.io": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+            "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+            "dev": true,
+            "requires": {
+                "debug": "~3.1.0",
+                "engine.io": "~3.2.0",
+                "has-binary2": "~1.0.2",
+                "socket.io-adapter": "~1.1.0",
+                "socket.io-client": "2.1.1",
+                "socket.io-parser": "~3.2.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "socket.io-adapter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+            "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+            "dev": true
+        },
+        "socket.io-client": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+            "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+            "dev": true,
+            "requires": {
+                "backo2": "1.0.2",
+                "base64-arraybuffer": "0.1.5",
+                "component-bind": "1.0.0",
+                "component-emitter": "1.2.1",
+                "debug": "~3.1.0",
+                "engine.io-client": "~3.2.0",
+                "has-binary2": "~1.0.2",
+                "has-cors": "1.1.0",
+                "indexof": "0.0.1",
+                "object-component": "0.0.3",
+                "parseqs": "0.0.5",
+                "parseuri": "0.0.5",
+                "socket.io-parser": "~3.2.0",
+                "to-array": "0.1.4"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "socket.io-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+            "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+            "dev": true,
+            "requires": {
+                "component-emitter": "1.2.1",
+                "debug": "~3.1.0",
+                "isarray": "2.0.1"
+            },
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+                    "dev": true
+                }
+            }
+        },
         "sort-keys": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -11091,6 +11934,56 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.2"
+            }
+        },
+        "streamroller": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.6.tgz",
+            "integrity": "sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.2",
+                "date-format": "^2.0.0",
+                "debug": "^3.2.6",
+                "fs-extra": "^7.0.1",
+                "lodash": "^4.17.14"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                },
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "fs-extra": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
             }
         },
         "strict-uri-encode": {
@@ -11474,6 +12367,12 @@
                 "is-negated-glob": "^1.0.0"
             }
         },
+        "to-array": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+            "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+            "dev": true
+        },
         "to-buffer": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
@@ -11645,9 +12544,9 @@
             }
         },
         "typescript": {
-            "version": "3.7.0-dev.20191018",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191018.tgz",
-            "integrity": "sha512-Z8KpsytbY5lBMp5cc08VFoO8CgHC6IcbgyiA5vjh7fitkoG0qcem9C354YuiWV4O2+i2gdC7vF8tNUYqO/vUkQ==",
+            "version": "3.7.0-dev.20191017",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.0-dev.20191017.tgz",
+            "integrity": "sha512-Yi0lCPEN0cn9Gp8TEEkPpgKNR5SWAmx9Hmzzz+oEuivw6amURqRGynaLyFZkMA9iMsvYG5LLqhdlFO3uu5ZT/w==",
             "dev": true
         },
         "uglify-js": {
@@ -11920,6 +12819,16 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
+        "useragent": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+            "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+            "dev": true,
+            "requires": {
+                "lru-cache": "4.1.x",
+                "tmp": "0.0.x"
+            }
+        },
         "utf8": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
@@ -12083,6 +12992,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
             "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+            "dev": true
+        },
+        "void-elements": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+            "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
             "dev": true
         },
         "wait-port": {
@@ -12510,7 +13425,7 @@
             "requires": {
                 "underscore": "1.9.1",
                 "web3-core-helpers": "1.2.1",
-                "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+                "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
             }
         },
         "web3-shh": {
@@ -12732,6 +13647,12 @@
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
             "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+            "dev": true
+        },
+        "xmlhttprequest-ssl": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+            "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
             "dev": true
         },
         "xtend": {
@@ -12971,6 +13892,12 @@
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
             }
+        },
+        "yeast": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+            "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+            "dev": true
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,6 +1706,24 @@
             "integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg==",
             "dev": true
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "bip66": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+            "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "bl": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -3641,6 +3659,17 @@
                 "is-obj": "^1.0.0"
             }
         },
+        "drbg.js": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+            "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "^1.0.6",
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4"
+            }
+        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -4033,6 +4062,37 @@
                 "xhr-request-promise": "^0.1.2"
             }
         },
+        "ethereumjs-common": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.2.tgz",
+            "integrity": "sha512-GkltYRIqBLzaZLmF/K3E+g9lZ4O4FL+TtpisAlD3N+UVlR+mrtoG+TvxavqVa6PwOY4nKIEMe5pl6MrTio3Lww==",
+            "dev": true
+        },
+        "ethereumjs-tx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.1.tgz",
+            "integrity": "sha512-QtVriNqowCFA19X9BCRPMgdVNJ0/gMBS91TQb1DfrhsbR748g4STwxZptFAwfqehMyrF8rDwB23w87PQwru0wA==",
+            "dev": true,
+            "requires": {
+                "ethereumjs-common": "^1.3.1",
+                "ethereumjs-util": "^6.0.0"
+            }
+        },
+        "ethereumjs-util": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+            "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+            }
+        },
         "ethers": {
             "version": "4.0.33",
             "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.33.tgz",
@@ -4152,6 +4212,16 @@
                         "strip-hex-prefix": "1.0.0"
                     }
                 }
+            }
+        },
+        "ethjs-util": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+            "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+            "dev": true,
+            "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
             }
         },
         "eventemitter3": {
@@ -4512,6 +4582,12 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
             "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+            "dev": true
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
             "dev": true
         },
         "fileset": {
@@ -8423,6 +8499,18 @@
                 "colors": "^1.1.2"
             }
         },
+        "keccak": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+            "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+            "dev": true,
+            "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "keccakjs": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
@@ -11205,6 +11293,16 @@
                 "inherits": "^2.0.1"
             }
         },
+        "rlp": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
+            "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.11.1",
+                "safe-buffer": "^5.1.1"
+            }
+        },
         "run-async": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -11279,6 +11377,22 @@
             "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
             "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
             "dev": true
+        },
+        "secp256k1": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+            "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+            "dev": true,
+            "requires": {
+                "bindings": "^1.5.0",
+                "bip66": "^1.1.5",
+                "bn.js": "^4.11.8",
+                "create-hash": "^1.2.0",
+                "drbg.js": "^1.0.1",
+                "elliptic": "^6.4.1",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.1.2"
+            }
         },
         "seek-bzip": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
         "test:e2e:ganache": "./scripts/e2e.ganache.sh",
         "test:e2e:geth:auto": "./scripts/e2e.geth.automine.sh",
         "test:e2e:geth:insta": "./scripts/e2e.geth.instamine.sh",
-        "test:e2e:all": "npm run test:e2e:ganache; npm run test:e2e:geth:insta; npm run test:e2e:geth:auto",
+        "test:e2e:clients": "npm run test:e2e:ganache; npm run test:e2e:geth:insta; npm run test:e2e:geth:auto",
+        "test:e2e:chrome": "./scripts/e2e.chrome.sh",
+        "test:e2e:firefox": "./scripts/e2e.firefox.sh",
+        "test:e2e:browsers": "npm run build; npm run test:e2e:chrome; npm run test:e2e:firefox",
         "ci": "./scripts/ci.sh",
         "coveralls": "./scripts/coveralls.sh"
     },
@@ -73,11 +76,12 @@
     ],
     "devDependencies": {
         "@babel/core": "^7.6.4",
+        "@babel/polyfill": "^7.6.0",
         "@babel/preset-env": "^7.6.3",
         "@types/bignumber.js": "^4.0.2",
-        "@types/underscore": "^1.8.0",
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.6.1",
+        "@types/underscore": "^1.8.0",
         "bignumber.js": "^4.0.0",
         "bluebird": "3.3.1",
         "bn.js": "^4.11.8",
@@ -102,12 +106,19 @@
         "istanbul": "^1.1.0-alpha.1",
         "istanbul-combine-updated": "^0.3.0",
         "jshint": "^2.10.2",
+        "karma": "^4.4.1",
+        "karma-browserify": "^6.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^1.2.0",
+        "karma-mocha": "^1.3.0",
+        "karma-spec-reporter": "0.0.32",
         "lerna": "^2.5.1",
         "mocha": "^6.2.1",
+        "puppeteer": "^1.20.0",
         "sandboxed-module": "^2.0.3",
+        "typescript": "next",
         "underscore": "^1.9.1",
         "vinyl-source-stream": "^2.0.0",
-        "wait-port": "^0.2.6",
-        "typescript": "next"
+        "wait-port": "^0.2.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
         "coveralls": "^3.0.7",
         "crypto-js": "^3.1.9-1",
         "del": "^4.1.1",
+        "ethereumjs-common": "^1.3.2",
+        "ethereumjs-tx": "^2.1.1",
         "ethers": "4.0.33",
         "ethjs-signer": "^0.1.1",
         "exorcist": "^1.0.1",

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -336,7 +336,7 @@
 			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.4.2.tgz",
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"requires": {
-				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -129,7 +129,7 @@
 			"resolved": "https://registry.npmjs.org/dtslint/-/dtslint-0.4.2.tgz",
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"requires": {
-				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,13 +9,15 @@ set -o errexit
 
 if [ "$TEST" = "unit" ]; then
 
-  npm run build
   npm run test:unit
+
+if [ "$TEST" = "build_and_lint" ]; then
+
+  npm run build
   npm run dtslint
 
 elif [ "$TEST" = "unit_and_e2e_clients" ]; then
 
-  npm run build
   npm run test:e2e:ganache
   npm run test:e2e:geth:insta
   npm run test:e2e:geth:auto

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,12 +13,19 @@ if [ "$TEST" = "unit" ]; then
   npm run test:unit
   npm run dtslint
 
-elif [ "$TEST" = "unit_and_e2e" ]; then
+elif [ "$TEST" = "unit_and_e2e_clients" ]; then
 
   npm run build
-  npm run test:e2e:all
+  npm run test:e2e:ganache
+  npm run test:e2e:geth:insta
+  npm run test:e2e:geth:auto
   npm run test:unit
-  npm run dtslint
   npm run coveralls
+
+elif [ "$TEST" = "e2e_browsers" ]; then
+
+  npm run build
+  npm run test:e2e:chrome
+  npm run test:e2e:firefox
 
 fi

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -11,7 +11,7 @@ if [ "$TEST" = "unit" ]; then
 
   npm run test:unit
 
-if [ "$TEST" = "build_and_lint" ]; then
+elif [ "$TEST" = "build_and_lint" ]; then
 
   npm run build
   npm run dtslint

--- a/scripts/e2e.chrome.sh
+++ b/scripts/e2e.chrome.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# -------------------------------------------------------------------------------------
+# Runs mocha tests tagged 'e2e' vs chrome headless + insta-mining ganache client
+# -------------------------------------------------------------------------------------
+
+# Exit immediately on error
+set -o errexit
+
+# Run cleanup on exit
+trap cleanup EXIT
+
+cleanup() {
+  if [ -n "$client" ]; then
+    kill -9 $client
+  fi
+}
+
+echo " "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "E2E: chrome headless browser             "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo " "
+
+# Launch ganache, track its PID and wait until port is open
+npx ganache-cli --noVMErrorsOnRPCResponse > /dev/null &
+client=$!
+npx wait-port 8545
+
+# Test
+karma start \
+  --single-run \
+  --browsers ChromeHeadless

--- a/scripts/e2e.firefox.sh
+++ b/scripts/e2e.firefox.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# -------------------------------------------------------------------------------------
+# Runs mocha tests tagged 'e2e' vs firefox headless + insta-mining ganache client
+# -------------------------------------------------------------------------------------
+
+# Exit immediately on error
+set -o errexit
+
+# Run cleanup on exit
+trap cleanup EXIT
+
+cleanup() {
+  if [ -n "$client" ]; then
+    kill -9 $client
+  fi
+}
+
+echo " "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "E2E: firefox headless browser             "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo " "
+
+# Launch ganache, track its PID and wait until port is open
+npx ganache-cli --noVMErrorsOnRPCResponse > /dev/null &
+client=$!
+npx wait-port 8545
+
+# Test
+karma start \
+  --single-run \
+  --browsers FirefoxHeadless

--- a/test/e2e.contract.deploy.js
+++ b/test/e2e.contract.deploy.js
@@ -1,8 +1,8 @@
 var assert = require('assert');
-var Web3 = require('../packages/web3');
 var Basic = require('./sources/Basic');
 var Reverts = require('./sources/Reverts');
 var utils = require('./helpers/test.utils');
+var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
 
 describe('contract.deploy [ @E2E ]', function() {
     var web3;
@@ -78,7 +78,8 @@ describe('contract.deploy [ @E2E ]', function() {
 
         before(async function(){
             // Ganache runs ws and http over the same port
-            var port = process.env.GANACHE ?  8545 : 8546;
+            // & we use it in headless browser tests
+            var port = ( process.env.GANACHE || global.window ) ?  8545 : 8546;
 
             web3 = new Web3('ws://localhost:' + port);
             accounts = await web3.eth.getAccounts();

--- a/test/e2e.contract.deploy.js
+++ b/test/e2e.contract.deploy.js
@@ -77,9 +77,7 @@ describe('contract.deploy [ @E2E ]', function() {
         if (process.env.GETH_INSTAMINE) return;
 
         before(async function(){
-            // Ganache runs ws and http over the same port
-            // & we use it in headless browser tests
-            var port = ( process.env.GANACHE || global.window ) ?  8545 : 8546;
+            var port = utils.getWebsocketPort();
 
             web3 = new Web3('ws://localhost:' + port);
             accounts = await web3.eth.getAccounts();

--- a/test/e2e.contract.deploy.js
+++ b/test/e2e.contract.deploy.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 var Basic = require('./sources/Basic');
 var Reverts = require('./sources/Reverts');
 var utils = require('./helpers/test.utils');
-var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
+var Web3 = utils.getWeb3();
 
 describe('contract.deploy [ @E2E ]', function() {
     var web3;

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
-var Web3 = require('../packages/web3');
 var Basic = require('./sources/Basic');
 var utils = require('./helpers/test.utils');
+var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
 
 describe('contract.events [ @E2E ]', function() {
     var web3;
@@ -17,7 +17,8 @@ describe('contract.events [ @E2E ]', function() {
 
     before(async function(){
         // Ganache runs ws and http over the same port
-        var port = process.env.GANACHE ?  8545 : 8546;
+        // & we use it in headless browser tests
+        var port = ( process.env.GANACHE || global.window ) ?  8545 : 8546;
 
         web3 = new Web3('ws://localhost:' + port);
         accounts = await web3.eth.getAccounts();
@@ -27,6 +28,9 @@ describe('contract.events [ @E2E ]', function() {
     })
 
     it('contract.getPastEvents', async function(){
+        // `getPastEvents` not working with Geth instamine over websockets.
+        if (process.env.GETH_INSTAMINE) return;
+
         await instance
             .methods
             .firesEvent(accounts[0], 1)

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -4,6 +4,9 @@ var utils = require('./helpers/test.utils');
 var Web3 = utils.getWeb3();
 
 describe('contract.events [ @E2E ]', function() {
+    // `getPastEvents` not working with Geth instamine over websockets.
+    if (process.env.GETH_INSTAMINE) return;
+
     var web3;
     var accounts;
     var basic;
@@ -26,9 +29,6 @@ describe('contract.events [ @E2E ]', function() {
     })
 
     it('contract.getPastEvents', async function(){
-        // `getPastEvents` not working with Geth instamine over websockets.
-        if (process.env.GETH_INSTAMINE) return;
-
         await instance
             .methods
             .firesEvent(accounts[0], 1)

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var Basic = require('./sources/Basic');
 var utils = require('./helpers/test.utils');
-var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
+var Web3 = utils.getWeb3();
 
 describe('contract.events [ @E2E ]', function() {
     var web3;

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -16,9 +16,7 @@ describe('contract.events [ @E2E ]', function() {
     };
 
     before(async function(){
-        // Ganache runs ws and http over the same port
-        // & we use it in headless browser tests
-        var port = ( process.env.GANACHE || global.window ) ?  8545 : 8546;
+        var port = utils.getWebsocketPort();
 
         web3 = new Web3('ws://localhost:' + port);
         accounts = await web3.eth.getAccounts();

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
-var Web3 = require('../packages/web3');
 var Basic = require('./sources/Basic');
 var utils = require('./helpers/test.utils');
+var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
 
 describe('method.send [ @E2E ]', function() {
     var web3;
@@ -73,7 +73,8 @@ describe('method.send [ @E2E ]', function() {
 
         before(async function(){
             // Ganache runs ws and http over the same port
-            var port = process.env.GANACHE ?  8545 : 8546;
+            // & we use it in headless browser tests
+            var port = ( process.env.GANACHE || global.window ) ?  8545 : 8546;
 
             web3 = new Web3('ws://localhost:' + port);
             accounts = await web3.eth.getAccounts();

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -72,9 +72,7 @@ describe('method.send [ @E2E ]', function() {
         if (process.env.GETH_INSTAMINE) return;
 
         before(async function(){
-            // Ganache runs ws and http over the same port
-            // & we use it in headless browser tests
-            var port = ( process.env.GANACHE || global.window ) ?  8545 : 8546;
+            var port = utils.getWebsocketPort();
 
             web3 = new Web3('ws://localhost:' + port);
             accounts = await web3.eth.getAccounts();

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var Basic = require('./sources/Basic');
 var utils = require('./helpers/test.utils');
-var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
+var Web3 = utils.getWeb3();
 
 describe('method.send [ @E2E ]', function() {
     var web3;

--- a/test/e2e.method.signing.js
+++ b/test/e2e.method.signing.js
@@ -3,7 +3,7 @@ var EJSCommon = require('ethereumjs-common');
 var EJSTx = require('ethereumjs-tx');
 var Basic = require('./sources/Basic');
 var utils = require('./helpers/test.utils');
-var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
+var Web3 = utils.getWeb3();
 
 describe('transaction and message signing [ @E2E ]', function() {
     let web3;

--- a/test/e2e.method.signing.js
+++ b/test/e2e.method.signing.js
@@ -1,5 +1,9 @@
-let assert = require('assert');
-let Web3 = require('../packages/web3');
+var assert = require('assert');
+var EJSCommon = require('ethereumjs-common');
+var EJSTx = require('ethereumjs-tx');
+var Basic = require('./sources/Basic');
+var utils = require('./helpers/test.utils');
+var Web3 = (global.window) ? require('../packages/web3/dist/web3.min') : require('../packages/web3');
 
 describe('transaction and message signing [ @E2E ]', function() {
     let web3;
@@ -22,7 +26,7 @@ describe('transaction and message signing [ @E2E ]', function() {
 
     it('sendSignedTransaction (with eth.signTransaction)', async function(){
         // ganache does not support eth_signTransaction
-        if (process.env.GANACHE) return;
+        if (process.env.GANACHE || global.window ) return
 
         const destination = wallet[1].address;
         const source = accounts[0]; // Unlocked geth-dev account
@@ -171,7 +175,7 @@ describe('transaction and message signing [ @E2E ]', function() {
 
     it('eth.personal.sign', async function(){
         // ganache does not support eth_sign
-        if (process.env.GANACHE) return;
+        if (process.env.GANACHE || global.window ) return
 
         const message = 'hello';
 
@@ -186,8 +190,7 @@ describe('transaction and message signing [ @E2E ]', function() {
     });
 
     it('eth.accounts.sign', async function(){
-        // ganache does not support eth_sign
-        if (process.env.GANACHE) return;
+        if (process.env.GANACHE || global.window ) return
 
         const message = 'hello';
 

--- a/test/helpers/test.utils.js
+++ b/test/helpers/test.utils.js
@@ -45,11 +45,18 @@ var getWeb3 = function(){
         : require('../../packages/web3');
 }
 
+// Gets correct websocket port for client. Ganache uses 8545 for both
+// http and ws. It's run in e2e.ganache.sh and for all the headless browser tests
+var getWebsocketPort = function(){
+    return ( process.env.GANACHE || global.window ) ?  8545 : 8546;
+}
+
 module.exports = {
     methodExists: methodExists,
     propertyExists: propertyExists,
     mine: mine,
     extractReceipt: extractReceipt,
-    getWeb3: getWeb3
+    getWeb3: getWeb3,
+    getWebsocketPort: getWebsocketPort,
 };
 

--- a/test/helpers/test.utils.js
+++ b/test/helpers/test.utils.js
@@ -37,10 +37,19 @@ var extractReceipt = function(message){
     return JSON.parse(receiptString);
 }
 
+// Conditionally requires web3:
+// loads web3.min when running headless browser tests, the unbuilt web3 otherwise.
+var getWeb3 = function(){
+    return (global.window)
+        ? require('../../packages/web3/dist/web3.min')
+        : require('../../packages/web3');
+}
+
 module.exports = {
     methodExists: methodExists,
     propertyExists: propertyExists,
     mine: mine,
     extractReceipt: extractReceipt,
+    getWeb3: getWeb3
 };
 


### PR DESCRIPTION
Part of #3098

+ Adds new CI job to run the existing E2E tests in headless chrome, headless firefox
+ When browser testing, loads Web3 from `packages/web3/dist/web3.min.js`

There are various ways of setting this up. phantomjs is [deprecated now][1] fwiw. 

Picked karma because it's well supported by Google/Angular, runs mocha tests easily, has lots of plugins, stack-overflow/github help, and should be low-maintenance. 

**Reference Documentation**
+ [karma][2]
+ [karma-chrome-launcher][3]
+ [karma-firefox-launcher][4]

[1]: https://github.com/ariya/phantomjs
[2]: https://karma-runner.github.io/latest/index.html
[3]: https://github.com/karma-runner/karma-chrome-launcher
[4]: https://github.com/karma-runner/karma-firefox-launcher