### PR TITLE
Skip chromium download in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ before_install:
       export LINK="gcc-5";
       export LINKXX="g++-5";
     fi
-  - "export DISPLAY=:99.0"
+  - export DISPLAY=:99.0
+  - export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 install:
     - npm install
 script:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,8 +1,11 @@
-process.env.CHROME_BIN = require('puppeteer').executablePath();
 process.env.MOZ_HEADLESS = 1;
 
+if (!process.env.TRAVIS){
+    process.env.CHROME_BIN = require('puppeteer').executablePath();
+}
+
 module.exports = function (config) {
-    config.set({
+    var configuration = {
         frameworks: [
             'mocha',
             'browserify'
@@ -35,6 +38,19 @@ module.exports = function (config) {
                 base: 'Firefox',
                 flags: ['-headless'],
             },
+            Chrome_travis_ci: {
+                base: 'Chrome',
+                flags: ['--no-sandbox']
+            }
         },
-    });
+    };
+
+    if(process.env.TRAVIS) {
+        configuration.browsers = [
+            'Chrome_travis_ci',
+            'FirefoxHeadless'
+        ];
+    }
+
+    config.set(configuration);
 };


### PR DESCRIPTION
To speed up CI a bit, asks karma to use the chromium stable exposed in the Travis container. 

Locally it uses the chromium downloaded by puppeteer on npm install.