### PR TITLE
Add E2E Mosaic test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - node_js: 10
       env: TEST=e2e_truffle
     - node_js: 10
+      env: TEST=e2e_mosaic
+    - node_js: 10
       env: TEST=e2e_browsers
       addons:
         chrome: stable
@@ -26,6 +28,8 @@ matrix:
   allow_failures:
     - node_js: 10
       env: TEST=e2e_truffle
+    - node_js: 10
+      env: TEST=e2e_mosaic
 
 addons:
   apt:
@@ -45,7 +49,7 @@ before_install:
   - export DISPLAY=:99.0
   - export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 install:
-  - if [ $TEST != "e2e_truffle" ]; then
+  - if [[ $TEST != "e2e_truffle" ]] && [[ $TEST != "e2e_mosaic" ]]; then
       npm install;
     fi
 script:

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "test:e2e:browsers": "npm run build; npm run test:e2e:chrome; npm run test:e2e:firefox",
         "test:e2e:publish": "./scripts/e2e.npm.publish.sh",
         "test:e2e:truffle": "./scripts/e2e.truffle.sh",
+        "test:e2e:mosaic": "./scripts/e2e.mosaic.sh",
         "ci": "./scripts/ci.sh",
         "coveralls": "./scripts/coveralls.sh"
     },

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -144,6 +144,7 @@ RequestManager.prototype.send = function (data, callback) {
             return callback(errors.InvalidResponse(result));
         }
 
+        console.log('In published web3 @ requestManager.send');
         callback(null, result.result);
     });
 };

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -65,6 +65,7 @@ RequestManager.providers = {
  */
 RequestManager.prototype.setProvider = function (p, net) {
     var _this = this;
+    console.log('Using published Web3 @ RequestManager.setProvider')
 
     // autodetect provider
     if(p && typeof p === 'string' && this.providers) {
@@ -144,7 +145,6 @@ RequestManager.prototype.send = function (data, callback) {
             return callback(errors.InvalidResponse(result));
         }
 
-        console.log('In published web3 @ requestManager.send');
         callback(null, result.result);
     });
 };

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -65,7 +65,6 @@ RequestManager.providers = {
  */
 RequestManager.prototype.setProvider = function (p, net) {
     var _this = this;
-    console.log('Using published Web3 @ RequestManager.setProvider')
 
     // autodetect provider
     if(p && typeof p === 'string' && this.providers) {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -39,4 +39,9 @@ elif [ "$TEST" = "e2e_truffle" ]; then
   npm run test:e2e:publish
   npm run test:e2e:truffle
 
+elif [ "$TEST" = "e2e_mosaic" ]; then
+
+  npm run test:e2e:publish
+  npm run test:e2e:mosaic
+
 fi

--- a/scripts/e2e.mosaic.sh
+++ b/scripts/e2e.mosaic.sh
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------------------------------------
+# Run mosaicdao/mosaic-1 fork (w/ buidler truffle5 plugin) using a candidate
+# branch of web3 which has been published to a proxy npm registry in `e2e.npm.publish.sh`
+#
+# This test's purpose is to watch web3 execute a long, complex test suite
+# It uses buidler-adapted fork of mosaicdao because that tool is simpler and
+# more modular than Truffle and lets us resolve arbitrary versions of web3 more easily.
+# --------------------------------------------------------------------------------------------
+
+# Exit immediately on error
+set -o errexit
+
+# To mimic `npm install web3` correctly, this test does not install Web3's dev deps.
+# However, we need the npm package `semver` to coerce yarn resolutions correctly.
+# It must be installed as a dev dep or Node complains. We also need web3's package.json
+# to resolve the current version + patch increment. So some file renaming is necessary here...
+cp package.json original.package.json
+rm package.json
+rm package-lock.json
+npm init --yes
+npm install --save-dev semver
+
+# Install mosaic and set yarn resolutions to virtually published patch version
+git clone https://github.com/cgewecke/mosaic-1.git
+scripts/js/resolutions.js mosaic-1
+cd mosaic-1
+
+# Install via registry and verify
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "Installing updated web3 via virtual registry "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+
+git submodule update --init --recursive
+yarn --registry http://localhost:4873
+
+yarn add web3@e2e --registry http://localhost:4873
+
+yarn list web3
+yarn list web3-utils
+yarn list web3-core
+yarn list web3-core-promievent
+
+cat ./package.json
+
+# Test
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "Running mosaicdao/mosaic-1 unit tests.      "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+
+# Launch ganache
+./tools/run_ganache_cli.sh </dev/null 1>/dev/null 2>&1 &
+sleep 10
+
+# Compile and test
+npx buidler compile
+npm test

--- a/scripts/e2e.npm.publish.sh
+++ b/scripts/e2e.npm.publish.sh
@@ -23,7 +23,6 @@ fi
 # what it needs here.
 npm install -g verdaccio@4.3.4
 npm install -g npm-auth-to-token@1.0.0
-npm install -g geth-dev-assistant@0.1.3
 npm install -g lerna@3.18.3
 
 # Launch npm proxy registry

--- a/scripts/e2e.truffle.sh
+++ b/scripts/e2e.truffle.sh
@@ -8,6 +8,9 @@
 # Exit immediately on error
 set -o errexit
 
+# Install test specific dependencies
+npm install -g geth-dev-assistant@0.1.3
+
 # Launch geth
 npm run geth
 

--- a/scripts/js/resolutions.js
+++ b/scripts/js/resolutions.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * This script is a helper for running a buidler based e2e unit test target and is
+ * used in combination with the npm virtual publishing script.
+ *
+ * It discovers the current web3 package version, gets its patch increment
+ * (also the value of the virtually published version) and attaches a yarn resolutions field
+ * to the target's package.json to coerce any Web3 packages up to the patch when target is
+ * installed.
+ *
+ * USAGE:    resolutions.js <target-folder-name>
+ * EXAMPLE:  node scripts/js/resolutions.js mosaic-1
+ *
+ */
+const fs = require('fs');
+const path = require('path');
+
+const semver = require('semver');
+const web3PackagePath = path.join(process.cwd(), 'original.package.json');
+const targetPackagePath = path.join(process.cwd(), process.argv[2], 'package.json');
+
+const web3Package = require(web3PackagePath);
+const targetPackage = require(targetPackagePath);
+
+const patch = semver.inc(web3Package.version, 'patch');
+
+targetPackage.resolutions = {
+  "@nomiclabs/**/web3": `${patch}`,
+  "@nomiclabs/**/web3-bzz": `${patch}`,
+  "@nomiclabs/**/web3-core-helpers": `${patch}`,
+  "@nomiclabs/**/web3-core-method": `${patch}`,
+  "@nomiclabs/**/web3-core-promievent": `${patch}`,
+  "@nomiclabs/**/web3-core-requestmanager": `${patch}`,
+  "@nomiclabs/**/web3-core-subscriptions": `${patch}`,
+  "@nomiclabs/**/web3-core": `${patch}`,
+  "@nomiclabs/**/web3-eth-abi": `${patch}`,
+  "@nomiclabs/**/web3-eth-accounts": `${patch}`,
+  "@nomiclabs/**/web3-eth-contract": `${patch}`,
+  "@nomiclabs/**/web3-eth-ens": `${patch}`,
+  "@nomiclabs/**/web3-eth-iban": `${patch}`,
+  "@nomiclabs/**/web3-eth-personal": `${patch}`,
+  "@nomiclabs/**/web3-eth": `${patch}`,
+  "@nomiclabs/**/web3-net": `${patch}`,
+  "@nomiclabs/**/web3-providers-http": `${patch}`,
+  "@nomiclabs/**/web3-providers-ipc": `${patch}`,
+  "@nomiclabs/**/web3-providers-ws": `${patch}`,
+  "@nomiclabs/**/web3-shh": `${patch}`,
+  "@nomiclabs/**/web3-utils": `${patch}`
+}
+
+console.log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+console.log(`Yarn will resolve Web3 packages in "${process.argv[2]}"" to...`);
+console.log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
+
+console.log(JSON.stringify(targetPackage.resolutions, null, ' '));
+
+fs.writeFileSync(targetPackagePath, JSON.stringify(targetPackage, null, '    '));
+

--- a/test/contract.js
+++ b/test/contract.js
@@ -3219,7 +3219,7 @@ describe('typical usage', function() {
         //     done();
         // });
 
-    }).timeout(6000);
+    }).timeout(10000);
         // TODO add error check
 });
 


### PR DESCRIPTION
## Description

In #3266, larger Solidity contract unit test suites that use Web3 are seeing random crashes and poor performance using  Web3 >= 1.2.2. Believe this bug is at Truffle ... (see [truffle 2688][7])

PR models that use-case by virtually publishing Web3 and running the unit tests of a [fork of mosaicdao/mosaic-1][1]. The project was selected because it [reported the same bug][2] and it's relatively small (~300 unit tests). 

The fork is adapted to use the [Buidler][3] test runner instead of Truffle. The change-set for those modifications can be seen [here][8].

Truffle is quite complex and ships as a web-packed bundle. It's also downgraded Web3 to 1.2.1 and the latest state of Web3 does not install there because recent TS fixes at Truffle were reverted.  

Buidler is simpler / more modular and allows us to use [yarn resolutions][4] to coerce all nested web3 packages in the target project to the one we want. 

This is a useful replacement for the (now) broken Truffle E2E test as well. 

**Proofs that the test correctly uses virtually published Web3**
+ [yarn list][5] of web3 deps in CI
+ [CI Run][9] with introduced log line...

[1]: https://github.com/cgewecke/mosaic-1#e2e-test-of-web3js
[2]: https://github.com/trufflesuite/ganache-cli/issues/702
[3]: https://buidler.dev/
[4]: https://yarnpkg.com/lang/en/docs/selective-version-resolutions/#toc-why-would-you-want-to-do-this
[5]: https://travis-ci.org/ethereum/web3.js/jobs/625375811#L1206-L1320
[7]: https://github.com/trufflesuite/truffle/issues/2688
[8]: https://github.com/cgewecke/mosaic-1/pull/1/files
[9]: https://travis-ci.org/ethereum/web3.js/jobs/625416616#L3153-L3156

Fixes #3266 

## Type of change

- [x] Test (non-breaking change)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
