### PR TITLE
Revert 3123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,5 +89,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix perfect gas usage causes tx to error (#3175)
 - Fix TS types for eth.subscribe syncing, newBlockHeaders, pendingTransactions (#3159)
 - Improve web3-eth-abi decodeParameters error message (#3134)

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -394,7 +394,7 @@ Method.prototype._confirmTransaction = function(defer, result, payload) {
                 .then(function(receipt) {
                     if (!isContractDeployment && !promiseResolved) {
                         if (!receipt.outOfGas &&
-                            (!gasProvided || gasProvided !== utils.numberToHex(receipt.gasUsed)) &&
+                            (!gasProvided || gasProvided !== receipt.gasUsed) &&
                             (receipt.status === true || receipt.status === '0x1' || typeof receipt.status === 'undefined')) {
                             defer.eventEmitter.emit('receipt', receipt);
                             defer.resolve(receipt);


### PR DESCRIPTION
## Description

Reverts #3123 - just queuing this up so that it's possible to publish quickly if necessary.

#3123 fixed a bug in the expression which evaluates tx success/error conditions for pre-byzantium chains. However it broke expected behavior for post-byzantium chains such that calls which supply the perfect amount of gas now error even though the transaction succeeded. 

**Ex:**
```javascript
web3.eth.sendTransaction({
  from: accounts[0],
  to: accounts[1],
  value: web3.utils.toWei('1', 'ether'),
  gas: 21000
})
```
There's ongoing work to resolve this to everyone's satisfaction in #3189 (but no agreement yet). 

Fixes #3175

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run test``` with success and extended the tests if necessary.
- [x] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
