### PR TITLE
fix: Fix typings export for web3-providers-ws

### DIFF
--- a/packages/web3-providers-ws/types/index.d.ts
+++ b/packages/web3-providers-ws/types/index.d.ts
@@ -22,4 +22,4 @@
 
 import { WebsocketProviderBase } from 'web3-core-helpers';
 
-export class WebsocketProvider extends WebsocketProviderBase { }
+export default class WebsocketProvider extends WebsocketProviderBase { }

--- a/packages/web3-providers-ws/types/tests/web3-provider-ws-tests.ts
+++ b/packages/web3-providers-ws/types/tests/web3-provider-ws-tests.ts
@@ -21,7 +21,7 @@
  */
 
 import { WebsocketProviderOptions, JsonRpcResponse } from 'web3-core-helpers';
-import { WebsocketProvider } from 'web3-providers';
+import WebsocketProvider from 'web3-providers';
 
 const options: WebsocketProviderOptions = {
     timeout: 30000,


### PR DESCRIPTION
The WebsocketProvider class is set as `module.exports` in https://github.com/ethereum/web3.js/blob/1.x/packages/web3-providers-ws/src/index.js#L417 which makes it a `default` export.

Currently, if you use the typings published in v1.2.4 you will get an error like `TypeError: WebsocketProvider is not a constructor` when trying to use it.