### PR TITLE
Defines corejs v2 in the gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -188,7 +188,7 @@ packages.forEach(function(pckg, i) {
         stream = stream.pipe(source(pckg.fileName + '.js'))
             .pipe(streamify(babel({
                 compact: false,
-                presets: [[ '@babel/preset-env', { "useBuiltIns": "usage" } ]]
+                presets: [[ '@babel/preset-env', { "useBuiltIns": "usage", "corejs": 2 } ]]
             })));
 
         if (pckg.fileName === 'web3') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "web3",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -16463,9 +16463,9 @@
             }
         },
         "typescript": {
-            "version": "3.8.0-dev.20191031",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191031.tgz",
-            "integrity": "sha512-hnIkoA1tdqCoO71ocviQg+ojLPwuZw6IxUtW12hhI+0XCpqNinQOcvUJlak0pVRUKL6vMRjvmhMbE0+uDJp/sA==",
+            "version": "3.8.0-dev.20191114",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191114.tgz",
+            "integrity": "sha512-MAs1r6AQm48QXLqa8u7rkwb4GRhK/SABox5WwQjSJJN/a0uP3Mpw77C92gG6+M+BuGnhQq5sNAz5NleL7lj2Dg==",
             "dev": true
         },
         "uglify-js": {
@@ -17566,7 +17566,7 @@
                 },
                 "scrypt-shim": {
                     "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-                    "from": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+                    "from": "github:web3-js/scrypt-shim",
                     "dev": true,
                     "requires": {
                         "scryptsy": "^2.1.0",
@@ -17683,7 +17683,7 @@
             "dependencies": {
                 "websocket": {
                     "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-                    "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+                    "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
                     "dev": true,
                     "requires": {
                         "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3",
     "private": true,
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Ethereum JavaScript API wrapper repository",
     "license": "LGPL-3.0",
     "engines": {
@@ -91,6 +91,7 @@
         "bower": "1.8.8",
         "browserify": "^16.5.0",
         "chai": "^4.2.0",
+        "core-js": "^2.6.10",
         "coveralls": "^3.0.7",
         "crypto-js": "^3.1.9-1",
         "del": "^4.1.1",


### PR DESCRIPTION
## Description

The ``corejs`` options property was missing in the babel config and brought up a warning during bundling of web3.js. Instead of letting babel choose automatically version 2 of it do we now defined it explicit. 

## Type of change

<!--- Please delete options that are not relevant. -->

- [X] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary.
- [x] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
