### PR TITLE
Removes GitHub dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1897,7 +1897,7 @@
         },
         "bluebird": {
             "version": "3.3.1",
-            "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.1.tgz",
             "integrity": "sha1-+Xrhlw9B2FF3KDBT6aEgFg5mxh0=",
             "dev": true
         },
@@ -5254,7 +5254,8 @@
                     "version": "2.1.1",
                     "resolved": false,
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -5278,13 +5279,15 @@
                     "version": "1.0.0",
                     "resolved": false,
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": false,
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -5301,19 +5304,22 @@
                     "version": "1.1.0",
                     "resolved": false,
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": false,
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": false,
                     "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -5444,7 +5450,8 @@
                     "version": "2.0.3",
                     "resolved": false,
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -5458,6 +5465,7 @@
                     "resolved": false,
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -5474,6 +5482,7 @@
                     "resolved": false,
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -5482,13 +5491,15 @@
                     "version": "0.0.8",
                     "resolved": false,
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "resolved": false,
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -5509,6 +5520,7 @@
                     "resolved": false,
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5597,7 +5609,8 @@
                     "version": "1.0.1",
                     "resolved": false,
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -5611,6 +5624,7 @@
                     "resolved": false,
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -5706,7 +5720,8 @@
                     "version": "5.1.2",
                     "resolved": false,
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -5748,6 +5763,7 @@
                     "resolved": false,
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -5769,6 +5785,7 @@
                     "resolved": false,
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -5817,13 +5834,15 @@
                     "version": "1.0.2",
                     "resolved": false,
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "resolved": false,
                     "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -7093,7 +7112,7 @@
         },
         "globby": {
             "version": "6.1.0",
-            "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
@@ -12035,7 +12054,7 @@
             "dependencies": {
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
@@ -13850,9 +13869,9 @@
             }
         },
         "typescript": {
-            "version": "3.8.0-dev.20191023",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191023.tgz",
-            "integrity": "sha512-wzKrmiTbjXsppJhmWev/LVrpih1TNJH1u7Co/3y7WMg3tr5etU6wyvKFGb8SUaov2HlBmuuAe0/ircfdndlS4A==",
+            "version": "3.8.0-dev.20191031",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191031.tgz",
+            "integrity": "sha512-hnIkoA1tdqCoO71ocviQg+ojLPwuZw6IxUtW12hhI+0XCpqNinQOcvUJlak0pVRUKL6vMRjvmhMbE0+uDJp/sA==",
             "dev": true
         },
         "uglify-js": {
@@ -14889,7 +14908,7 @@
                 "eth-lib": "0.2.7",
                 "ethereumjs-common": "^1.3.2",
                 "ethereumjs-tx": "^2.1.1",
-                "scrypt-shim": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+                "scrypt-shim": "github:web3-js/scrypt-shim",
                 "underscore": "1.9.1",
                 "uuid": "3.3.2",
                 "web3-core": "1.2.2",
@@ -15023,7 +15042,7 @@
             "requires": {
                 "underscore": "1.9.1",
                 "web3-core-helpers": "1.2.2",
-                "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+                "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
             },
             "dependencies": {
                 "websocket": {

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -25,6 +25,22 @@
 			"resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
 			"integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ=="
 		},
+		"@web3-js/scrypt-shim": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
+			"integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
+			"requires": {
+				"scryptsy": "^2.1.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
+		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -80,7 +96,7 @@
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
+			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -551,7 +567,7 @@
 		"hash.js": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -685,7 +701,7 @@
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
@@ -859,21 +875,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-		},
-		"scrypt-shim": {
-			"version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-			"from": "github:web3-js/scrypt-shim",
-			"requires": {
-				"scryptsy": "^2.1.0",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
-			}
 		},
 		"scryptsy": {
 			"version": "2.1.0",

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -18,7 +18,7 @@
         "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
-        "@web3-js/scrypt-shim": "1.0.0",
+        "@web3-js/scrypt-shim": "^0.1.0",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.2",

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -18,7 +18,7 @@
         "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
-        "scrypt-shim": "github:web3-js/scrypt-shim",
+        "scrypt-shim": "@web3-js/scrypt-shim",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.2",

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -18,7 +18,7 @@
         "eth-lib": "0.2.7",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
-        "scrypt-shim": "@web3-js/scrypt-shim",
+        "@web3-js/scrypt-shim": "1.0.0",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.2",

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -25,6 +25,18 @@
 			"resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.0.tgz",
 			"integrity": "sha512-bsTIJFVQv7jnvNiC42ld2pQW2KRI+pAG243L+iATvqzy3X6+NH1obz2itRKDZZ8VVhN3wjwYax/VBGCcXzgTqQ=="
 		},
+		"@web3-js/websocket": {
+			"version": "1.0.29",
+			"resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.29.tgz",
+			"integrity": "sha512-QDr5mwRd50qcaIc91yqhpA6CAKgkFBBSPpshlkpU6qDPdtrZoch+AOcUpzGgQHpgg7nvfCtU9VYbnShv8uusJA==",
+			"requires": {
+				"debug": "^2.2.0",
+				"es5-ext": "^0.10.50",
+				"nan": "^2.14.0",
+				"typedarray-to-buffer": "^3.1.5",
+				"yaeti": "^0.0.6"
+			}
+		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -419,17 +431,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-		},
-		"websocket": {
-			"version": "github:web3-js/WebSocket-Node#b134a75541b5db59668df81c03e926cd5f325077",
-			"from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
-			"requires": {
-				"debug": "^2.2.0",
-				"es5-ext": "^0.10.50",
-				"nan": "^2.14.0",
-				"typedarray-to-buffer": "^3.1.5",
-				"yaeti": "^0.0.6"
-			}
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "underscore": "1.9.1",
     "web3-core-helpers": "1.2.2",
-    "websocket": "@web3-js/WebSocket-Node"
+    "@web3-js/WebSocket-Node": "1.0.29"
   },
   "devDependencies": {
     "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "underscore": "1.9.1",
     "web3-core-helpers": "1.2.2",
-    "@web3-js/WebSocket-Node": "1.0.29"
+    "@web3-js/websocket": "^1.0.29"
   },
   "devDependencies": {
     "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "underscore": "1.9.1",
     "web3-core-helpers": "1.2.2",
-    "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+    "websocket": "@web3-js/WebSocket-Node"
   },
   "devDependencies": {
     "definitelytyped-header-parser": "^1.0.1",


### PR DESCRIPTION
Fixes #3071 

### Description

The ``scrypt-shim`` and ``WebsocketNode`` package from the web3-js GitHub organization are currently defined as GitHub dependency instead of npm packages. This PR does update those dependency definitions with published npm packages from us.

The following PRs can only get merged after the release of ``1.2.3`` otherwise the package will not get resolved because of the added scope prefix to the name of those packages:

- https://github.com/web3-js/WebSocket-Node/pull/1
- https://github.com/web3-js/scrypt-shim/pull/2 