### PR TITLE
Callback type for Accounts.signTransaction fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,3 +119,4 @@ Released with 1.0.0-beta.37 code base.
 - Fix minified bundle (#3256)
 - ``defaultBlock`` property handling fixed (#3247)
 - ``clearSubscriptions`` does no longer throw an error if no running subscriptions do exist (#3246) 
+- callback type definition for ``Accounts.signTransaction`` fixed (#3280)

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -268,7 +268,7 @@ export class AccountsBase {
     signTransaction(
         transactionConfig: TransactionConfig,
         privateKey: string,
-        callback?: () => void
+        callback?: (error: Error, signedTransaction: SignedTransaction) => void
     ): Promise<SignedTransaction>;
 
     recoverTransaction(signature: string): string;

--- a/packages/web3-eth-accounts/types/index.d.ts
+++ b/packages/web3-eth-accounts/types/index.d.ts
@@ -19,6 +19,8 @@
 
 import { AccountsBase, SignedTransaction, WalletBase } from 'web3-core';
 
+export {SignedTransaction} from 'web3-core';
+
 export class Accounts extends AccountsBase {}
 
 export class Wallet extends WalletBase {}

--- a/packages/web3-eth-accounts/types/tests/accounts-tests.ts
+++ b/packages/web3-eth-accounts/types/tests/accounts-tests.ts
@@ -16,7 +16,7 @@
  * @author Josh Stevens <joshstevens19@hotmail.co.uk>
  * @date 2018
  */
-import { Accounts } from 'web3-eth-accounts';
+import { Accounts, SignedTransaction } from 'web3-eth-accounts';
 
 // $ExpectType Accounts
 const accounts_empty = new Accounts();
@@ -63,7 +63,7 @@ accounts.signTransaction(
         gas: 2000000
     },
     '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
-    () => {
+    (error: Error, signedTransaction: SignedTransaction) => {
         console.log('hey');
     }
 );


### PR DESCRIPTION
## Description

This PR adds the callback parameters with his types to the type definition of the ``Accounts.signTransaction`` method.

Fixes #3278

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Types

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
