### PR TITLE
Improve eth-abi decodeParameters error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,3 +90,4 @@ Released with 1.0.0-beta.37 code base.
 ### Fixed
 
 - Fix TS types for eth.subscribe syncing, newBlockHeaders, pendingTransactions (#3159)
+- Improve web3-eth-abi decodeParameters error message (#3134)

--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -223,7 +223,11 @@ ABICoder.prototype.decodeParameter = function (type, bytes) {
  */
 ABICoder.prototype.decodeParameters = function (outputs, bytes) {
     if (outputs.length > 0 && (!bytes || bytes === '0x' || bytes === '0X')) {
-        throw new Error('Returned values aren\'t valid, did it run Out of Gas?');
+        throw new Error(
+            'Returned values aren\'t valid, did it run Out of Gas? ' +
+            'Are you using the correct ABI for the contract you are ' +
+            'retrieving data from?'
+        );
     }
 
     var res = ethersAbiCoder.decode(this.mapTypes(outputs), '0x' + bytes.replace(/0x/i, ''));

--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -225,8 +225,10 @@ ABICoder.prototype.decodeParameters = function (outputs, bytes) {
     if (outputs.length > 0 && (!bytes || bytes === '0x' || bytes === '0X')) {
         throw new Error(
             'Returned values aren\'t valid, did it run Out of Gas? ' +
-            'Are you using the correct ABI for the contract you are ' +
-            'retrieving data from?'
+            'You might also see this error if you are not using the ' +
+            'correct ABI for the contract you are retrieving data from, ' +
+            'requesting data from a block number that does not exist, ' +
+            'or querying a node which is not fully synced.'
         );
     }
 

--- a/test/e2e.method.call.js
+++ b/test/e2e.method.call.js
@@ -1,0 +1,68 @@
+var assert = require('assert');
+var Basic = require('./sources/Basic');
+var Misc = require('./sources/Misc');
+var utils = require('./helpers/test.utils');
+var Web3 = utils.getWeb3();
+
+describe('method.call [ @E2E ]', function() {
+    var web3;
+    var accounts;
+    var basic;
+    var instance;
+    var options;
+
+    var basicOptions = {
+        data: Basic.bytecode,
+        gasPrice: '1',
+        gas: 4000000
+    };
+
+    var miscOptions = {
+        data: Misc.bytecode,
+        gasPrice: '1',
+        gas: 4000000
+    };
+
+    before(async function(){
+        web3 = new Web3('http://localhost:8545');
+        accounts = await web3.eth.getAccounts();
+
+        basic = new web3.eth.Contract(Basic.abi, basicOptions);
+        instance = await basic.deploy().send({from: accounts[0]});
+    })
+
+    it('retrieves a uint value', async function(){
+        var expected = '1';
+
+        await instance
+            .methods
+            .setValue(expected)
+            .send({from: accounts[0]});
+
+        var value = await instance
+            .methods
+            .getValue()
+            .call({from: accounts[0]});
+
+        assert.equal(value, expected);
+    });
+
+    it('errors correctly when abi and bytecode do not match', async function(){
+        // Misc n.eq Basic
+        var wrong = new web3.eth.Contract(Basic.abi, miscOptions);
+        var wrongInstance = await wrong.deploy().send({from: accounts[0]});
+
+        try {
+            await wrongInstance
+                .methods
+                .getValue()
+                .call();
+
+            assert.fail();
+
+        } catch(err){
+            assert(err.message.includes("Returned values aren't valid"));
+            assert(err.message.includes('the correct ABI'));
+        }
+    })
+});

--- a/test/sources/Misc.json
+++ b/test/sources/Misc.json
@@ -1,0 +1,15 @@
+{
+  "contractName": "Misc",
+  "abi": [
+    {
+      "inputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    }
+  ],
+  "bytecode": "0x6080604052348015600f57600080fd5b50603580601d6000396000f3fe6080604052600080fdfea165627a7a723058205b81906cade92d8eeda5d0627076490bd44b563a504fe790edbcd6afadbe359d0029",
+  "deployedBytecode": "0x6080604052600080fdfea165627a7a723058205b81906cade92d8eeda5d0627076490bd44b563a504fe790edbcd6afadbe359d0029",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/test/sources/Misc.sol
+++ b/test/sources/Misc.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.5.1;
+
+contract Misc {
+
+    string misc;
+
+    constructor() public {
+    }
+}


### PR DESCRIPTION
Addresses #3134

Also adding a couple small tests / e2e fixtures for 'method.call', because those are missing. 

There's discussion in #3134 about whether current error makes sense at all because it mentions OOG in a context where that's unlikely to be a cause. Am very reluctant to change error messages in 1.x because people may be grepping them to handle certain error conditions, so have just appended some more info that might be helpful. 

