### PR TITLE
Add tests for core-subscriptions edge cases

### DIFF
--- a/packages/web3-core-subscriptions/src/index.js
+++ b/packages/web3-core-subscriptions/src/index.js
@@ -59,7 +59,7 @@ Subscriptions.prototype.buildCall = function() {
         }
 
         var subscription = new Subscription({
-            subscription: _this.subscriptions[arguments[0]],
+            subscription: _this.subscriptions[arguments[0]] || {}, // Subscript might not exist
             requestManager: _this.requestManager,
             type: _this.type
         });

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -196,18 +196,28 @@ Subscription.prototype.subscribe = function() {
         return this;
     }
 
+    // throw error, if provider is not set
     if(!this.options.requestManager.provider) {
-        var err1 = new Error('No provider set.');
-        this.callback(err1, null, this);
-        this.emit('error', err1);
+        setTimeout(function(){
+            var err1 = new Error('No provider set.');
+            _this.callback(err1, null, _this);
+            _this.emit('error', err1);
+        },0);
+
         return this;
     }
 
     // throw error, if provider doesnt support subscriptions
     if(!this.options.requestManager.provider.on) {
-        var err2 = new Error('The current provider doesn\'t support subscriptions: '+ this.options.requestManager.provider.constructor.name);
-        this.callback(err2, null, this);
-        this.emit('error', err2);
+        setTimeout(function(){
+            var err2 = new Error(
+                'The current provider doesn\'t support subscriptions: ' +
+                _this.options.requestManager.provider.constructor.name
+            );
+            _this.callback(err2, null, _this);
+            _this.emit('error', err2);
+        },0);
+
         return this;
     }
 

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -77,7 +77,11 @@ Subscription.prototype._validateArgs = function (args) {
         subscription.params = 0;
 
     if (args.length !== subscription.params) {
-        throw errors.InvalidNumberOfParams(args.length, subscription.params + 1, args[0]);
+        throw errors.InvalidNumberOfParams(
+            args.length,
+            subscription.params,
+            subscription.subscriptionName
+        );
     }
 };
 

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -246,8 +246,10 @@ Subscription.prototype.subscribe = function() {
                 // TODO subscribe here? after the past logs?
 
             } else {
-                _this.callback(err, null, _this);
-                _this.emit('error', err);
+                setTimeout(function(){
+                    _this.callback(err, null, _this);
+                    _this.emit('error', err);
+                },0);
             }
         });
     }
@@ -289,8 +291,10 @@ Subscription.prototype.subscribe = function() {
                 }
             });
         } else {
-            _this.callback(err, false, _this);
-            _this.emit('error', err);
+            setTimeout(function(){
+                _this.callback(err, false, _this);
+                _this.emit('error', err);
+            },0);
         }
     });
 

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -43,7 +43,27 @@ describe('subscription connect/reconnect', function() {
             });
     });
 
-    it('resubscribes', function(done){
+    it('resubscribes to an existing subscription', function(done){
+        this.timeout(5000);
+
+        let stage = 0;
+
+        subscription = web3.eth.subscribe('newBlockHeaders');
+
+        subscription.on('data', function(result){
+            if (stage === 0) {
+              subscription.resubscribe();
+              stage = 1;
+              return;
+            }
+
+            assert(result.parentHash);
+            subscription.unsubscribe(); // Stop listening..
+            done();
+        });
+    });
+
+    it('resubscribes after being unsubscribed', function(done){
         this.timeout(5000);
 
         let stage = 0;

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -3,7 +3,7 @@ const ganache = require('ganache-cli');
 const pify = require('pify');
 const Web3 = require('./helpers/test.utils').getWeb3();
 
-describe.only('subscription connect/reconnect', function() {
+describe('subscription connect/reconnect', function() {
     let server;
     let web3;
     let accounts;

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -3,7 +3,7 @@ const ganache = require('ganache-cli');
 const pify = require('pify');
 const Web3 = require('./helpers/test.utils').getWeb3();
 
-describe('subscription connect/reconnect', function() {
+describe.only('subscription connect/reconnect', function() {
     let server;
     let web3;
     let accounts;
@@ -44,6 +44,8 @@ describe('subscription connect/reconnect', function() {
     });
 
     it('resubscribes', function(done){
+        this.timeout(5000);
+
         let stage = 0;
 
         subscription = web3.eth

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -44,15 +44,28 @@ describe('subscription connect/reconnect', function() {
     });
 
     it('resubscribes', function(done){
-        subscription = web3.eth.subscribe('newBlockHeaders')
-        subscription.unsubscribe();
-        subscription.resubscribe()
+        let stage = 0;
 
-        subscription.on('data', function(result){
-            assert(result.parentHash);
-            subscription.unsubscribe(); // Stop listening..
-            done();
-        })
+        subscription = web3.eth
+            .subscribe('newBlockHeaders')
+            .on('data', function(result) {
+                assert(result.parentHash);
+                subscription.unsubscribe();
+                stage = 1;
+            });
+
+        // Resubscribe from outside
+        interval = setInterval(async function(){
+            if (stage === 1){
+                clearInterval(interval);
+                subscription.resubscribe();
+                subscription.on('data', function(result){
+                    assert(result.parentHash);
+                    subscription.unsubscribe(); // Stop listening..
+                    done();
+                })
+            }
+        }, 500)
     });
 
     it('allows a subscription which does not exist', function(){

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -43,6 +43,16 @@ describe('subscription connect/reconnect', function() {
             });
     });
 
+    it('subscription emits a connected event', function(done){
+        subscription = web3.eth
+            .subscribe('newBlockHeaders')
+            .on('connected', function(result){
+                assert(result)              // First subscription
+                subscription.unsubscribe(); // Stop listening..
+                done();
+            });
+    });
+
     it('resubscribes to an existing subscription', function(done){
         this.timeout(5000);
 

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -104,14 +104,44 @@ describe('subscription connect/reconnect', function() {
         }
     });
 
-    // Could not get the .on('error') version of this to work - maybe a race condition setting it up.
-    it('errors when the provider is not set', function(done){
+    it('errors when the provider is not set (callback)', function(done){
         web3 = new Web3();
 
         web3.eth.subscribe('newBlockHeaders', function(err, result){
             assert(err.message.includes('No provider set'));
             done();
         })
+    });
+
+    it('errors when the provider is not set (.on("error"))', function(done){
+        web3 = new Web3();
+
+        web3.eth
+            .subscribe('newBlockHeaders')
+            .on("error", function(err){
+                assert(err.message.includes('No provider set'));
+                done();
+            })
+    });
+
+    it('errors when the provider does not support subscriptions (callback)', function(done){
+        web3 = new Web3('http://localhost:' + port);
+
+        web3.eth.subscribe('newBlockHeaders', function(err, result){
+            assert(err.message.includes("provider doesn't support subscriptions: HttpProvider"));
+            done();
+        });
+    });
+
+    it('errors when the provider is not set (.on("error"))', function(done){
+        web3 = new Web3('http://localhost:' + port);
+
+        web3.eth
+            .subscribe('newBlockHeaders')
+            .on("error", function(err){
+                assert(err.message.includes("provider doesn't support subscriptions: HttpProvider"));
+                done();
+            })
     });
 
     it('errors when the `eth_subscribe` request got send, the reponse isnt returned from the node, and the connection does get closed in the mean time', async function() {

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -57,7 +57,6 @@ describe('subscription connect/reconnect', function() {
             subscription.resubscribe()
 
             subscription.on('data', function(result){
-                console.log(result.parentHash)
                 assert(result.parentHash);
                 subscription.unsubscribe(); // Stop listening..
                 resolve();


### PR DESCRIPTION
## Description

**This PR targets #3190 (Provider Improvements)**
 
Adds a few tests for edge cases in web3-core-subscriptions. Found two tiny bugs - have changed the code to fix them. 

+ `web3.eth.subscribe('newBlockHeaders', 5)`, which fails in _invalidParams, gave a message like: "invalid params for "5". Expected 1, Got 1."

+ `web3.eth.subscribe('does-not-exist')` resulted in a syntax error. It should just log a warning to std.out.


<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Unit tests

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
