### PR TITLE
Prefer receipt status to code availability on contract deployment 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,4 @@ Released with 1.0.0-beta.37 code base.
 - ``clearSubscriptions`` does no longer throw an error if no running subscriptions do exist (#3246)
 - callback type definition for ``Accounts.signTransaction`` fixed (#3280)
 - fix: export bloom functions on the index.js
+- Prefer receipt status to code availability on contract deployment (#3298)

--- a/test/e2e.contract.deploy.js
+++ b/test/e2e.contract.deploy.js
@@ -9,11 +9,13 @@ describe('contract.deploy [ @E2E ]', function() {
     var accounts;
     var basic;
     var reverts;
+    var noBytecode;
     var options;
 
     // Error message variants
-    var ganacheRevert = "revert";
-    var gethRevert = "code couldn't be stored";
+    var revertMessage = "revert";
+    var couldNotBeStoredMessage = "code couldn't be stored";
+    var creationWithoutDataMessage = "contract creation without any data provided";
 
     var basicOptions = {
         data: Basic.bytecode,
@@ -27,6 +29,12 @@ describe('contract.deploy [ @E2E ]', function() {
         gas: 4000000
     }
 
+    var noBytecodeOptions = {
+        data: '0x',
+        gasPrice: '1',
+        gas: 4000000
+    }
+
     describe('http', function() {
         before(async function(){
             web3 = new Web3('http://localhost:8545');
@@ -34,6 +42,7 @@ describe('contract.deploy [ @E2E ]', function() {
 
             basic = new web3.eth.Contract(Basic.abi, basicOptions);
             reverts = new web3.eth.Contract(Reverts.abi, revertsOptions);
+            noBytecode = new web3.eth.Contract(Basic.abi, noBytecodeOptions);
         })
 
         it('returns an instance', async function(){
@@ -44,7 +53,9 @@ describe('contract.deploy [ @E2E ]', function() {
             assert(web3.utils.isAddress(instance.options.address));
         });
 
-        it('errors on OOG', async function(){
+        // Clients reject this kind of OOG is early because
+        // the gas is obviously way too low.
+        it('errors on "intrinic gas too low" OOG', async function(){
             try {
                 await basic
                     .deploy()
@@ -53,8 +64,48 @@ describe('contract.deploy [ @E2E ]', function() {
                 assert.fail();
             } catch(err){
                 assert(err.message.includes('gas'))
+                assert(err.receipt === undefined);
             }
         });
+
+        // Clients reject this kind of OOG when the EVM runs out of gas
+        // while running the code. A contractAddress is set on the
+        // receipt, but the status will be false.
+        it('errors on OOG reached while running EVM', async function(){
+            const estimate = await basic
+                .deploy()
+                .estimateGas()
+
+            const gas = estimate - 1000;
+
+            try {
+                await basic
+                    .deploy()
+                    .send({from: accounts[0], gas: gas});
+
+                assert.fail();
+            } catch(err){
+                assert(err.message.includes(couldNotBeStoredMessage));
+                assert(err.receipt.status === false);
+            }
+        });
+
+        // Geth immediately rejects a zero length bytecode without mining,
+        // Ganache accepts and mines it, returning a receipt with status === true
+        it('errors deploying a zero length bytecode', async function(){
+            try {
+                await noBytecode
+                    .deploy()
+                    .send({from: accounts[0]});
+
+                assert.fail();
+            } catch(err){
+                assert(
+                    err.message.includes(creationWithoutDataMessage) ||
+                    err.message.includes(couldNotBeStoredMessage)
+                );
+            }
+        })
 
         it('errors on revert', async function(){
             try {
@@ -65,9 +116,11 @@ describe('contract.deploy [ @E2E ]', function() {
                 assert.fail();
             } catch(err){
                 assert(
-                    err.message.includes(gethRevert) ||
-                    err.message.includes(ganacheRevert)
+                    err.message.includes(couldNotBeStoredMessage) ||
+                    err.message.includes(revertMessage)
                 );
+
+                assert(err.receipt.status === false);
             }
         });
     });
@@ -115,8 +168,8 @@ describe('contract.deploy [ @E2E ]', function() {
                 assert.fail();
             } catch(err){
                 assert(
-                    err.message.includes(gethRevert) ||
-                    err.message.includes(ganacheRevert)
+                    err.message.includes(couldNotBeStoredMessage) ||
+                    err.message.includes(revertMessage)
                 );
             }
         });
@@ -177,8 +230,8 @@ describe('contract.deploy [ @E2E ]', function() {
                 .send({from: accounts[0]})
                 .on('error', err => {
                     assert(
-                        err.message.includes(gethRevert) ||
-                        err.message.includes(ganacheRevert)
+                        err.message.includes(couldNotBeStoredMessage) ||
+                        err.message.includes(revertMessage)
                     );
                     done();
                 })


### PR DESCRIPTION
## Description

Addresses problem described in [truffle 2257][1] where the availability of the contract code in the client DB lags the delivery of the tx receipt on deployment. Web3 tries to fetch the code immediately, can't find anything and errors with 
```
The contract code couldn't be stored, please check your gas limit.
```

At the moment people frequently see successful contract deployments reported as failures 
Commit 17f72d7312affbec3021178a5a35eec494604819 adds additional tests cases which hit this error, to establish a behavioral baseline for the logic change.

+ OOG (where tx runs out of gas while the evm processes the code)
+ Deploying a zero length bytecode on ganache. (Ganache allows this, and can happen by accident when someone tries to deploy a Solidity 'interface' contract)

Commit aec5c082ab031678957adbdc3b35dbf91dff917c adds logic to allow any deployment which had a 'real' bytecode and a true receipt status to be treated as successful. 

The code  length check is kept as an alternative for pre-byzantium chains and to preserve current behavior when deploying zero length bytecodes to ganache (e.g should error). 

[1]: https://github.com/trufflesuite/truffle/issues/2257
<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
