### PR TITLE
types(web3-core-helpers): fix disconnect args

### DIFF
--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -97,7 +97,7 @@ export class WebsocketProviderBase {
 
     reset(): void;
 
-    disconnect(code: number, reason: string): void;
+    disconnect(code?: number, reason?: string): void;
 }
 
 export class IpcProviderBase {


### PR DESCRIPTION
This PR makes WebsocketProviderBase.disconnect arguments optional in the type declaration file, since they have a default value in the JavaScript implementation for the 2.x branch and the arguments aren't even present in the 1.x branch, and they should be optional per [the MDN WebSocket.close() docs](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close).

The correct change would be to actually remove the arguments in the 1.x branch and make them optional in the 2.x branch, but that would be an unnecessary breaking change for the 1.x branch without much added value (other than to warn users that the arguments they are passing won't do anything).

I have only tested this by manually introducing the change to the installed library in my project under `node_modules` and running `npm run build` in my project, which uses Web3.

Will open a PR with the same change for the 2.x branch if this one is accepted.

Relevant code:

https://github.com/ethereum/web3.js/blob/5c78c2b7cfa37afedfe1ac020bf912b3e85cfd8a/packages/web3-providers-ws/src/index.js#L401-L405

https://github.com/ethereum/web3.js/blob/8a3b5a7e1e07a5bd7b76a92005870c80cb96d521/packages/web3-providers/src/providers/WebsocketProvider.js#L132-L144

## Checklist:

- [ ] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run test``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build``` and tested the resulting file from ```dist``` folder in a browser.
- [ ] I have tested my code on the live network.
