### PR TITLE
Prefer receipt status when checking for OOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,5 +89,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix incorrectly errors on tx success when using perfect gas estimates
 - Fix TS types for eth.subscribe syncing, newBlockHeaders, pendingTransactions (#3159)
 - Improve web3-eth-abi decodeParameters error message (#3134)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
-- Fix incorrectly errors on tx success when using perfect gas estimates
+- Fix incorrectly errors on tx success when using perfect gas estimates (#3175)
 - Fix TS types for eth.subscribe syncing, newBlockHeaders, pendingTransactions (#3159)
 - Improve web3-eth-abi decodeParameters error message (#3134)

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -399,7 +399,7 @@ Method.prototype._confirmTransaction = function(defer, result, payload) {
 
                         if (!receipt.outOfGas &&
                             (!gasProvided || !isOOG) &&
-                            (receipt.status === true || receipt.status === '0x1' || typeof receipt.status === 'undefined')) {
+                            (receipt.status === true || typeof receipt.status === 'undefined')) {
                             defer.eventEmitter.emit('receipt', receipt);
                             defer.resolve(receipt);
 

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -393,8 +393,12 @@ Method.prototype._confirmTransaction = function(defer, result, payload) {
                 // CHECK for normal tx check for receipt only
                 .then(function(receipt) {
                     if (!isContractDeployment && !promiseResolved) {
+
+                        var hasStatus = receipt.status === false || receipt.status === true;
+                        var isOOG = !hasStatus && gasProvided === utils.numberToHex(receipt.gasUsed);
+
                         if (!receipt.outOfGas &&
-                            (!gasProvided || gasProvided !== utils.numberToHex(receipt.gasUsed)) &&
+                            (!gasProvided || !isOOG) &&
                             (receipt.status === true || receipt.status === '0x1' || typeof receipt.status === 'undefined')) {
                             defer.eventEmitter.emit('receipt', receipt);
                             defer.resolve(receipt);

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -35,6 +35,20 @@ describe('method.send [ @E2E ]', function() {
             assert(web3.utils.isHexStrict(receipt.transactionHash));
         });
 
+        it('succeeds when using a perfect estimate', async function(){
+            var estimate = await instance
+                .methods
+                .setValue('1')
+                .estimateGas();
+
+            var receipt = await instance
+                .methods
+                .setValue('1')
+                .send({from: accounts[0], gas: estimate});
+
+            assert(receipt.status === true);
+        });
+
         it('errors on OOG', async function(){
             try {
                 await instance
@@ -64,6 +78,29 @@ describe('method.send [ @E2E ]', function() {
                 assert(err.message.includes('revert'))
                 assert(receipt.status === false);
             }
+        });
+
+        it('errors on revert using a perfect estimate', async function(){
+            var estimate = await instance
+                .methods
+                .setValue('1')
+                .estimateGas();
+
+            try {
+                await instance
+                    .methods
+                    .reverts()
+                    .send({from: accounts[0], gas: estimate});
+
+                assert.fail();
+
+            } catch(err){
+                var receipt = utils.extractReceipt(err.message);
+
+                assert(err.message.includes('revert'))
+                assert(receipt.status === false);
+            }
+
         });
     });
 

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -79,29 +79,6 @@ describe('method.send [ @E2E ]', function() {
                 assert(receipt.status === false);
             }
         });
-
-        it('errors on revert using a perfect estimate', async function(){
-            var estimate = await instance
-                .methods
-                .setValue('1')
-                .estimateGas();
-
-            try {
-                await instance
-                    .methods
-                    .reverts()
-                    .send({from: accounts[0], gas: estimate});
-
-                assert.fail();
-
-            } catch(err){
-                var receipt = utils.extractReceipt(err.message);
-
-                assert(err.message.includes('revert'))
-                assert(receipt.status === false);
-            }
-
-        });
     });
 
     describe('ws', function() {


### PR DESCRIPTION
## Description

If receipt has a valid (e.g `true` or `false`) value, it cannot be OOG anymore. This is slightly different than what is suggested in  #3175 by @nivida, and does not include the additional contract data checks suggested by @gabmontes. Pinging both of you for review...

RE: 

> - If the ``status`` property is ``false`` and ``providedGas !== gasUsed`` then the transaction got reverted because of the logic implemented of the current contract (``require``, ``throw``). 
> - If the ``status`` property is ``false`` and ``providedGas === gasUsed`` then the transaction got reverted by a non-contract-logic related problem (not enough gas).   

This PR includes the second case as a test which expects `revert`. It's possible for someone to use a perfect estimate for a method that calls `require` for example. I *think* this is closest the currently expected behavior since the gas check wasn't really being done before.

Fixes #3175

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
