### PR TITLE
Provider improvements/geth disconnect test

### DIFF
--- a/scripts/e2e.geth.automine.sh
+++ b/scripts/e2e.geth.automine.sh
@@ -27,7 +27,7 @@ echo " "
 geth-dev-assistant --period 2 --accounts 1 --tag 'stable'
 
 # Test
-istanbul cover _mocha -- \
+GETH_AUTOMINE=true istanbul cover _mocha -- \
   --reporter spec \
   --grep 'E2E' \
   --timeout 15000 \

--- a/test/e2e.subscribe.geth.js
+++ b/test/e2e.subscribe.geth.js
@@ -1,0 +1,179 @@
+const assert = require('assert');
+const utils = require('./helpers/test.utils');
+const geth = require('./helpers/test.geth.api');
+const Web3 = utils.getWeb3();
+const util = require('util')
+
+// NB: there are parallel tests for ganache at `eth.subscribe.ganache` in the main unit tests
+describe('subscription connect/reconnect (geth) [ @E2E ]', function() {
+    this.timeout(15000);
+
+    // Geth instamine over WS is unreliable
+    if (!process.env.GETH_AUTOMINE) return;
+
+    let web3;
+    let accounts;
+
+    // Setup a seperate RPC connection for the admin startWS calls
+    // Once we close the websocket with the 'test Web3 instance',
+    // it cannot be used to make more admin calls.
+    before(function(){
+        geth.connectHTTP(Web3, 8545);
+    });
+
+    beforeEach(async function() {
+        web3 = new Web3('ws://localhost:8546');
+        accounts = await web3.eth.getAccounts();
+    });
+
+    afterEach(async function() {
+        await geth.admin.wsStart();
+    });
+
+    // Usually passes, unstable when run with other suites.
+    // Test closes the connection and is notified of the drop.
+    it.skip('(1) admin.close closes the connection (baseline)', async function(){
+        try {
+            await geth.admin.wsStop(web3);
+            assert(fail);
+        } catch (err) {
+            assert(err.message.includes('CONNECTION ERROR'));
+            assert(err.message.includes('1006'));
+        }
+    });
+
+    // Usually passes, unstable when run with other suites.
+    it.skip('(2) eth calls fail after the connection has been dropped (baseline)', async function(){
+        await geth.admin.wsStopQuietly(web3)
+
+        try {
+            const val = await web3.eth.getBlockNumber();
+            assert.fail();
+        } catch (err){
+            assert(err.message.includes('connection not open on send()'))
+        }
+    });
+
+
+    it('(3) subscribes (baseline)', function() {
+        return new Promise(async function (resolve) {
+            web3.eth
+                .subscribe('newBlockHeaders')
+                .on('data', function(result) {
+                    assert(result.parentHash);
+                    this.removeAllListeners();
+                    resolve();
+                })
+        });
+    });
+
+    // This test times-out. There *is* a `connection not open on send()` error
+    // received in the callback handler in Subscription.subscribe, but it does not bubble up.
+    it.skip('(4) errors on subscribing when connection is already closed', async function() {
+        await geth.admin.wsStopQuietly(web3)
+
+        return new Promise(async function (resolve) {
+            web3.eth
+                .subscribe('newBlockHeaders')
+                .on('error', function(err) {
+                    assert(err.message.includes('CONNECTION ERROR'));
+                    this.removeAllListeners(); // Idk about this...
+                    resolve();
+                });
+        });
+    });
+
+    // This test usually passes on its own, usually fails in sequence: race-conditiony.
+    it.skip('(5) errors when subscr is already running & connection gets closed', function() {
+        let stage = 0;
+        let interval;
+
+        return new Promise(async function (resolve) {
+            web3.eth
+                .subscribe('newBlockHeaders')
+                .on('data', async function() {
+                    stage = 1;
+                })
+                .on('error', function(err) {
+                    assert(err.message.includes('CONNECTION ERROR'));
+                    this.removeAllListeners();
+                    resolve();
+                });
+
+            // StopWS from outside the handler logic,
+            interval = setInterval(async function(){
+                if (stage === 1){
+                    await geth.admin.wsStopQuietly(web3);
+                    clearInterval(interval);
+                }
+            }, 50)
+
+        });
+    });
+
+    // This test usually passes on its own, usually fails in sequence: race-conditiony.
+    it.skip('(6) auto reconnects and keeps the subscription running', function() {
+        const provider = new Web3.providers.WebsocketProvider(
+            'ws://localhost:8546',
+            {reconnect: {auto: true}}
+        )
+
+        web3.setProvider(provider);
+
+        return new Promise(async function (resolve) {
+            // Stage 0:
+            let stage = 0;
+
+            web3.eth
+                .subscribe('newBlockHeaders')
+                .on('data', function(result) {
+                    assert(result.parentHash);
+
+                    // Exit point, flag set below
+                    if (stage === 1) {
+                        web3.currentProvider.disconnect();
+                        this.removeAllListeners();
+                        resolve();
+                    }
+                });
+
+            // Stage 1: Close & re-open server
+            await geth.admin.wsStopQuietly(web3);
+            await geth.admin.wsStart();
+            stage = 1;
+        });
+    });
+
+    // This test always times out, even alone.
+    it.skip('(7) auto reconnects, keeps subscr. running & triggers `connected` listener twice', function() {
+        const provider = new Web3.providers.WebsocketProvider(
+            'ws://localhost:8546',
+            {reconnect: {auto: true}}
+        );
+
+        web3.setProvider(provider);
+
+        return new Promise(async function (resolve) {
+            // Stage 0:
+            let stage = 0;
+
+            web3.eth
+                .subscribe('newBlockHeaders')
+                .on('connected', function(result) {
+                    assert(result);
+
+                    // Exit point, flag set below
+                    if (stage === 1) {
+                        web3.currentProvider.disconnect();
+                        resolve();
+                    }
+                });
+
+            // Stage 1: Close & re-open server
+            await geth.admin.wsStopQuietly(web3);
+            await geth.admin.wsStart();
+            stage = 1;
+        });
+    });
+});
+

--- a/test/helpers/test.geth.api.js
+++ b/test/helpers/test.geth.api.js
@@ -1,0 +1,67 @@
+//Helpers to make RPC calls for non-standard geth apis
+const wait = require('./test.utils').wait;
+
+let adminWeb3;
+
+// Methods
+async function send(_web3, packet){
+  return new Promise((resolve, reject) => {
+    _web3.currentProvider.send(packet, (err, res) => {
+      if (err !== null) return reject(err);
+      return resolve(res);
+    });
+  });
+}
+
+// Opens own RPC connection
+async function connectHTTP(Web3, port){
+  adminWeb3 = new Web3('http://localhost:' + port);
+}
+
+// RPC Packets
+const wsStartPacket = {
+    jsonrpc: "2.0",
+    method: "admin_startWS",
+    params: [],
+    id: new Date().getTime()
+};
+
+const wsStopPacket = {
+    jsonrpc: "2.0",
+    method: "admin_stopWS",
+    params: [],
+    id: new Date().getTime()
+}
+
+// Admin API Endpoints to open and close ws connections over RPC
+
+// wsStart with the http connection, since we're using the
+// ws connection to close and it will be broken when we want to start again.
+async function wsStart(){
+  await send(adminWeb3, wsStartPacket);
+  await wait(250);
+}
+
+// wsStop with the ws connection created in the test so the relevant instance
+// definitely hears the close event, definitely runs the close logic.
+async function wsStop(testWeb3){
+  await send(testWeb3, wsStopPacket);
+}
+
+// Stop and swallow error so we don't have to wrap wsStop in a try catch everywhere.
+async function wsStopQuietly(testWeb3){
+  try { await send(testWeb3, wsStopPacket) } catch (err){}
+}
+
+
+const admin = {
+    wsStart: wsStart,
+    wsStop: wsStop,
+    wsStopQuietly: wsStopQuietly
+}
+
+// Exports
+module.exports = {
+  admin: admin,
+  connectHTTP: connectHTTP
+}

--- a/test/helpers/test.utils.js
+++ b/test/helpers/test.utils.js
@@ -51,6 +51,11 @@ var getWebsocketPort = function(){
     return ( process.env.GANACHE || global.window ) ?  8545 : 8546;
 }
 
+// waits milliseconds
+async function wait(ms=0){
+  return new Promise(resolve => setTimeout(() => resolve(), ms))
+}
+
 module.exports = {
     methodExists: methodExists,
     propertyExists: propertyExists,
@@ -58,5 +63,6 @@ module.exports = {
     extractReceipt: extractReceipt,
     getWeb3: getWeb3,
     getWebsocketPort: getWebsocketPort,
+    wait: wait
 };
 


### PR DESCRIPTION
## Description

Mix of good and bad news, I guess. 

**Good**
+ 3 (real) tests pass.

**Less good**
+ The simple test case for `eth.subscribe` when the connection is already closed fails. There *is* a "connection not open on send()" error caught in Subscription.subscribe but it doesn't bubble up. This emitter seems disconnected from anything:
https://github.com/ethereum/web3.js/blob/8804708330c25de72c13dcb6182729e52693ba06/packages/web3-core-subscriptions/src/subscription.js#L300
  In the ganache tests, it looks like this error case is handled by the WS module [close handler][1], the client behavior is different somehow.

[1]: https://github.com/ethereum/web3.js/blob/provider-related-improvements/packages/web3-providers-ws/src/index.js#L199-L226

+ The passing tests error when run in sequence - will have to debug that further.

+ The last, more complex autoreconnect case fails.

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.