### PR TITLE
[types] AbiOutput: add internalType

### DIFF
--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -223,4 +223,5 @@ export interface AbiOutput {
     name: string;
     type: string;
 	components?: AbiOutput[];
+    internalType?: 'address' | 'string' | 'uint256';
 }

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -223,5 +223,5 @@ export interface AbiOutput {
     name: string;
     type: string;
 	components?: AbiOutput[];
-    internalType?: 'address' | 'string' | 'uint256';
+    internalType?: string;
 }


### PR DESCRIPTION
I'm not sure about this one, but `solc` seems emits it, and Truffle [seems to have added it, too](https://github.com/trufflesuite/truffle/pull/2323/files).

I couldn't find anything in the [abi specs](https://solidity.readthedocs.io/en/develop/abi-spec.html) regarding `internalType`.

Setting it to `'address' | 'string' | 'uint256'` for now since I don't really know what values it can have - feedback appreciated :) Otherwise we could just do `string`. 

Also setting it as optional. Again, I have no idea if this should be so, but feels right considering now it's missing altogether.

Random info that may add value:
```
$ solc --version
solc, the solidity compiler commandline interface
Version: 0.5.12+commit.7709ece9.Linux.g+
```

This is the contract source code:
```solidity
pragma solidity ^0.5.0;

contract PoetRegistry {
  struct CID {
    string cid;
  }

  address public _owner;
  CID[] public cids;

  constructor() public {
    _owner = msg.sender;
  }

  function addCid(string memory cid) public {
    cids.push(CID(cid));
  }

  function getCidCount() public view returns (uint) {
    return cids.length;
  }

}
```

And this is the generated abi, converted to TS:
```ts
export const EthereumRegistryContractAbi: AbiItem[] = [
  {
    inputs: [],
    payable: false,
    stateMutability: 'nonpayable',
    type: 'constructor'
  },
  {
    constant: true,
    inputs: [],
    name: '_owner',
    outputs: [
      {
        internalType: 'address',
        name: '',
        type: 'address'
      }
    ],
    payable: false,
    stateMutability: 'view',
    type: 'function'
  },
  {
    constant: false,
    inputs: [
      {
        internalType: 'string',
        name: 'cid',
        type: 'string'
      }
    ],
    name: 'addCid',
    outputs: [],
    payable: false,
    stateMutability: 'nonpayable',
    type: 'function'
  },
  {
    constant: true,
    inputs: [
      {
        internalType: 'uint256',
        name: '',
        type: 'uint256'
      }
    ],
    name: 'cids',
    outputs: [
      {
        internalType: 'string',
        name: 'cid',
        type: 'string'
      }
    ],
    payable: false,
    stateMutability: 'view',
    type: 'function'
  },
  {
    constant: true,
    inputs: [],
    name: 'getCidCount',
    outputs: [
      {
        internalType: 'uint256',
        name: '',
        type: 'uint256'
      }
    ],
    payable: false,
    stateMutability: 'view',
    type: 'function'
  }
]
```

This TS fails to compile with the following error right now:

```
error TS2322: Type '{ internalType: string; name: string; type: string; }' is not assignable to type 'AbiOutput'.
  Object literal may only specify known properties, and 'internalType' does not exist in type 'AbiOutput'.

16         internalType: 'address',
           ~~~~~~~~~~~~~~~~~~~~~~~
```

Using web3 version `1.2.2` in my source code, but property seems to be missing for the 2.x branch too.