### PR TITLE
Extends the web3-eth module with the method getPendingTransactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,5 +105,6 @@ Released with 1.0.0-beta.37 code base.
 - ``eth_requestAccounts`` as ``requestAccounts`` added to web3-eth package (#3219)
 - ``sha3Raw`` and ``soliditySha3Raw`` added to web3-utils package (#3226)
 - ``eth_getProof`` as ``getProof`` added to web3-eth package (#3220)
+- ``getPendingTransactions`` added to web3-eth package (#3239)
 
 ### Fixed

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -1047,7 +1047,89 @@ Example
         "input": "0x57cb2fc4"
     }
 
+------------------------------------------------------------------------------
 
+.. _eth-getpendingtransactions:
+
+getPendingTransactions
+======================
+
+.. code-block:: javascript
+
+    web3.eth.getPendingTransactions([, callback])
+
+Returns a list of pending transactions.
+
+----------
+Parameters
+----------
+
+1. ``Function`` - (optional) Optional callback, returns an error object as first parameter and the result as second.
+
+
+.. _eth-getpendingtransactions-return:
+
+-------
+Returns
+-------
+
+
+``Promise<object[]>`` - Array of pending transactions:
+
+  - ``hash`` 32 Bytes - ``String``: Hash of the transaction.
+  - ``nonce`` - ``Number``: The number of transactions made by the sender prior to this one.
+  - ``blockHash`` 32 Bytes - ``String``: Hash of the block where this transaction was in. ``null`` when its pending.
+  - ``blockNumber`` - ``Number``: Block number where this transaction was in. ``null`` when its pending.
+  - ``transactionIndex`` - ``Number``: Integer of the transactions index position in the block. ``null`` when its pending.
+  - ``from`` - ``String``: Address of the sender.
+  - ``to`` - ``String``: Address of the receiver. ``null`` when its a contract creation transaction.
+  - ``value`` - ``String``: Value transferred in :ref:`wei <what-is-wei>`.
+  - ``gasPrice`` - ``String``: The wei per unit of gas provided by the sender in :ref:`wei <what-is-wei>`.
+  - ``gas`` - ``Number``: Gas provided by the sender.
+  - ``input`` - ``String``: The data sent along with the transaction.
+
+
+
+-------
+Example
+-------
+
+.. code-block:: javascript
+
+    web3.eth.getPendingTransactions().then(console.log);
+    >  [
+        {
+            hash: '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
+            nonce: 2,
+            blockHash: '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46',
+            blockNumber: 3,
+            transactionIndex: 0,
+            from: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+            to: '0x6295ee1b4f6dd65047762f924ecd367c17eabf8f',
+            value: '123450000000000000',
+            gas: 314159,
+            gasPrice: '2000000000000',
+            input: '0x57cb2fc4'
+            v: '0x3d',
+            r: '0xaabc9ddafffb2ae0bac4107697547d22d9383667d9e97f5409dd6881ce08f13f',
+            s: '0x69e43116be8f842dcd4a0b2f760043737a59534430b762317db21d9ac8c5034'
+        },....,{
+            hash: '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b',
+            nonce: 3,
+            blockHash: '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46',
+            blockNumber: 4,
+            transactionIndex: 0,
+            from: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+            to: '0x6295ee1b4f6dd65047762f924ecd367c17eabf8f',
+            value: '123450000000000000',
+            gas: 314159,
+            gasPrice: '2000000000000',
+            input: '0x57cb2fc4'
+            v: '0x3d',
+            r: '0xaabc9ddafffb2ae0bac4107697547d22d9383667d9e97f5409dd6881ce08f13f',
+            s: '0x69e43116be8f842dcd4a0b2f760043737a59534430b762317db21d9ac8c5034'
+        }
+   ]
 
 ------------------------------------------------------------------------------
 

--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -496,6 +496,12 @@ var Eth = function Eth() {
             inputFormatter: [formatter.inputAddressFormatter, formatter.inputStorageKeysFormatter, formatter.inputDefaultBlockNumberFormatter],
             outputFormatter: formatter.outputProofFormatter
         }),
+        new Method({
+            name: 'getPendingTransactions',
+            call: 'eth_pendingTransactions',
+            params: 0,
+            outputFormatter: formatter.outputTransactionFormatter
+        }),
 
         // subscriptions
         new Subscriptions({

--- a/test/eth.getPendingTransactions.js
+++ b/test/eth.getPendingTransactions.js
@@ -1,0 +1,44 @@
+var testMethod = require('./helpers/test.method.js');
+
+var unformattedTx = {
+    "hash":"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+    "nonce":"0x5",
+    "blockHash": "0x6fd9e2a26ab",
+    "blockNumber": "0x15df",
+    "transactionIndex":  "0x1",
+    "from":"0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+    "to":"0x85f43d8a49eeb85d32cf465507dd71d507100c1d",
+    "value":"0x7f110",
+    "gas": "0x7f110",
+    "gasPrice":"0x09184e72a000",
+    "input":"0x603880600c6000396000f30060"
+};
+
+var result = [unformattedTx, unformattedTx];
+
+var formattedTx = {
+    "hash":"0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+    "nonce":5,
+    "blockHash": "0x6fd9e2a26ab",
+    "blockNumber": 5599,
+    "transactionIndex":  1,
+    "from":"0x407D73d8a49eeb85D32Cf465507dd71d507100c1", // checksum address
+    "to":"0x85F43D8a49eeB85d32Cf465507DD71d507100C1d", // checksum address
+    "value": '520464',
+    "gas": 520464,
+    "gasPrice": '10000000000000',
+    "input":"0x603880600c6000396000f30060"
+};
+
+var formattedResult = [formattedTx, formattedTx];
+
+var tests = [{
+    args: [],
+    formattedArgs: [],
+    result: result,
+    formattedResult: formattedResult,
+    call: 'eth_pendingTransactions'
+}];
+
+testMethod.runTests('eth', 'getPendingTransactions', tests);
+


### PR DESCRIPTION
## Description

This PR does add the JSON-RPC method ``eth_pendingTransactions`` as ``getPendingTransactions`` method to the ``web3-eth`` module.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
