### PR TITLE
Make user supplied callback fire in accounts.signTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ Released with 1.0.0-beta.37 code base.
 - ``eth_requestAccounts`` as ``requestAccounts`` added to web3-eth package (#3219)
 - ``sha3Raw`` and ``soliditySha3Raw`` added to web3-utils package (#3226)
 - ``eth_getProof`` as ``getProof`` added to web3-eth package (#3220)
-- ``BN`` and ``BigNumber`` objects are now supported by the ``abi.encodeParameter(s)`` method (#3238) 
+- ``BN`` and ``BigNumber`` objects are now supported by the ``abi.encodeParameter(s)`` method (#3238)
 - ``getPendingTransactions`` added to web3-eth package (#3239)
 - Revert instruction handling added which can get activated with the ``handleRevert`` module property (#3248)
 - The ``receipt`` does now exist as property on the error object for transaction related errors (#3259)
@@ -117,7 +117,8 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix user supplied callback not fired in eth.accounts.signTransaction (#3283)
 - Fix minified bundle (#3256)
 - ``defaultBlock`` property handling fixed (#3247)
-- ``clearSubscriptions`` does no longer throw an error if no running subscriptions do exist (#3246) 
+- ``clearSubscriptions`` does no longer throw an error if no running subscriptions do exist (#3246)
 - callback type definition for ``Accounts.signTransaction`` fixed (#3280)

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -128,7 +128,6 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
     var _this = this,
         error = false,
         transactionOptions = {},
-        result,
         hasTxSigningOptions = !!(tx && ((tx.chain && tx.hardfork) || tx.common));
 
     callback = callback || function() {
@@ -235,7 +234,7 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
             var rawTransaction = '0x' + rlpEncoded;
             var transactionHash = utils.keccak256(rawTransaction);
 
-            return {
+            var result = {
                 messageHash: '0x' + Buffer.from(ethTx.hash(false)).toString('hex'),
                 v: '0x' + Buffer.from(ethTx.v).toString('hex'),
                 r: '0x' + Buffer.from(ethTx.r).toString('hex'),
@@ -244,13 +243,13 @@ Accounts.prototype.signTransaction = function signTransaction(tx, privateKey, ca
                 transactionHash: transactionHash
             };
 
+            callback(null, result);
+            return result;
+
         } catch (e) {
             callback(e);
             return Promise.reject(e);
         }
-
-        callback(null, result);
-        return result;
     }
 
 

--- a/test/e2e.method.signing.js
+++ b/test/e2e.method.signing.js
@@ -113,6 +113,24 @@ describe('transaction and message signing [ @E2E ]', function() {
         assert(receipt.status === true);
     });
 
+    it('accounts.signTransaction, (with callback, nonce not specified)', function(done){
+        const source = wallet[0].address;
+        const destination = wallet[1].address;
+
+        const txObject = {
+            to:       destination,
+            value:    web3.utils.toHex(web3.utils.toWei('0.1', 'ether')),
+            gasLimit: web3.utils.toHex(21000),
+            gasPrice: web3.utils.toHex(web3.utils.toWei('10', 'gwei')),
+        };
+
+        web3.eth.accounts.signTransaction(txObject, wallet[0].privateKey, async function(err, signed){
+            const receipt = await web3.eth.sendSignedTransaction(signed.rawTransaction);
+            assert(receipt.status === true);
+            done();
+        });
+    });
+
     it('accounts.signTransaction errors when common, chain and hardfork all defined', async function(){
         const source = wallet[0].address;
         const destination = wallet[1].address;


### PR DESCRIPTION
## Description

Fixes a bug which disabled the ability to call `eth.accounts.signTransaction` using the callback form. 

@michaelsbradleyjr This only addresses the narrowest part of your issue. Have not used `Object.assign` as you suggest there, mostly to keep with the pattern of Web3's existing code. Please advise if you believe that's critical though. 

Fixes #3283 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
