### PR TITLE
Verify that event arg indexing matches received topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix crash when decoding events with identical signatures, differently indexed args (#3272)
 - Fix user supplied callback not fired in eth.accounts.signTransaction (#3283)
 - Fix minified bundle (#3256)
 - ``defaultBlock`` property handling fixed (#3247)

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -450,6 +450,19 @@ Contract.prototype._decodeEventABI = function (data) {
     // create empty inputs if none are present (e.g. anonymous events on allEvents)
     event.inputs = event.inputs || [];
 
+    // Handle case where an event signature shadows the current ABI with non-identical
+    // arg indexing. If # of topics doesn't match, event is anon.
+    if (!event.anonymous){
+        let indexedInputs = 0;
+        event.inputs.forEach(input => input.indexed ? indexedInputs++ : null);
+
+        if (indexedInputs > 0 && (data.topics.length !== indexedInputs + 1)){
+            event = {
+                anonymous: true,
+                inputs: []
+            }
+        }
+    }
 
     var argTopics = event.anonymous ? data.topics : data.topics.slice(1);
 

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -460,7 +460,7 @@ Contract.prototype._decodeEventABI = function (data) {
             event = {
                 anonymous: true,
                 inputs: []
-            }
+            };
         }
     }
 

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -28,7 +28,7 @@ describe('contract.events [ @E2E ]', function() {
 
         basic = new web3.eth.Contract(Basic.abi, basicOptions);
         instance = await basic.deploy().send({from: accounts[0]});
-    })
+    });
 
     it('contract.getPastEvents', async function(){
         await instance
@@ -84,7 +84,7 @@ describe('contract.events [ @E2E ]', function() {
         const options = {
             gasPrice: '1',
             gas: 4000000
-        }
+        };
 
         options.data = Child.bytecode;
         contract = new web3.eth.Contract(Child.abi, options);
@@ -97,12 +97,12 @@ describe('contract.events [ @E2E ]', function() {
         await parent
             .methods
             .fireChildSimilarEvent(child.options.address)
-            .send({from: accounts[0]})
+            .send({from: accounts[0]});
 
         await parent
             .methods
             .fireChildIdenticalEvent(child.options.address)
-            .send({from: accounts[0]})
+            .send({from: accounts[0]});
 
         const childEvents = await child.getPastEvents({
             fromBlock: 0,

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -77,6 +77,8 @@ describe('contract.events [ @E2E ]', function() {
     // Child and parent contracts have an event named `similar` which has the same
     // function signature but indexes arguments differently.
     it('handles child events with shadowed signatures', async function(){
+        this.timeout(25000);
+
         let contract;
 
         const options = {

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -1,5 +1,7 @@
 var assert = require('assert');
 var Basic = require('./sources/Basic');
+var Child = require('./sources/Child');
+var Parent = require('./sources/Parent');
 var utils = require('./helpers/test.utils');
 var Web3 = utils.getWeb3();
 
@@ -69,6 +71,55 @@ describe('contract.events [ @E2E ]', function() {
                 .firesEvent(accounts[0], 1)
                 .send({from: accounts[0]});
         });
+    });
+
+    // Test models event signature shadowing when one contract calls another.
+    // Child and parent contracts have an event named `similar` which has the same
+    // function signature but indexes arguments differently.
+    it('handles child events with shadowed signatures', async function(){
+        let contract;
+
+        const options = {
+            gasPrice: '1',
+            gas: 4000000
+        }
+
+        options.data = Child.bytecode;
+        contract = new web3.eth.Contract(Child.abi, options);
+        const child = await contract.deploy().send({from: accounts[0]});
+
+        options.data = Parent.bytecode;
+        contract = new web3.eth.Contract(Parent.abi, options);
+        const parent = await contract.deploy().send({from: accounts[0]});
+
+        await parent
+            .methods
+            .fireChildSimilarEvent(child.options.address)
+            .send({from: accounts[0]})
+
+        await parent
+            .methods
+            .fireChildIdenticalEvent(child.options.address)
+            .send({from: accounts[0]})
+
+        const childEvents = await child.getPastEvents({
+            fromBlock: 0,
+            toBlock: 'latest'
+        });
+
+        const parentEvents = await parent.getPastEvents({
+            fromBlock: 0,
+            toBlock: 'latest'
+        });
+
+        assert.equal(childEvents.length, 2);
+        assert.equal(parentEvents.length, 0);
+
+        assert.equal(childEvents[0].event, 'Similar');
+        assert.equal(typeof childEvents[0].returnValues._owner, 'string');
+
+        assert.equal(childEvents[1].event, 'Identical');
+        assert.equal(typeof childEvents[1].returnValues.childA, 'string');
     });
 });
 

--- a/test/sources/Child.json
+++ b/test/sources/Child.json
@@ -1,0 +1,71 @@
+{
+  "contractName": "Child",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "childA",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "childB",
+          "type": "address"
+        }
+      ],
+      "name": "Identical",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_approved",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "Similar",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "fireIdentical",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [],
+      "name": "fireSimilar",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x608060405234801561001057600080fd5b50610142806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c806339eb06131461003b578063e62f414814610045575b600080fd5b61004361004f565b005b61004d6100ad565b005b600073ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167f9b0c381f66eebc6aa094560f95fd7139c7d4e8c57ef35970d31529af03897b8960405160405180910390a3565b6001600073ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167fb2cae8315bd3bec790522b2d91759938a5db9279c1ffabbc6a7d3575466245d160405160405180910390a456fea265627a7a7231582033099c95ce3ccb847b6cb79edc99bc8b6b78d98245a78a0dc5ae3c32796c54bf64736f6c634300050f0032",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106100365760003560e01c806339eb06131461003b578063e62f414814610045575b600080fd5b61004361004f565b005b61004d6100ad565b005b600073ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167f9b0c381f66eebc6aa094560f95fd7139c7d4e8c57ef35970d31529af03897b8960405160405180910390a3565b6001600073ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167fb2cae8315bd3bec790522b2d91759938a5db9279c1ffabbc6a7d3575466245d160405160405180910390a456fea265627a7a7231582033099c95ce3ccb847b6cb79edc99bc8b6b78d98245a78a0dc5ae3c32796c54bf64736f6c634300050f0032",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/test/sources/Parent.json
+++ b/test/sources/Parent.json
@@ -1,0 +1,83 @@
+{
+  "contractName": "Parent",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "parentA",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "parentB",
+          "type": "address"
+        }
+      ],
+      "name": "Identical",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Similar",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "a",
+          "type": "address"
+        }
+      ],
+      "name": "fireChildIdenticalEvent",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "a",
+          "type": "address"
+        }
+      ],
+      "name": "fireChildSimilarEvent",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x608060405234801561001057600080fd5b506101be806100206000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c806333953f3e1461003b578063cdaef7191461007f575b600080fd5b61007d6004803603602081101561005157600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506100c3565b005b6100c16004803603602081101561009557600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610126565b005b8073ffffffffffffffffffffffffffffffffffffffff1663e62f41486040518163ffffffff1660e01b8152600401600060405180830381600087803b15801561010b57600080fd5b505af115801561011f573d6000803e3d6000fd5b5050505050565b8073ffffffffffffffffffffffffffffffffffffffff166339eb06136040518163ffffffff1660e01b8152600401600060405180830381600087803b15801561016e57600080fd5b505af1158015610182573d6000803e3d6000fd5b505050505056fea265627a7a723158201570ee9f18c1363a1ed9485e2163e981c47ef63669cd44ce420f350ed4949ad664736f6c634300050f0032",
+  "deployedBytecode": "0x608060405234801561001057600080fd5b50600436106100365760003560e01c806333953f3e1461003b578063cdaef7191461007f575b600080fd5b61007d6004803603602081101561005157600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506100c3565b005b6100c16004803603602081101561009557600080fd5b81019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610126565b005b8073ffffffffffffffffffffffffffffffffffffffff1663e62f41486040518163ffffffff1660e01b8152600401600060405180830381600087803b15801561010b57600080fd5b505af115801561011f573d6000803e3d6000fd5b5050505050565b8073ffffffffffffffffffffffffffffffffffffffff166339eb06136040518163ffffffff1660e01b8152600401600060405180830381600087803b15801561016e57600080fd5b505af1158015610182573d6000803e3d6000fd5b505050505056fea265627a7a723158201570ee9f18c1363a1ed9485e2163e981c47ef63669cd44ce420f350ed4949ad664736f6c634300050f0032",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/test/sources/ParentAndChild.sol
+++ b/test/sources/ParentAndChild.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.5.0;
+
+// This contract models event signature shadowing when
+// one contract calls another. Events `similar` and `identical` have
+// the same signature but their arguments are processed differently
+// because of indexing.
+
+contract Child  {
+    // Three indexed args
+    event Similar(
+        address indexed _owner,
+        address indexed _approved,
+        uint256 indexed _tokenId
+    );
+
+    // Two indexed args
+    event Identical(
+      address indexed childA,
+      address indexed childB
+    );
+
+    function fireIdentical() public {
+         emit Identical(address(0), address(0));
+    }
+
+    function fireSimilar() public {
+         emit Similar(address(0), address(0), 1);
+    }
+}
+
+contract Parent  {
+    // Two (vs 3) indexed args, different names
+    event Similar(
+        address indexed owner,
+        address indexed spender,
+        uint256  value
+    );
+
+    // Two indexed args, named parent
+    event Identical(
+      address indexed parentA,
+      address indexed parentB
+    );
+
+    function fireChildIdenticalEvent(address a) public {
+        Child(a).fireIdentical();
+    }
+
+    function fireChildSimilarEvent(address a) public {
+        Child(a).fireSimilar();
+    }
+}


### PR DESCRIPTION
## Description

Per #3272, when a transaction sent to one contract triggers an event in another contract whose signature shadows the ABI of calling contract, but whose arguments are indexed differently, Web3 crashes while formatting the receipt's logs because the topics and data don't match expectations.

PR adds logic to verify that the number of indexed args is compatible with the number of received topics. 

Tests are based on the reproduction case in [truffle 1729][1]

[1]: https://github.com/trufflesuite/truffle/issues/1729

Fixes #3272

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
