### PR TITLE
Build is smaller on second install?

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ var exorcist = require('exorcist');
 var bower = require('bower');
 var streamify = require('gulp-streamify');
 var replace = require('gulp-replace');
-var shakeify = require('common-shakeify');
+//var shakeify = require('common-shakeify');
 var exec = require('child_process').exec;
 
 var DEST = path.join(__dirname, 'dist/');
@@ -166,7 +166,7 @@ packages.forEach(function(pckg, i) {
         browserifyOptions.standalone = pckg.expose;
 
         var stream = browserify(browserifyOptions)
-            .plugin(shakeify)
+            //.plugin(shakeify)
             .require(pckg.src, {expose: pckg.expose})
             .require('bn.js', {expose: 'BN'}) // expose it to dapp developers
             .add(pckg.src);

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,6 +13,11 @@ if [ "$TEST" = "unit" ]; then
 
 elif [ "$TEST" = "build_and_lint" ]; then
 
+  cd packages/web3
+  npm install --save bn.js@4.11.8
+  npm install --save underscore@1.9.1
+  cd ../..
+
   npm run build
   npm run dtslint
   npm run depcheck


### PR DESCRIPTION
## Description
**NB: PR targets #3262 which standardizes the bn.js version across the project**

PR reduces the bundlesize ~20%, but in a way that is super weird. Suggests something is wrong with the way browserify de-duplicates things in a lerna monorepo. 

TLDR; if you install the project and *then* go to packages/web3 (the bundle entry point) and install the most widely duplicated deps there, there's a big bundle reduction. 

+ [with common-shakeify][1]:  **885kb**  (Broken build)
+ without common-shakeify:  **906kb**

Also tried browserify's `preserveSymlinks` option to address this and was quickly OOM within 4GB - @nivida was this the same thing you were seeing when you looked at this in October?

**[EDITED notes...]**
+ ~~treat the published min as a convenience and not worry about it's size too much (although it would be great to get something on the CDN that was small)~~
+ Actually, this PR and #3262 show rollup is the best approach. Browserify is not bundling correctly.
+ We could also try to measure size by :
  + running virtual npm publish, 
  + create a tiny fake project with installed web3, 
  + webpack with minnification
  + measure size of webpack build.

[1]: https://travis-ci.org/ethereum/web3.js/jobs/622370838#L1171
