### PR TITLE
temporary fix for batchRequest

### DIFF
--- a/packages/web3-providers/src/providers/MetamaskProvider.js
+++ b/packages/web3-providers/src/providers/MetamaskProvider.js
@@ -139,8 +139,11 @@ export default class MetamaskProvider extends AbstractSocketProvider {
      * @returns {Promise<any>}
      */
     sendPayload(payload) {
+        const method = Array.isArray(payload)
+            ? 'sendAsync'
+            : 'send';
         return new Promise((resolve, reject) => {
-            this.connection.send(payload, (error, response) => {
+            this.connection[method](payload, (error, response) => {
                 if (!error) {
                     return resolve(response);
                 }


### PR DESCRIPTION
correct me if I am making it wrong or worse.
Yesterday, MetaMask has just released version 7.7 and it seems the new release is not compatible with BatchReqest.
https://github.com/ethereum/EIPs/issues/2319#issuecomment-544795458
I checked the code a little bit. MetaMaskInPageProvider used to call `sendAsync` kind of directly, So I think we still need that feature when it comes to batchRequest.

Hence the change.
BTW, I also heard that even `sendAsync` would be superseded by `send()`.