### PR TITLE
Fix TS types for subscription categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,3 +82,11 @@ Released with 1.0.0-beta.37 code base.
 - Fix hexToNumber and hexToNumberString prefix validation (#3086)
 - The receipt will now returned on a EVM error (this got removed on beta.18) (#3129)
 - Fixes transaction confirmations with the HttpProvider (#3140)
+
+## [1.2.3]
+
+### Added
+
+### Fixed
+
+- Fix TS types for eth.subscribe syncing, newBlockHeaders, pendingTransactions (#3159)

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -78,32 +78,21 @@ export class Eth {
 
     subscribe(
         type: 'logs',
-        options?: LogsOptions,
+        options: LogsOptions,
         callback?: (error: Error, log: Log) => void
     ): Subscription<Log>;
     subscribe(
         type: 'syncing',
-        options?: null,
         callback?: (error: Error, result: Syncing) => void
     ): Subscription<Syncing>;
     subscribe(
         type: 'newBlockHeaders',
-        options?: null,
         callback?: (error: Error, blockHeader: BlockHeader) => void
     ): Subscription<BlockHeader>;
     subscribe(
         type: 'pendingTransactions',
-        options?: null,
         callback?: (error: Error, transactionHash: string) => void
     ): Subscription<string>;
-    subscribe(
-        type: 'pendingTransactions' | 'logs' | 'syncing' | 'newBlockHeaders',
-        options?: null | LogsOptions,
-        callback?: (
-            error: Error,
-            item: Log | Syncing | BlockHeader | string
-        ) => void
-    ): Subscription<Log | BlockHeader | Syncing | string>;
 
     getProtocolVersion(
         callback?: (error: Error, protocolVersion: string) => void

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -80,9 +80,6 @@ eth.net;
 eth.clearSubscriptions(() => {});
 
 // $ExpectType Subscription<Log>
-eth.subscribe('logs');
-
-// $ExpectType Subscription<Log>
 eth.subscribe('logs', {});
 // $ExpectType Subscription<Log>
 eth.subscribe('logs', {}, (error: Error, log: Log) => {});
@@ -90,14 +87,16 @@ eth.subscribe('logs', {}, (error: Error, log: Log) => {});
 // $ExpectType Subscription<Syncing>
 eth.subscribe('syncing');
 // $ExpectType Subscription<Syncing>
-eth.subscribe('syncing', null, (error: Error, result: Syncing) => {});
+eth.subscribe(
+    'syncing',
+    (error: Error, result: Syncing) => {}
+);
 
 // $ExpectType Subscription<BlockHeader>
 eth.subscribe('newBlockHeaders');
 // $ExpectType Subscription<BlockHeader>
 eth.subscribe(
     'newBlockHeaders',
-    null,
     (error: Error, blockHeader: BlockHeader) => {}
 );
 
@@ -106,7 +105,6 @@ eth.subscribe('pendingTransactions');
 // $ExpectType Subscription<string>
 eth.subscribe(
     'pendingTransactions',
-    null,
     (error: Error, transactionHash: string) => {}
 );
 


### PR DESCRIPTION


#3159 

In [web3-eth/src/index.js][2], `syncing`, `newBlockHeaders`, and `pendingTransactions` do not expect any options param. 

The 1.x documentation for these subscriptions is [correct][3].

[2]: https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth/src/index.js#L488-L566
[3]: https://web3js.readthedocs.io/en/v1.2.2/web3-eth-subscribe.html#subscribe-pendingtransactions