### PR TITLE
Minimize changes to test/contract.js (#3190)

### DIFF
--- a/docs/include_package-core.rst
+++ b/docs/include_package-core.rst
@@ -15,7 +15,6 @@ Will change the provider for its module.
 
 .. note::
     When called on the umbrella package ``web3`` it will also set the provider for all sub modules ``web3.eth``, ``web3.shh``, etc EXCEPT ``web3.bzz`` which needs a separate provider at all times.
-    Be aware to clean up the listeners of your provider if you pass the exact same provider instance a second time to the ``setProvider`` method of any module. This because the ``setProvider`` method will register the listeners required from web3.js again.
 
 ----------
 Parameters

--- a/docs/include_package-core.rst
+++ b/docs/include_package-core.rst
@@ -13,7 +13,9 @@ setProvider
 
 Will change the provider for its module.
 
-.. note:: When called on the umbrella package ``web3`` it will also set the provider for all sub modules ``web3.eth``, ``web3.shh``, etc EXCEPT ``web3.bzz`` which needs a separate provider at all times.
+.. note::
+    When called on the umbrella package ``web3`` it will also set the provider for all sub modules ``web3.eth``, ``web3.shh``, etc EXCEPT ``web3.bzz`` which needs a separate provider at all times.
+    Be aware to clean up the listeners of your provider if you pass the exact same provider instance a second time to the ``setProvider`` method of any module. This because the ``setProvider`` method will register the listeners required from web3.js again.
 
 ----------
 Parameters

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -260,7 +260,7 @@ RequestManager.prototype.clearSubscriptions = function (keepIsSyncing) {
     var _this = this;
 
     // uninstall all subscriptions
-    if (this.subscriptions) {
+    if (this.subscriptions.size > 0) {
         this.subscriptions.forEach(function (value, id) {
             if (!keepIsSyncing || value.name !== 'syncing')
                 _this.removeSubscription(id);

--- a/test/contract.js
+++ b/test/contract.js
@@ -240,7 +240,7 @@ var getEthContractInstance = function(abi, address, options, provider) {
     }
 
     var eth = new Eth(provider);
-    eth.setProvider(provider);
+    //eth.setProvider(provider);
     return new eth.Contract(abi, address, options);
 }
 

--- a/test/contract.js
+++ b/test/contract.js
@@ -9,231 +9,247 @@ var StandAloneContract = require('../packages/web3-eth-contract');
 
 
 var abi = [{
-    'type': 'constructor',
-    'inputs': [{
-        'name': 'who',
-        'type': 'address'
-    }, {
-        'name': 'myValue',
-        'type': 'uint256'
+    "type": "constructor",
+    "inputs": [{
+        "name": "who",
+        "type": "address"
+    },{
+        "name": "myValue",
+        "type": "uint256"
     }]
-}, {
-    'constant': false,
-    'inputs': [
+},{
+    "constant": false,
+    "inputs": [
         {
-            'components': [
-                {'name': 'status', 'type': 'bool'}
+            "components": [
+                {"name": "status", "type": "bool"}
             ],
-            'name': 'nestedStruct',
-            'type': 'tuple'
+            "name": "nestedStruct",
+            "type": "tuple"
         }
     ],
-    'name': 'addStruct',
-    'outputs': [],
-    'payable': false,
-    'stateMutability': 'nonpayable',
-    'type': 'function'
-}, {
-    'constant': true,
-    'inputs': [
+    "name": "addStruct",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+},{
+    "constant": true,
+    "inputs": [
         {
-            'name': '',
-            'type': 'address'
+            "name": "",
+            "type": "address"
         }
     ],
-    'name': 'listOfNestedStructs',
-    'outputs': [
+    "name": "listOfNestedStructs",
+    "outputs": [
         {
-            'components': [
-                {'name': 'status', 'type': 'bool'}
+            "components": [
+                {"name": "status", "type": "bool"}
             ],
-            'name': 'nestedStruct',
-            'type': 'tuple'
+            "name": "nestedStruct",
+            "type": "tuple"
         }
     ],
-    'payable': false,
-    'stateMutability': 'view',
-    'type': 'function'
-}, {
-    'name': 'balance',
-    'type': 'function',
-    'inputs': [{
-        'name': 'who',
-        'type': 'address'
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+},{
+    "name": "balance",
+    "type": "function",
+    "inputs": [{
+        "name": "who",
+        "type": "address"
     }],
-    'constant': true,
-    'outputs': [{
-        'name': 'value',
-        'type': 'uint256'
+    "constant": true,
+    "outputs": [{
+        "name": "value",
+        "type": "uint256"
     }]
-}, {
-    'name': 'hasALotOfParams',
-    'inputs': [
+},{
+    "name": "hasALotOfParams",
+    "inputs": [
         {
-            'name': '_var1',
-            'type': 'bytes32'
+            "name": "_var1",
+            "type": "bytes32"
         },
         {
-            'name': '_var2',
-            'type': 'string'
+            "name": "_var2",
+            "type": "string"
         },
         {
-            'name': '_var3',
-            'type': 'bytes32[]'
+            "name": "_var3",
+            "type": "bytes32[]"
         }
     ],
-    'outputs': [
+    "outputs": [
         {
-            'name': 'owner',
-            'type': 'address'
+            "name": "owner",
+            "type": "address"
         }
     ],
-    'constant': false,
-    'payable': false,
-    'type': 'function'
-}, {
-    'name': 'getStr',
-    'type': 'function',
-    'inputs': [],
-    'constant': true,
-    'outputs': [{
-        'name': 'myString',
-        'type': 'string'
+    "constant": false,
+    "payable": false,
+    "type": "function"
+},{
+    "name": "getStr",
+    "type": "function",
+    "inputs": [],
+    "constant": true,
+    "outputs": [{
+        "name": "myString",
+        "type": "string"
+    }]
+},{
+    "name": "owner",
+    "type": "function",
+    "inputs": [],
+    "constant": true,
+    "outputs": [{
+        "name": "owner",
+        "type": "address"
     }]
 }, {
-    'name': 'owner',
-    'type': 'function',
-    'inputs': [],
-    'constant': true,
-    'outputs': [{
-        'name': 'owner',
-        'type': 'address'
-    }]
-}, {
-    'name': 'mySend',
-    'type': 'function',
-    'inputs': [{
-        'name': 'to',
-        'type': 'address'
+    "name": "mySend",
+    "type": "function",
+    "inputs": [{
+        "name": "to",
+        "type": "address"
     }, {
-        'name': 'value',
-        'type': 'uint256'
+        "name": "value",
+        "type": "uint256"
     }],
-    'outputs': [],
-    'stateMutability': 'payable'
-}, {
-    'name': 'myDisallowedSend',
-    'type': 'function',
-    'inputs': [{
-        'name': 'to',
-        'type': 'address'
+    "outputs": [],
+    "stateMutability": "payable"
+},{
+    "name": "myDisallowedSend",
+    "type": "function",
+    "inputs": [{
+        "name": "to",
+        "type": "address"
     }, {
-        'name': 'value',
-        'type': 'uint256'
+        "name": "value",
+        "type": "uint256"
     }],
-    'outputs': [],
-    'payable': false
+    "outputs": [],
+    "payable": false
 }, {
-    'name': 'testArr',
-    'type': 'function',
-    'inputs': [{
-        'name': 'value',
-        'type': 'int[]'
+    "name": "testArr",
+    "type": "function",
+    "inputs": [{
+        "name": "value",
+        "type": "int[]"
     }],
-    'constant': true,
-    'outputs': [{
-        'name': 'd',
-        'type': 'int'
+    "constant": true,
+    "outputs": [{
+        "name": "d",
+        "type": "int"
     }]
 }, {
-    'name': 'Changed',
-    'type': 'event',
-    'inputs': [
-        {'name': 'from', 'type': 'address', 'indexed': true},
-        {'name': 'amount', 'type': 'uint256', 'indexed': true},
-        {'name': 't1', 'type': 'uint256', 'indexed': false},
-        {'name': 't2', 'type': 'uint256', 'indexed': false}
+    "name":"Changed",
+    "type":"event",
+    "inputs": [
+        {"name":"from","type":"address","indexed":true},
+        {"name":"amount","type":"uint256","indexed":true},
+        {"name":"t1","type":"uint256","indexed":false},
+        {"name":"t2","type":"uint256","indexed":false}
     ]
 }, {
-    'name': 'Unchanged',
-    'type': 'event',
-    'inputs': [
-        {'name': 'value', 'type': 'uint256', 'indexed': true},
-        {'name': 'addressFrom', 'type': 'address', 'indexed': true},
-        {'name': 't1', 'type': 'uint256', 'indexed': false}
-    ]
+        "name":"Unchanged",
+        "type":"event",
+        "inputs": [
+            {"name":"value","type":"uint256","indexed":true},
+            {"name":"addressFrom","type":"address","indexed":true},
+            {"name":"t1","type":"uint256","indexed":false}
+        ]
 }, {
-    'name': 'overloadedFunction',
-    'type': 'function',
-    'inputs': [
-        {'name': 'a', 'type': 'uint256'}
+    "name":"overloadedFunction",
+    "type":"function",
+    "inputs":[
+        {"name":"a","type":"uint256"}
     ],
-    'constant': true,
-    'outputs': [
-        {'name': '', 'type': 'uint256'}
+    "constant":true,
+    "outputs":[
+        {"name":"", "type":"uint256"}
     ],
-    'payable': false,
-    'stateMutability': 'view'
+    "payable":false,
+    "stateMutability":"view"
 }, {
-    'name': 'overloadedFunction',
-    'type': 'function',
-    'inputs': [],
-    'constant': true,
-    'outputs': [
-        {'name': '', 'type': 'uint256'}
+    "name":"overloadedFunction",
+    "type":"function",
+    "inputs":[],
+    "constant":true,
+    "outputs":[
+        {"name":"","type":"uint256"}
     ],
-    'payable': false,
-    'stateMutability': 'view'
-}];
+    "payable":false,
+    "stateMutability":"view"
+    }];
 
 var address = '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe';
 var addressLowercase = '0x11f4d0a3c12e86b4b5f39b213f7e19d048276dae';
 var address2 = '0x5555567890123456789012345678901234567891';
-var account = {
-    address: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
-    privateKey: '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728'
-};
 
-/**
- * Factory method for standalone Contract objects.
- *
- * @method getStandAloneContractInstance
- *
- * @param {Array} abi
- * @param {String} address
- * @param {providers} provider
- * @param {Object} options
- *
- * @returns {Contract}
- */
-var getStandAloneContractInstance = function (abi, address, provider, options) {
+var getStandAloneContractInstance = function(abi, address, options, provider) {
+
+    // if no address supplied
+    if (address && typeof address != 'string') {
+
+        // no options provided, either
+        if (!options && !provider) {
+            provider = address;
+            address = undefined;
+            options = undefined;
+        } else if (options) {
+            // options provided, but no address
+            options = address;
+            provider = options;
+            address = undefined;
+        }
+    } else if (!provider) {
+        // address provided, but no options
+        provider = options;
+        options = undefined;
+    }
+
+
     StandAloneContract.setProvider(provider);
     return new StandAloneContract(abi, address, options);
-};
+}
 
-/**
- * Factory method for eth.Contract objects.
- *
- * @method getEthContractInstance
- *
- * @param {Array} abi
- * @param {String} address
- * @param {providers} provider
- * @param {Object} options
- *
- * @returns {Contract}
- */
-var getEthContractInstance = function (abi, address, provider, options) {
+var getEthContractInstance = function(abi, address, options, provider) {
+
+    // if no address supplied
+    if (address && typeof address != 'string') {
+
+        // no options provided, either
+        if (!options && !provider) {
+            provider = address;
+            address = undefined;
+            options = undefined;
+        } else if (options) {
+            // options provided, but no address
+            options = address;
+            provider = options;
+            address = undefined;
+        }
+    } else if (!provider) {
+        // address provided, but no options
+        provider = options;
+        options = undefined;
+    }
+
     var eth = new Eth(provider);
-    const contract = new eth.Contract(abi, address, options);
+    eth.setProvider(provider);
+    return new eth.Contract(abi, address, options);
+}
 
-    return contract;
+var account = {
+    address: '0xEB014f8c8B418Db6b45774c326A0E64C78914dC0',
+    privateKey: '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728',
 };
 
-/**
- * @param {getEthContractInstance|getStandAloneContractInstance} contractFactory
- */
-var runTests = function (contractFactory) {
+var runTests = function(contractFactory) {
     describe('instantiation', function () {
         it('should transform address from checksum addressess', function () {
             var provider = new FakeIpcProvider();
@@ -262,111 +278,111 @@ var runTests = function (contractFactory) {
             var provider = new FakeIpcProvider();
 
             var test = function () {
-                contractFactory(abi, address, provider, {from: '0x11F4D0A3c12e86B4b5F39B213F7E19D048276DAe'});
+                contractFactory(abi, address, {from: '0x11F4D0A3c12e86B4b5F39B213F7E19D048276DAe'}, provider);
             };
 
             assert.throws(test);
         });
-        it('should define the handleRevert object property if passed over the options', function () {
+        it('should define the handleRevert object property if passed over the options', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {handleRevert: true});
+            var contract = contractFactory(abi, address, {handleRevert: true}, provider);
 
             assert.equal(contract.handleRevert, true);
             assert.equal(contract.options.handleRevert, true);
         });
-        it('should update the handleRevert property in the options object', function () {
+        it('should update the handleRevert property in the options object', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {handleRevert: false});
+            var contract = contractFactory(abi, address, {handleRevert: false}, provider);
 
             contract.handleRevert = true;
 
             assert.equal(contract.options.handleRevert, true);
         });
-        it('should define the defaultCommon object property if passed over the options', function () {
+        it('should define the defaultCommon object property if passed over the options', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {common: true});
+            var contract = contractFactory(abi, address, {common: true}, provider);
 
             assert.equal(contract.defaultCommon, true);
             assert.equal(contract.options.common, true);
         });
-        it('should update the defaultCommon property in the options object', function () {
+        it('should update the defaultCommon property in the options object', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {common: false});
+            var contract = contractFactory(abi, address, {common: false}, provider);
 
             contract.defaultCommon = true;
 
             assert.equal(contract.options.common, true);
         });
-        it('should define the defaultHardfork object property if passed over the options', function () {
+        it('should define the defaultHardfork object property if passed over the options', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {hardfork: 'istanbul'});
+            var contract = contractFactory(abi, address, {hardfork: 'istanbul'}, provider);
 
             assert.equal(contract.defaultHardfork, 'istanbul');
             assert.equal(contract.options.hardfork, 'istanbul');
         });
-        it('should update the defaultHardfork property in the options object', function () {
+        it('should update the defaultHardfork property in the options object', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {hardfork: false});
+            var contract = contractFactory(abi, address, {hardfork: false}, provider);
 
             contract.defaultHardfork = true;
 
             assert.equal(contract.options.hardfork, true);
         });
-        it('should define the defaultChain object property if passed over the options', function () {
+        it('should define the defaultChain object property if passed over the options', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {chain: 'mainnet'});
+            var contract = contractFactory(abi, address, {chain: 'mainnet'}, provider);
 
             assert.equal(contract.defaultChain, 'mainnet');
             assert.equal(contract.options.chain, 'mainnet');
         });
-        it('should update the defaultChain property in the options object', function () {
+        it('should update the defaultChain property in the options object', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {chain: false});
+            var contract = contractFactory(abi, address, {chain: false}, provider);
 
             contract.defaultChain = true;
 
             assert.equal(contract.options.chain, true);
         });
-        it('should define the transactionPollingTimeout object property if passed over the options', function () {
+        it('should define the transactionPollingTimeout object property if passed over the options', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {transactionPollingTimeout: 0});
+            var contract = contractFactory(abi, address, {transactionPollingTimeout: 0}, provider);
 
             assert.equal(contract.transactionPollingTimeout, 0);
             assert.equal(contract.options.transactionPollingTimeout, 0);
         });
-        it('should update the transactionPollingTimeout property in the options object', function () {
+        it('should update the transactionPollingTimeout property in the options object', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {transactionPollingTimeout: 1});
+            var contract = contractFactory(abi, address, {transactionPollingTimeout: 1}, provider);
 
             contract.transactionPollingTimeout = 0;
 
             assert.equal(contract.options.transactionPollingTimeout, 0);
         });
-        it('should define the transactionConfirmationBlocks object property if passed over the options', function () {
+        it('should define the transactionConfirmationBlocks object property if passed over the options', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {transactionConfirmationBlocks: 0});
+            var contract = contractFactory(abi, address, {transactionConfirmationBlocks: 0}, provider);
 
             assert.equal(contract.transactionConfirmationBlocks, 0);
             assert.equal(contract.options.transactionConfirmationBlocks, 0);
         });
-        it('should update the transactionConfirmationBlocks property in the options object', function () {
+        it('should update the transactionConfirmationBlocks property in the options object', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {transactionConfirmationBlocks: 1});
+            var contract = contractFactory(abi, address, {transactionConfirmationBlocks: 1}, provider);
 
             contract.transactionConfirmationBlocks = 0;
 
             assert.equal(contract.options.transactionConfirmationBlocks, 0);
         });
-        it('should define the transactionBlockTimeout object property if passed over the options', function () {
+        it('should define the transactionBlockTimeout object property if passed over the options', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {transactionBlockTimeout: 0});
+            var contract = contractFactory(abi, address, {transactionBlockTimeout: 0}, provider);
 
             assert.equal(contract.transactionBlockTimeout, 0);
             assert.equal(contract.options.transactionBlockTimeout, 0);
         });
-        it('should update the transactionBlockTimeout property in the options object', function () {
+        it('should update the transactionBlockTimeout property in the options object', function() {
             var provider = new FakeIpcProvider();
-            var contract = contractFactory(abi, address, provider, {transactionBlockTimeout: 1});
+            var contract = contractFactory(abi, address, {transactionBlockTimeout: 1}, provider);
 
             contract.transactionBlockTimeout = 0;
 
@@ -377,29 +393,27 @@ var runTests = function (contractFactory) {
 
             var fromAddress = '0xDDfFD0A3C12e86b4b5f39B213f7e19d048276daE';
             var abi2 = [{
-                'name': 'ballerRo',
-                'type': 'function',
-                'inputs': [{
-                    'name': 'So',
-                    'type': 'address'
+                "name": "ballerRo",
+                "type": "function",
+                "inputs": [{
+                    "name": "So",
+                    "type": "address"
                 }],
-                'constant': true,
-                'outputs': [{
-                    'name': 'man',
-                    'type': 'uint256'
+                "constant": true,
+                "outputs": [{
+                    "name": "man",
+                    "type": "uint256"
                 }]
             }];
 
-            var contract1 = contractFactory(
-                abi,
+            var contract1 = contractFactory(abi,
                 address,
-                provider,
                 {
                     gas: 1222,
                     gasPrice: 12345678,
                     from: fromAddress
-                }
-            );
+                },
+                provider);
 
             var contract2 = contract1.clone();
 
@@ -422,7 +436,7 @@ var runTests = function (contractFactory) {
         });
     });
 
-    describe('provider assignment', function () {
+    describe('provider assignment', function() {
         it('should assign a provider to a new instance without modifying old instance', function () {
             var provider1 = new FakeIpcProvider();
             var provider2 = new FakeHttpProvider();
@@ -443,13 +457,13 @@ var runTests = function (contractFactory) {
 
             var result = contract._encodeEventABI({
                 signature: '0x1234',
-                'name': 'Changed',
-                'type': 'event',
-                'inputs': [
-                    {'name': 'from', 'type': 'address', 'indexed': true},
-                    {'name': 'amount', 'type': 'uint256', 'indexed': true},
-                    {'name': 't1', 'type': 'uint256', 'indexed': false},
-                    {'name': 't2', 'type': 'uint256', 'indexed': false}
+                "name":"Changed",
+                "type":"event",
+                "inputs": [
+                    {"name":"from","type":"address","indexed":true},
+                    {"name":"amount","type":"uint256","indexed":true},
+                    {"name":"t1","type":"uint256","indexed":false},
+                    {"name":"t2","type":"uint256","indexed":false}
                 ]
             });
 
@@ -470,13 +484,13 @@ var runTests = function (contractFactory) {
 
             var result = contract._encodeEventABI({
                 signature: '0x1234',
-                'name': 'Changed',
-                'type': 'event',
-                'inputs': [
-                    {'name': 'from', 'type': 'address', 'indexed': true},
-                    {'name': 'amount', 'type': 'uint256', 'indexed': true},
-                    {'name': 't1', 'type': 'uint256', 'indexed': false},
-                    {'name': 't2', 'type': 'uint256', 'indexed': false}
+                "name":"Changed",
+                "type":"event",
+                "inputs": [
+                    {"name":"from","type":"address","indexed":true},
+                    {"name":"amount","type":"uint256","indexed":true},
+                    {"name":"t1","type":"uint256","indexed":false},
+                    {"name":"t2","type":"uint256","indexed":false}
                 ]
             }, {filter: {amount: 12}, fromBlock: 2});
 
@@ -497,16 +511,16 @@ var runTests = function (contractFactory) {
 
             var result = contract._encodeEventABI({
                 signature: '0x1234',
-                'name': 'Changed',
-                'type': 'event',
-                'inputs': [
-                    {'name': 'test', 'type': 'uint256', 'indexed': true},
-                    {'name': 'from', 'type': 'address', 'indexed': true},
-                    {'name': 'amount', 'type': 'uint256', 'indexed': true},
-                    {'name': 't1', 'type': 'uint256', 'indexed': false},
-                    {'name': 't2', 'type': 'uint256', 'indexed': false}
+                "name":"Changed",
+                "type":"event",
+                "inputs": [
+                    {"name":"test","type":"uint256","indexed":true},
+                    {"name":"from","type":"address","indexed":true},
+                    {"name":"amount","type":"uint256","indexed":true},
+                    {"name":"t1","type":"uint256","indexed":false},
+                    {"name":"t2","type":"uint256","indexed":false}
                 ]
-            }, {filter: {amount: [12, 10], from: address}, fromBlock: 2});
+            }, {filter: {amount: [12,10], from: address}, fromBlock: 2});
 
             assert.deepEqual(result, {
                 address: addressLowercase,
@@ -514,7 +528,7 @@ var runTests = function (contractFactory) {
                 topics: [
                     '0x1234',
                     null,
-                    '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                     ['0x000000000000000000000000000000000000000000000000000000000000000c', '0x000000000000000000000000000000000000000000000000000000000000000a']
                 ]
             });
@@ -528,19 +542,19 @@ var runTests = function (contractFactory) {
 
             var result = contract._decodeEventABI.call({
                 signature: sha3(signature),
-                'name': 'Changed',
-                'type': 'event',
-                'inputs': [
-                    {'name': 'from', 'type': 'address', 'indexed': true},
-                    {'name': 'amount', 'type': 'uint256', 'indexed': true},
-                    {'name': 't1', 'type': 'uint256', 'indexed': false},
-                    {'name': 't2', 'type': 'uint256', 'indexed': false}
+                "name":"Changed",
+                "type":"event",
+                "inputs": [
+                    {"name":"from","type":"address","indexed":true},
+                    {"name":"amount","type":"uint256","indexed":true},
+                    {"name":"t1","type":"uint256","indexed":false},
+                    {"name":"t2","type":"uint256","indexed":false}
                 ]
             }, {
                 address: address,
                 topics: [
                     sha3(signature),
-                    '0x000000000000000000000000' + address.replace('0x', ''),
+                    '0x000000000000000000000000'+ address.replace('0x',''),
                     '0x0000000000000000000000000000000000000000000000000000000000000001'
                 ],
                 blockNumber: '0x3',
@@ -549,7 +563,7 @@ var runTests = function (contractFactory) {
                 transactionIndex: '0x0',
                 logIndex: '0x4',
                 data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                    '0000000000000000000000000000000000000000000000000000000000000008'
+                '0000000000000000000000000000000000000000000000000000000000000008'
             });
 
             assert.equal(result.blockNumber, 3);
@@ -570,12 +584,12 @@ var runTests = function (contractFactory) {
             var contract = contractFactory(abi, address, provider);
 
             var result = contract._decodeMethodReturn([{
-                'name': 'myAddress',
-                'type': 'address'
-            }, {
-                'name': 'value',
-                'type': 'uint256'
-            }], '0x000000000000000000000000' + address.replace('0x', '') +
+                "name": "myAddress",
+                "type": "address"
+            },{
+                "name": "value",
+                "type": "uint256"
+            }], '0x000000000000000000000000'+ address.replace('0x','')+
                 '000000000000000000000000000000000000000000000000000000000000000a');
 
             assert.isObject(result);
@@ -592,9 +606,9 @@ var runTests = function (contractFactory) {
             var contract = contractFactory(abi, address, provider);
 
             var result = contract._decodeMethodReturn([{
-                'name': 'myAddress',
-                'type': 'address'
-            }], '0x000000000000000000000000' + address.replace('0x', ''));
+                "name": "myAddress",
+                "type": "address"
+            }], '0x000000000000000000000000'+ address.replace('0x',''));
 
             assert.equal(result, address);
 
@@ -606,10 +620,10 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: signature + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a',
+                    data: signature +'000000000000000000000000'+ addressLowercase.replace('0x','') +'000000000000000000000000000000000000000000000000000000000000000a',
                     from: address2,
                     to: addressLowercase,
-                    gasPrice: '0x5af3107a4000'
+                    gasPrice: "0x5af3107a4000"
                 }]);
             });
             provider.injectResult('0x1234000000000000000000000000000000000000000000000000000000056789');
@@ -633,40 +647,37 @@ var runTests = function (contractFactory) {
             var txObject = {};
             txObject._method = {
                 signature: signature,
-                'name': 'send',
-                'type': 'function',
-                'inputs': [{
-                    'name': 'to',
-                    'type': 'address'
+                "name": "send",
+                "type": "function",
+                "inputs": [{
+                    "name": "to",
+                    "type": "address"
                 }, {
-                    'name': 'value',
-                    'type': 'uint256'
+                    "name": "value",
+                    "type": "uint256"
                 }],
-                'outputs': []
+                "outputs": []
             };
             txObject._parent = contract;
             txObject.encodeABI = contract._encodeMethodABI.bind(txObject);
             txObject.arguments = [address, 10];
 
-            var deploy = contract._executeMethod.call(txObject, 'send', {
-                from: address2,
-                gasPrice: '100000000000000'
-            }, function (err, result) {
+            var deploy = contract._executeMethod.call(txObject, 'send', {from: address2, gasPrice: '100000000000000' }, function (err, result) {
                 // tx hash
                 assert.equal(result, '0x1234000000000000000000000000000000000000000000000000000000056789');
             })
-                .on('receipt', function (result) {
+            .on('receipt', function(result){
 
-                    assert.deepEqual(result, {
-                        contractAddress: address,
-                        cumulativeGasUsed: 10,
-                        transactionIndex: 3,
-                        blockNumber: 10,
-                        blockHash: '0xbf1234',
-                        gasUsed: 0
-                    });
-                    done();
+                assert.deepEqual(result, {
+                    contractAddress: address,
+                    cumulativeGasUsed: 10,
+                    transactionIndex: 3,
+                    blockNumber: 10,
+                    blockHash: '0xbf1234',
+                    gasUsed: 0
                 });
+                done();
+            });
 
         });
         it('_executeMethod should sendTransaction and check for receipts', function (done) {
@@ -676,10 +687,10 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: signature + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a',
+                    data: signature +'000000000000000000000000'+ addressLowercase.replace('0x','') +'000000000000000000000000000000000000000000000000000000000000000a',
                     from: address2,
                     to: addressLowercase,
-                    gasPrice: '0x5af3107a4000'
+                    gasPrice: "0x5af3107a4000"
                 }]);
             });
             provider.injectResult('0x1234000000000000000000000000000000000000000000000000000000056789');
@@ -731,39 +742,36 @@ var runTests = function (contractFactory) {
             var txObject = {};
             txObject._method = {
                 signature: signature,
-                'name': 'send',
-                'type': 'function',
-                'inputs': [{
-                    'name': 'to',
-                    'type': 'address'
+                "name": "send",
+                "type": "function",
+                "inputs": [{
+                    "name": "to",
+                    "type": "address"
                 }, {
-                    'name': 'value',
-                    'type': 'uint256'
+                    "name": "value",
+                    "type": "uint256"
                 }],
-                'outputs': []
+                "outputs": []
             };
             txObject._parent = contract;
             txObject.encodeABI = contract._encodeMethodABI.bind(txObject);
             txObject.arguments = [address, 10];
 
-            var deploy = contract._executeMethod.call(txObject, 'send', {
-                from: address2,
-                gasPrice: '100000000000000'
-            }, function (err, result) {
+            var deploy = contract._executeMethod.call(txObject, 'send', {from: address2, gasPrice: '100000000000000' }, function (err, result) {
                 // tx hash
                 assert.equal(result, '0x1234000000000000000000000000000000000000000000000000000000056789');
             })
-                .on('receipt', function (result) {
-                    assert.deepEqual(result, {
-                        contractAddress: address,
-                        cumulativeGasUsed: 10,
-                        transactionIndex: 3,
-                        blockNumber: 10,
-                        blockHash: '0xbf1234',
-                        gasUsed: 0
-                    });
-                    done();
-                }).catch(console.log);
+            .on('receipt', function(result){
+                assert.deepEqual(result, {
+                    contractAddress: address,
+                    cumulativeGasUsed: 10,
+                    transactionIndex: 3,
+                    blockNumber: 10,
+                    blockHash: '0xbf1234',
+                    gasUsed: 0
+                });
+                done();
+            }).catch(console.log);
 
         });
         it('_executeMethod should call and return values', function (done) {
@@ -773,7 +781,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: signature + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: signature + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     from: address2,
                     to: addressLowercase
                 }, 'latest']);
@@ -786,35 +794,29 @@ var runTests = function (contractFactory) {
             var txObject = {};
             txObject._method = {
                 signature: signature,
-                'name': 'balance',
-                'type': 'function',
-                'inputs': [{
-                    'name': 'who',
-                    'type': 'address'
+                "name": "balance",
+                "type": "function",
+                "inputs": [{
+                    "name": "who",
+                    "type": "address"
                 }],
-                'constant': true,
-                'outputs': [{
-                    'name': 'value',
-                    'type': 'uint256'
+                "constant": true,
+                "outputs": [{
+                    "name": "value",
+                    "type": "uint256"
                 }]
             };
             txObject._parent = contract;
             txObject.encodeABI = contract._encodeMethodABI.bind(txObject);
             txObject.arguments = [address];
 
-            contract._executeMethod.call(
-                txObject,
-                'call',
-                {
-                    from: address2
-                },
-                function (err, result) {
-                    assert.equal(result, '10');
-                })
-                .then(function (result) {
-                    assert.equal(result, '10');
-                    done();
-                });
+            var deploy = contract._executeMethod.call(txObject, 'call', {from: address2}, function (err, result) {
+                assert.equal(result, '10');
+            })
+            .then(function(result){
+                assert.equal(result, '10');
+                done();
+            });
 
         });
     });
@@ -859,27 +861,21 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
 
             var contract = contractFactory(abi, address, provider);
 
-            contract.events.Changed(
-                {
-                    filter: {
-                        from: address
-                    }
-                },
-                function (err, result, sub) {
-                    assert.equal(result.returnValues.from, address);
-                    assert.equal(result.returnValues.amount, 1);
-                    assert.equal(result.returnValues.t1, 1);
-                    assert.equal(result.returnValues.t2, 8);
+            var event = contract.events.Changed({filter: {from: address}}, function (err, result, sub) {
+                assert.equal(result.returnValues.from, address);
+                assert.equal(result.returnValues.amount, 1);
+                assert.equal(result.returnValues.t1, 1);
+                assert.equal(result.returnValues.t2, 8);
 
-                    sub.unsubscribe();
-                });
+                sub.unsubscribe();
+            });
 
         });
 
@@ -892,24 +888,24 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_getLogs');
             });
             provider.injectResult([{
-                address: addressLowercase,
-                topics: [
-                    sha3(signature),
-                    '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
-                    '0x0000000000000000000000000000000000000000000000000000000000000002'
-                ],
-                blockNumber: '0x3',
-                transactionHash: '0x1234',
-                blockHash: '0x1345',
-                logIndex: '0x4',
-                data: '0x0000000000000000000000000000000000000000000000000000000000000002' +
+                    address: addressLowercase,
+                    topics: [
+                        sha3(signature),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
+                        '0x0000000000000000000000000000000000000000000000000000000000000002'
+                    ],
+                    blockNumber: '0x3',
+                    transactionHash: '0x1234',
+                    blockHash: '0x1345',
+                    logIndex: '0x4',
+                    data: '0x0000000000000000000000000000000000000000000000000000000000000002' +
                     '0000000000000000000000000000000000000000000000000000000000000009'
-            },
+                },
                 {
                     address: addressLowercase,
                     topics: [
                         sha3(signature),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         '0x0000000000000000000000000000000000000000000000000000000000000003'
                     ],
                     blockNumber: '0x4',
@@ -917,8 +913,8 @@ var runTests = function (contractFactory) {
                     blockHash: '0x1346',
                     logIndex: '0x1',
                     data: '0x0000000000000000000000000000000000000000000000000000000000000004' +
-                        '0000000000000000000000000000000000000000000000000000000000000005'
-                }]);
+                    '0000000000000000000000000000000000000000000000000000000000000005'
+            }]);
 
             provider.injectValidation(function (payload) {
                 assert.equal(payload.jsonrpc, '2.0');
@@ -926,7 +922,7 @@ var runTests = function (contractFactory) {
                 assert.deepEqual(payload.params[1], {
                     topics: [
                         sha3(signature),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         null
                     ],
                     address: addressLowercase
@@ -949,7 +945,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -957,32 +953,32 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
 
             var contract = contractFactory(abi, address, provider);
             var count = 0;
-            var event = contract.events.Changed({fromBlock: 0, filter: {from: address}})
+            var event = contract.events.Changed({fromBlock: 0,filter: {from: address}})
                 .on('data', function (result) {
                     count++;
 
-                    if (count === 1) {
+                    if(count === 1) {
                         assert.equal(result.returnValues.from, address);
                         assert.equal(result.returnValues.amount, 2);
                         assert.equal(result.returnValues.t1, 2);
                         assert.equal(result.returnValues.t2, 9);
 
                     }
-                    if (count === 2) {
+                    if(count === 2) {
                         assert.equal(result.returnValues.from, address);
                         assert.equal(result.returnValues.amount, 3);
                         assert.equal(result.returnValues.t1, 4);
                         assert.equal(result.returnValues.t2, 5);
 
                     }
-                    if (count === 3) {
+                    if(count === 3) {
                         assert.equal(result.returnValues.from, address);
                         assert.equal(result.returnValues.amount, 1);
                         assert.equal(result.returnValues.t1, 1);
@@ -1005,7 +1001,7 @@ var runTests = function (contractFactory) {
                 assert.deepEqual(payload.params[1], {
                     topics: [
                         sha3(signature),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         null
                     ],
                     address: addressLowercase
@@ -1028,7 +1024,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1036,7 +1032,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1062,7 +1058,7 @@ var runTests = function (contractFactory) {
                 assert.deepEqual(payload.params[1], {
                     topics: [
                         sha3(signature),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         null
                     ],
                     address: addressLowercase
@@ -1085,7 +1081,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1093,7 +1089,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1119,7 +1115,7 @@ var runTests = function (contractFactory) {
                 assert.deepEqual(payload.params[1], {
                     topics: [
                         sha3(signature),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         null
                     ],
                     address: addressLowercase
@@ -1141,7 +1137,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1149,7 +1145,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1162,7 +1158,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1170,7 +1166,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1223,7 +1219,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1231,7 +1227,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1244,7 +1240,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1252,7 +1248,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1290,7 +1286,7 @@ var runTests = function (contractFactory) {
                 assert.deepEqual(payload.params[1], {
                     topics: [
                         sha3(signature),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         null
                     ],
                     address: addressLowercase
@@ -1312,7 +1308,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1320,7 +1316,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1333,7 +1329,7 @@ var runTests = function (contractFactory) {
                         address: addressLowercase,
                         topics: [
                             sha3(signature),
-                            '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                            '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1342,7 +1338,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1350,25 +1346,25 @@ var runTests = function (contractFactory) {
             var count = 1;
             var contract = contractFactory(abi, address, provider);
             contract.events.Changed({filter: {from: address}})
-                .on('data', function (result) {
-                    assert.equal(result.returnValues.from, address);
-                    assert.equal(result.returnValues.amount, 1);
-                    assert.equal(result.returnValues.t1, 1);
-                    assert.equal(result.returnValues.t2, 8);
+            .on('data', function(result) {
+                assert.equal(result.returnValues.from, address);
+                assert.equal(result.returnValues.amount, 1);
+                assert.equal(result.returnValues.t1, 1);
+                assert.equal(result.returnValues.t2, 8);
 
-                    assert.equal(count, 1);
-                    count++;
+                assert.equal(count, 1);
+                count++;
 
-                })
-                .on('changed', function (result) {
-                    assert.equal(result.returnValues.from, address);
-                    assert.equal(result.returnValues.amount, 1);
-                    assert.equal(result.returnValues.t1, 1);
-                    assert.equal(result.returnValues.t2, 8);
-                    assert.equal(result.removed, true);
+            })
+            .on('changed', function(result) {
+                assert.equal(result.returnValues.from, address);
+                assert.equal(result.returnValues.amount, 1);
+                assert.equal(result.returnValues.t1, 1);
+                assert.equal(result.returnValues.t2, 8);
+                assert.equal(result.removed, true);
 
-                    assert.equal(count, 2);
-                });
+                assert.equal(count, 2);
+            });
 
             setTimeout(done, 60);
 
@@ -1402,13 +1398,13 @@ var runTests = function (contractFactory) {
             var event = contract.events.allEvents(function (err, result) {
                 count++;
 
-                if (count === 1) {
+                if(count === 1) {
                     assert.equal(result.returnValues.from, address);
                     assert.equal(result.returnValues.amount, 1);
                     assert.equal(result.returnValues.t1, 1);
                     assert.equal(result.returnValues.t2, 8);
                 }
-                if (count === 2) {
+                if(count === 2) {
                     assert.equal(result.returnValues.addressFrom, address);
                     assert.equal(result.returnValues.value, 2);
                     assert.equal(result.returnValues.t1, 5);
@@ -1427,7 +1423,7 @@ var runTests = function (contractFactory) {
                         address: address,
                         topics: [
                             sha3('Changed(address,uint256,uint256,uint256)'),
-                            '0x000000000000000000000000' + address.replace('0x', ''),
+                            '0x000000000000000000000000'+ address.replace('0x',''),
                             '0x0000000000000000000000000000000000000000000000000000000000000001'
                         ],
                         blockNumber: '0x3',
@@ -1435,7 +1431,7 @@ var runTests = function (contractFactory) {
                         blockHash: '0x1345',
                         logIndex: '0x4',
                         data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                            '0000000000000000000000000000000000000000000000000000000000000008'
+                        '0000000000000000000000000000000000000000000000000000000000000008'
                     }
                 }
             });
@@ -1450,7 +1446,7 @@ var runTests = function (contractFactory) {
                         topics: [
                             sha3('Unchanged(uint256,address,uint256)'),
                             '0x0000000000000000000000000000000000000000000000000000000000000002',
-                            '0x000000000000000000000000' + address.replace('0x', '')
+                            '0x000000000000000000000000'+ address.replace('0x','')
                         ],
                         blockNumber: '0x3',
                         transactionHash: '0x1234',
@@ -1472,7 +1468,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase,
                     from: address2
                 }, 'latest']);
@@ -1486,7 +1482,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: address2,
                     from: addressLowercase
                 }, 'latest']);
@@ -1498,29 +1494,29 @@ var runTests = function (contractFactory) {
         it('should reset functions when resetting json interface', function () {
             var provider = new FakeIpcProvider();
 
-            var contract = contractFactory(abi, '', provider);
+            var contract = contractFactory(abi, provider);
 
             assert.isFunction(contract.methods.mySend);
             assert.isFunction(contract.events.Changed);
 
             contract.options.jsonInterface = [{
-                'name': 'otherSend',
-                'type': 'function',
-                'inputs': [{
-                    'name': 'to',
-                    'type': 'address'
+                "name": "otherSend",
+                "type": "function",
+                "inputs": [{
+                    "name": "to",
+                    "type": "address"
                 }, {
-                    'name': 'value',
-                    'type': 'uint256'
+                    "name": "value",
+                    "type": "uint256"
                 }],
-                'outputs': []
+                "outputs": []
             }, {
-                'name': 'Unchanged',
-                'type': 'event',
-                'inputs': [
-                    {'name': 'value', 'type': 'uint256', 'indexed': true},
-                    {'name': 'addressFrom', 'type': 'address', 'indexed': true},
-                    {'name': 't1', 'type': 'uint256', 'indexed': false}
+                "name":"Unchanged",
+                "type":"event",
+                "inputs": [
+                    {"name":"value","type":"uint256","indexed":true},
+                    {"name":"addressFrom","type":"address","indexed":true},
+                    {"name":"t1","type":"uint256","indexed":false}
                 ]
             }];
 
@@ -1535,36 +1531,38 @@ var runTests = function (contractFactory) {
             var provider = new FakeIpcProvider();
             var signature = 'balance(address)';
 
-            var contract = contractFactory(abi, '', provider);
+            var contract = contractFactory(abi, provider);
 
             var result = contract.methods.balance(address).encodeABI();
 
-            assert.equal(result, sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''));
+            assert.equal(result, sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''));
         });
 
         it('should encode a constructor call with pre set data', function () {
             var provider = new FakeIpcProvider();
+            var signature = 'balance(address)';
 
-            var contract = contractFactory(abi, '', provider, {data: '0x1234'});
+            var contract = contractFactory(abi, {data: '0x1234'}, provider);
 
             var result = contract.deploy({
                 arguments: [address, 10]
             }).encodeABI();
 
-            assert.equal(result, '0x1234' + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a');
+            assert.equal(result, '0x1234' + '000000000000000000000000'+ addressLowercase.replace('0x','')+ '000000000000000000000000000000000000000000000000000000000000000a');
         });
 
         it('should encode a constructor call with passed data', function () {
             var provider = new FakeIpcProvider();
+            var signature = 'balance(address)';
 
-            var contract = contractFactory(abi, '', provider);
+            var contract = contractFactory(abi, provider);
 
             var result = contract.deploy({
                 arguments: [address, 10],
                 data: '0x1234'
             }).encodeABI();
 
-            assert.equal(result, '0x1234' + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a');
+            assert.equal(result, '0x1234' + '000000000000000000000000'+ addressLowercase.replace('0x','')+ '000000000000000000000000000000000000000000000000000000000000000a');
         });
 
 
@@ -1575,7 +1573,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_estimateGas');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase
                 }]);
             });
@@ -1596,12 +1594,12 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_estimateGas');
                 assert.deepEqual(payload.params, [{
-                    data: '0x1234000000000000000000000000' + addressLowercase.replace('0x', '') + '0000000000000000000000000000000000000000000000000000000000000032'
+                    data: '0x1234000000000000000000000000'+ addressLowercase.replace('0x','') +'0000000000000000000000000000000000000000000000000000000000000032'
                 }]);
             });
             provider.injectResult('0x000000000000000000000000000000000000000000000000000000000000000a');
 
-            var contract = contractFactory(abi, address, provider, {data: '0x1234'});
+            var contract = contractFactory(abi, address, {data: '0x1234'}, provider);
 
             contract.deploy({
                 arguments: [address, 50]
@@ -1621,17 +1619,17 @@ var runTests = function (contractFactory) {
                     to: addressLowercase
                 }, 'latest']);
             });
-            provider.injectResult('0x000000000000000000000000' + addressLowercase.replace('0x', ''));
+            provider.injectResult('0x000000000000000000000000'+ addressLowercase.replace('0x',''));
 
             var contract = contractFactory(abi, address, provider);
 
-            contract.methods.hasALotOfParams('0x24545345', '0xff24545345', ['0xff24545345', '0x5345', '0x4545', '0x453345']).call(function (err, res) {
+            contract.methods.hasALotOfParams("0x24545345", "0xff24545345", ["0xff24545345", "0x5345", "0x4545", "0x453345"]).call(function (err, res) {
                 assert.deepEqual(res, address);
                 done();
             });
         });
 
-        it('should send overload functions with zero parameters', function (done) {
+        it('should send overload functions with zero parameters', function(done) {
             var provider = new FakeIpcProvider();
 
             provider.injectValidation(function (payload) {
@@ -1650,7 +1648,7 @@ var runTests = function (contractFactory) {
             });
         });
 
-        it('should send overload functions with one parameters', function (done) {
+        it('should send overload functions with one parameters', function(done) {
             var provider = new FakeIpcProvider();
 
             provider.injectValidation(function (payload) {
@@ -1677,7 +1675,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase
                 }, 'latest']);
             });
@@ -1698,7 +1696,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase
                 }, '0xb']);
             });
@@ -1707,10 +1705,10 @@ var runTests = function (contractFactory) {
             var contract = contractFactory(abi, address, provider);
 
             contract.methods.balance(address).call(11)
-                .then(function (r) {
-                    assert.deepEqual(r, '50');
-                    done();
-                });
+            .then(function (r) {
+                assert.deepEqual(r, '50');
+                done();
+            });
         });
 
         it('should call constant concurrently', function (done) {
@@ -1719,7 +1717,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3('balance(address)').slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3('balance(address)').slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase
                 }, 'latest']);
             });
@@ -1748,7 +1746,7 @@ var runTests = function (contractFactory) {
                 contract.methods.balance(address).call(),
                 contract.methods.owner().call(),
                 contract.methods.getStr().call()
-            ).spread(function (m1, m2, m3) {
+            ).spread(function(m1, m2, m3) {
                 assert.deepEqual(m1, '10');
                 assert.deepEqual(m2, '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe');
                 assert.deepEqual(m3, 'Hello!%!');
@@ -1813,10 +1811,10 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: signature + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a',
+                    data: signature +'000000000000000000000000'+ addressLowercase.replace('0x','') +'000000000000000000000000000000000000000000000000000000000000000a',
                     from: address2,
                     to: addressLowercase,
-                    gasPrice: '0x1369ed97fb71'
+                    gasPrice: "0x1369ed97fb71"
                 }]);
             });
             provider.injectResult('0x1234000000000000000000000000000000000000000000000000000000056789');
@@ -1861,7 +1859,7 @@ var runTests = function (contractFactory) {
                     topics: [
                         sha3('Unchanged(uint256,address,uint256)'),
                         '0x0000000000000000000000000000000000000000000000000000000000000002',
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', '')
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x','')
                     ],
                     blockNumber: '0xa',
                     transactionHash: '0x1234',
@@ -1869,11 +1867,11 @@ var runTests = function (contractFactory) {
                     blockHash: '0x1345',
                     logIndex: '0x4',
                     data: '0x0000000000000000000000000000000000000000000000000000000000000005'
-                }, {
+                },{
                     address: address,
                     topics: [
                         sha3('Changed(address,uint256,uint256,uint256)'),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         '0x0000000000000000000000000000000000000000000000000000000000000001'
                     ],
                     blockNumber: '0xa',
@@ -1882,7 +1880,7 @@ var runTests = function (contractFactory) {
                     blockHash: '0x1345',
                     logIndex: '0x4',
                     data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                        '0000000000000000000000000000000000000000000000000000000000000008'
+                    '0000000000000000000000000000000000000000000000000000000000000008'
                 }]
             });
             provider.injectValidation(function (payload) {
@@ -1895,78 +1893,78 @@ var runTests = function (contractFactory) {
             var contract = contractFactory(abi, address, provider);
 
             contract.methods.mySend(address, 10).send({from: address2, gasPrice: '21345678654321'})
-                .on('receipt', function (receipt) {
-                    // console.log(receipt);
-                    // console.log(receipt.events[0].raw);
-                    // console.log(receipt.events[1].raw);
+            .on('receipt', function (receipt) {
+                // console.log(receipt);
+                // console.log(receipt.events[0].raw);
+                // console.log(receipt.events[1].raw);
 
-                    // wont throw if it errors ?!
-                    assert.deepEqual(receipt, {
-                        contractAddress: null,
-                        cumulativeGasUsed: 10,
-                        transactionIndex: 3,
-                        transactionHash: '0x1234',
-                        blockNumber: 10,
-                        blockHash: '0x1234',
-                        gasUsed: 0,
-                        events: {
-                            Unchanged: {
-                                address: address,
-                                blockNumber: 10,
-                                transactionHash: '0x1234',
-                                blockHash: '0x1345',
-                                logIndex: 4,
-                                id: 'log_9ff24cb4',
-                                transactionIndex: 0,
-                                returnValues: {
-                                    0: '2',
-                                    1: address,
-                                    2: '5',
-                                    value: '2',
-                                    addressFrom: address,
-                                    t1: '5'
-                                },
-                                event: 'Unchanged',
-                                signature: '0xf359668f205d0b5cfdc20d11353e05f633f83322e96f15486cbb007d210d66e5',
-                                raw: {
-                                    topics: ['0xf359668f205d0b5cfdc20d11353e05f633f83322e96f15486cbb007d210d66e5',
-                                        '0x0000000000000000000000000000000000000000000000000000000000000002',
-                                        '0x000000000000000000000000' + addressLowercase.replace('0x', '')],
-                                    data: '0x0000000000000000000000000000000000000000000000000000000000000005'
-                                }
+                // wont throw if it errors ?!
+                assert.deepEqual(receipt, {
+                    contractAddress: null,
+                    cumulativeGasUsed: 10,
+                    transactionIndex: 3,
+                    transactionHash: '0x1234',
+                    blockNumber: 10,
+                    blockHash: '0x1234',
+                    gasUsed: 0,
+                    events: {
+                        Unchanged: {
+                            address: address,
+                            blockNumber: 10,
+                            transactionHash: '0x1234',
+                            blockHash: '0x1345',
+                            logIndex: 4,
+                            id: 'log_9ff24cb4',
+                            transactionIndex: 0,
+                            returnValues: {
+                                0: '2',
+                                1: address,
+                                2: '5',
+                                value: '2',
+                                addressFrom: address,
+                                t1: '5'
                             },
-                            Changed: {
-                                address: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
-                                blockNumber: 10,
-                                transactionHash: '0x1234',
-                                blockHash: '0x1345',
-                                logIndex: 4,
-                                id: 'log_9ff24cb4',
-                                transactionIndex: 0,
-                                returnValues: {
-                                    0: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
-                                    1: '1',
-                                    2: '1',
-                                    3: '8',
-                                    from: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
-                                    amount: '1',
-                                    t1: '1',
-                                    t2: '8'
-                                },
-                                event: 'Changed',
-                                signature: '0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
-                                raw: {
-                                    topics: ['0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
-                                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
-                                        '0x0000000000000000000000000000000000000000000000000000000000000001'],
-                                    data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008'
-                                }
+                            event: 'Unchanged',
+                            signature: "0xf359668f205d0b5cfdc20d11353e05f633f83322e96f15486cbb007d210d66e5",
+                            raw: {
+                                topics: ['0xf359668f205d0b5cfdc20d11353e05f633f83322e96f15486cbb007d210d66e5',
+                                    '0x0000000000000000000000000000000000000000000000000000000000000002',
+                                    '0x000000000000000000000000' + addressLowercase.replace('0x', '')],
+                                data: '0x0000000000000000000000000000000000000000000000000000000000000005',
+                            }
+                        },
+                        Changed: {
+                            address: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+                            blockNumber: 10,
+                            transactionHash: '0x1234',
+                            blockHash: '0x1345',
+                            logIndex: 4,
+                            id: 'log_9ff24cb4',
+                            transactionIndex: 0,
+                            returnValues: {
+                                0: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+                                1: '1',
+                                2: '1',
+                                3: '8',
+                                from: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+                                amount: '1',
+                                t1: '1',
+                                t2: '8'
+                            },
+                            event: 'Changed',
+                            signature: "0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651",
+                            raw: {
+                                topics: ['0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
+                                    '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                                    '0x0000000000000000000000000000000000000000000000000000000000000001'],
+                                data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008',
                             }
                         }
-                    });
-
-                    done();
+                    }
                 });
+
+               done();
+            });
 
 
         });
@@ -1978,10 +1976,10 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: signature + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a',
+                    data: signature +'000000000000000000000000'+ addressLowercase.replace('0x','') +'000000000000000000000000000000000000000000000000000000000000000a',
                     from: address2,
                     to: addressLowercase,
-                    gasPrice: '0x1369ed97fb71'
+                    gasPrice: "0x1369ed97fb71"
                 }]);
             });
             provider.injectResult('0x1234000000000000000000000000000000000000000000000000000000056789');
@@ -2034,12 +2032,12 @@ var runTests = function (contractFactory) {
                     blockHash: '0x1345',
                     logIndex: '0x4',
                     data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                        '0000000000000000000000000000000000000000000000000000000000000008'
-                }, {
+                    '0000000000000000000000000000000000000000000000000000000000000008'
+                },{
                     address: address,
                     topics: [
                         sha3('Changed(address,uint256,uint256,uint256)'),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         '0x0000000000000000000000000000000000000000000000000000000000000002'
                     ],
                     blockNumber: '0xa',
@@ -2048,7 +2046,7 @@ var runTests = function (contractFactory) {
                     blockHash: '0x1345',
                     logIndex: '0x5',
                     data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                        '0000000000000000000000000000000000000000000000000000000000000008'
+                    '0000000000000000000000000000000000000000000000000000000000000008'
                 }]
             });
             provider.injectValidation(function (payload) {
@@ -2093,12 +2091,12 @@ var runTests = function (contractFactory) {
                                         t2: '8'
                                     },
                                     event: 'Changed',
-                                    signature: '0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
+                                    signature: "0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651",
                                     raw: {
-                                        topics: ['0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
+                                        topics: [ '0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
                                             '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
-                                            '0x0000000000000000000000000000000000000000000000000000000000000001'],
-                                        data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008'
+                                            '0x0000000000000000000000000000000000000000000000000000000000000001' ],
+                                        data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008',
                                     }
                                 }, {
                                     address: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
@@ -2119,12 +2117,12 @@ var runTests = function (contractFactory) {
                                         t2: '8'
                                     },
                                     event: 'Changed',
-                                    signature: '0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
+                                    signature: "0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651",
                                     raw: {
-                                        topics: ['0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
+                                        topics: [ '0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
                                             '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
-                                            '0x0000000000000000000000000000000000000000000000000000000000000002'],
-                                        data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008'
+                                            '0x0000000000000000000000000000000000000000000000000000000000000002' ],
+                                        data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008',
                                     }
                                 }
                             ]
@@ -2144,10 +2142,10 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: signature + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a',
+                    data: signature +'000000000000000000000000'+ addressLowercase.replace('0x','') +'000000000000000000000000000000000000000000000000000000000000000a',
                     from: address2,
                     to: addressLowercase,
-                    gasPrice: '0x1369ed97fb71'
+                    gasPrice: "0x1369ed97fb71"
                 }]);
             });
             provider.injectResult('0x1234000000000000000000000000000000000000000000000000000000056789');
@@ -2176,7 +2174,7 @@ var runTests = function (contractFactory) {
                     topics: [
                         sha3('Unchanged(uint256,address,uint256)'),
                         '0x0000000000000000000000000000000000000000000000000000000000000002',
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', '')
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x','')
                     ],
                     blockNumber: '0xa',
                     transactionHash: '0x1234',
@@ -2184,11 +2182,11 @@ var runTests = function (contractFactory) {
                     blockHash: '0x1345',
                     logIndex: '0x4',
                     data: '0x0000000000000000000000000000000000000000000000000000000000000005'
-                }, {
+                },{
                     address: address,
                     topics: [
                         sha3('Changed(address,uint256,uint256,uint256)'),
-                        '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
+                        '0x000000000000000000000000'+ addressLowercase.replace('0x',''),
                         '0x0000000000000000000000000000000000000000000000000000000000000001'
                     ],
                     blockNumber: '0xa',
@@ -2197,7 +2195,7 @@ var runTests = function (contractFactory) {
                     blockHash: '0x1345',
                     logIndex: '0x4',
                     data: '0x0000000000000000000000000000000000000000000000000000000000000001' +
-                        '0000000000000000000000000000000000000000000000000000000000000008'
+                    '0000000000000000000000000000000000000000000000000000000000000008'
                 }]
             });
             provider.injectValidation(function (payload) {
@@ -2247,7 +2245,7 @@ var runTests = function (contractFactory) {
                                     topics: ['0xf359668f205d0b5cfdc20d11353e05f633f83322e96f15486cbb007d210d66e5',
                                         '0x0000000000000000000000000000000000000000000000000000000000000002',
                                         '0x000000000000000000000000' + addressLowercase.replace('0x', '')],
-                                    data: '0x0000000000000000000000000000000000000000000000000000000000000005'
+                                    data: '0x0000000000000000000000000000000000000000000000000000000000000005',
                                 }
                             },
                             Changed: {
@@ -2274,7 +2272,7 @@ var runTests = function (contractFactory) {
                                     topics: ['0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
                                         '0x000000000000000000000000' + addressLowercase.replace('0x', ''),
                                         '0x0000000000000000000000000000000000000000000000000000000000000001'],
-                                    data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008'
+                                    data: '0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000008',
                                 }
                             }
                         }
@@ -2286,17 +2284,17 @@ var runTests = function (contractFactory) {
 
         });
 
-        it('should sendTransaction and receive multiple confirmations', function (done) {
+        it('should sendTransaction and receive multiple confirmations', function(done){
             var provider = new FakeIpcProvider();
             var signature = sha3('mySend(address,uint256)').slice(0, 10);
 
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: signature + '000000000000000000000000' + addressLowercase.replace('0x', '') + '000000000000000000000000000000000000000000000000000000000000000a',
+                    data: signature +'000000000000000000000000'+ addressLowercase.replace('0x','') +'000000000000000000000000000000000000000000000000000000000000000a',
                     from: address2,
                     to: addressLowercase,
-                    gasPrice: '0x1369ed97fb71'
+                    gasPrice: "0x1369ed97fb71"
                 }]);
             });
             provider.injectResult('0x1234000000000000000000000000000000000000000000000000000000056789');
@@ -2330,7 +2328,7 @@ var runTests = function (contractFactory) {
                 .send({from: address2, gasPrice: '21345678654321'})
                 .on('confirmation', function (confirmationNumber, receipt) {
                     count++;
-                    if (count === 1) {
+                    if(count === 1) {
                         assert.deepEqual(receipt, {
                             contractAddress: null,
                             cumulativeGasUsed: 10,
@@ -2344,7 +2342,7 @@ var runTests = function (contractFactory) {
 
                         assert.equal(confirmationNumber, 0);
                     }
-                    if (count === 2) {
+                    if(count === 2) {
                         assert.deepEqual(receipt, {
                             contractAddress: null,
                             cumulativeGasUsed: 10,
@@ -2391,11 +2389,11 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                    '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                    '0000000000000000000000000000000000000000000000000000000000000011' ,
                     from: addressLowercase,
                     to: addressLowercase,
-                    gasPrice: '0x369d1f7fd2'
+                    gasPrice: "0x369d1f7fd2"
                 }]);
             });
 
@@ -2409,16 +2407,16 @@ var runTests = function (contractFactory) {
 
             var contract = contractFactory(abi, address, provider);
 
-            try {
+            try{
                 contract.methods.myDisallowedSend(address, 17).send({from: address, value: 123})
-                    .on('error', function (e) {
-                        assert.isTrue(e instanceof Error, 'Should throw error');
-                    })
-                    .catch(function (e) {
-                        assert.isTrue(e instanceof Error, 'Should throw error');
-                    });
+                .on('error', function (e) {
+                    assert.isTrue(e instanceof Error, 'Should throw error');
+                })
+                .catch(function (e) {
+                    assert.isTrue(e instanceof Error, 'Should throw error');
+                });
 
-            } catch (e) {
+            } catch(e){
                 assert.isTrue(e instanceof Error, 'Should throw error');
             }
         });
@@ -2431,11 +2429,11 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                    '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                    '0000000000000000000000000000000000000000000000000000000000000011' ,
                     from: addressLowercase,
                     to: addressLowercase,
-                    gasPrice: '0x1555757ee6b1'
+                    gasPrice: "0x1555757ee6b1"
                 }]);
 
                 done();
@@ -2443,16 +2441,16 @@ var runTests = function (contractFactory) {
 
             var contract = contractFactory(abi, address, provider);
 
-            try {
+            try{
                 contract.methods.myDisallowedSend(address, 17).send({from: address, gasPrice: '23456787654321'})
-                    .on('error', function (e) {
-                        assert.isFalse(e instanceof Error, 'Should not throw error');
-                    })
-                    .catch(function (e) {
-                        assert.isFalse(e instanceof Error, 'Should not throw error');
-                    });
+                .on('error', function (e) {
+                    assert.isFalse(e instanceof Error, 'Should not throw error');
+                })
+                .catch(function (e) {
+                    assert.isFalse(e instanceof Error, 'Should not throw error');
+                });
 
-            } catch (e) {
+            } catch(e){
                 assert.isFalse(e instanceof Error, 'Should not throw error');
             }
         });
@@ -2466,11 +2464,11 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: signature +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                    '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                    '0000000000000000000000000000000000000000000000000000000000000011' ,
                     from: addressLowercase,
                     to: addressLowercase,
-                    gasPrice: '0x1555757ee6b1'
+                    gasPrice: "0x1555757ee6b1"
                 }]);
             });
 
@@ -2487,11 +2485,11 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: signature +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                    '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                    '0000000000000000000000000000000000000000000000000000000000000011' ,
                     from: addressLowercase,
                     to: addressLowercase,
-                    gasPrice: '0x49504f80'
+                    gasPrice: "0x49504f80"
                 }]);
             });
 
@@ -2508,8 +2506,8 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                    '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                    '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350',
@@ -2537,11 +2535,11 @@ var runTests = function (contractFactory) {
 
             provider.injectValidation(function (payload) {
                 count++;
-                if (count > 1) return;
+                if(count > 1) return;
 
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350'
@@ -2553,10 +2551,10 @@ var runTests = function (contractFactory) {
             var contract = contractFactory(abi, address, provider);
 
             contract.methods.balance(address).call({from: address, gas: 50000})
-                .then(function (r) {
-                    assert.deepEqual(r, '50');
-                    done();
-                });
+            .then(function (r) {
+                assert.deepEqual(r, '50');
+                done();
+            });
         });
 
         it('should explicitly make a call with optional params', function (done) {
@@ -2566,7 +2564,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350'
@@ -2577,10 +2575,10 @@ var runTests = function (contractFactory) {
             var contract = contractFactory(abi, address, provider);
 
             contract.methods.balance(address).call({from: address, gas: 50000})
-                .then(function (r) {
-                    assert.deepEqual(r, '50');
-                    done();
-                });
+            .then(function (r) {
+                assert.deepEqual(r, '50');
+                done();
+            });
 
         });
 
@@ -2591,7 +2589,7 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_call');
                 assert.deepEqual(payload.params, [{
-                    data: sha3(signature).slice(0, 10) + '000000000000000000000000' + addressLowercase.replace('0x', ''),
+                    data: sha3(signature).slice(0, 10) + '000000000000000000000000'+ addressLowercase.replace('0x',''),
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350'
@@ -2602,10 +2600,10 @@ var runTests = function (contractFactory) {
             var contract = contractFactory(abi, address, provider);
 
             contract.methods.balance(address).call({from: address, gas: 50000}, 11)
-                .then(function (r) {
-                    assert.deepEqual(r, '50');
-                    done();
-                });
+            .then(function (r) {
+                assert.deepEqual(r, '50');
+                done();
+            });
 
         });
 
@@ -2617,8 +2615,8 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                        '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                        '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350',
@@ -2650,8 +2648,8 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                    '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                    '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
                     gasPrice: '0x45656456456456'
@@ -2673,8 +2671,8 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                        '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                        '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350',
@@ -2700,8 +2698,8 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                        '000000000000000000000000'+ addressLowercase.replace('0x','') +
+                        '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350',
@@ -2712,16 +2710,11 @@ var runTests = function (contractFactory) {
 
             var contract = contractFactory(abi, address, provider);
 
-            contract.methods.mySend(address, 17).send({
-                from: address,
-                gas: 50000,
-                gasPrice: 3000,
-                value: 10000
-            }, function (err) {
+            contract.methods.mySend(address, 17).send({from: address, gas: 50000, gasPrice: 3000, value: 10000}, function (err) {
                 assert.equal(err, null);
                 done();
             });
-        });
+        })
 
         it('should explicitly estimateGas with optional params', function () {
             var provider = new FakeIpcProvider();
@@ -2731,8 +2724,8 @@ var runTests = function (contractFactory) {
                 assert.equal(payload.method, 'eth_estimateGas');
                 assert.deepEqual(payload.params, [{
                     data: sha3(signature).slice(0, 10) +
-                        '000000000000000000000000' + addressLowercase.replace('0x', '') +
-                        '0000000000000000000000000000000000000000000000000000000000000011',
+                        '000000000000000000000000' + addressLowercase.replace('0x','') +
+                        '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
                     gas: '0xc350',
@@ -2755,21 +2748,21 @@ var runTests = function (contractFactory) {
                 assert.deepEqual(payload.params, [{
                     address: addressLowercase,
                     topics: [
-                        '0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651',
-                        '0x000000000000000000000000' + address2.replace('0x', ''),
-                        null
+                          "0x792991ed5ba9322deaef76cff5051ce4bedaaa4d097585970f9ad8f09f54e651",
+                          "0x000000000000000000000000" + address2.replace('0x',''),
+                          null
                     ]
                 }]);
             });
 
             var topic1 = [
                 sha3(signature),
-                '0x000000000000000000000000' + address.replace('0x', ''),
+                '0x000000000000000000000000'+ address.replace('0x',''),
                 '0x000000000000000000000000000000000000000000000000000000000000000a'
             ];
             var topic2 = [
                 sha3(signature),
-                '0x000000000000000000000000' + address.replace('0x', ''),
+                '0x000000000000000000000000'+ address.replace('0x',''),
                 '0x0000000000000000000000000000000000000000000000000000000000000003'
             ];
 
@@ -2782,79 +2775,79 @@ var runTests = function (contractFactory) {
                 blockHash: '0x1345',
                 logIndex: '0x4',
                 data: '0x0000000000000000000000000000000000000000000000000000000000000002' +
-                    '0000000000000000000000000000000000000000000000000000000000000009'
+                '0000000000000000000000000000000000000000000000000000000000000009'
             },
-                {
-                    address: address,
-                    topics: topic2,
-                    blockNumber: '0x4',
-                    transactionHash: '0x1235',
-                    transactionIndex: '0x0',
-                    blockHash: '0x1346',
-                    logIndex: '0x1',
-                    data: '0x0000000000000000000000000000000000000000000000000000000000000004' +
-                        '0000000000000000000000000000000000000000000000000000000000000005'
-                }]);
+            {
+                address: address,
+                topics: topic2,
+                blockNumber: '0x4',
+                transactionHash: '0x1235',
+                transactionIndex: '0x0',
+                blockHash: '0x1346',
+                logIndex: '0x1',
+                data: '0x0000000000000000000000000000000000000000000000000000000000000004' +
+                '0000000000000000000000000000000000000000000000000000000000000005'
+            }]);
 
             var contract = contractFactory(abi, address, provider);
             contract.getPastEvents('Changed', {filter: {from: address2}})
-                .then(function (result) {
+            .then(function (result) {
 
-                    assert.deepEqual(result, [{
-                        event: 'Changed',
-                        signature: '0xc00c1c37cc8b83163fb4fddc06c74d1d5c00d74648e7cb28c0ebada3e32fd62c',
-                        id: 'log_9ff24cb4',
+                assert.deepEqual(result, [{
+                    event: "Changed",
+                    signature: "0xc00c1c37cc8b83163fb4fddc06c74d1d5c00d74648e7cb28c0ebada3e32fd62c",
+                    id: "log_9ff24cb4",
+                    address: address,
+                    blockNumber: 3,
+                    transactionHash: '0x1234',
+                    blockHash: '0x1345',
+                    logIndex: 4,
+                    transactionIndex: 0,
+                    raw: {
+                        data: '0x0000000000000000000000000000000000000000000000000000000000000002' +
+                        '0000000000000000000000000000000000000000000000000000000000000009',
+                        topics: topic1
+                    },
+                    returnValues: {
+                        0: address,
+                        1: '10',
+                        2: '2',
+                        3: '9',
+                        from: address,
+                        amount: '10',
+                        t1: '2',
+                        t2: '9'
+                    }
+                },
+                    {
+                        event: "Changed",
+                        signature: "0xc00c1c37cc8b83163fb4fddc06c74d1d5c00d74648e7cb28c0ebada3e32fd62c",
+                        id: "log_29c93e15",
                         address: address,
-                        blockNumber: 3,
-                        transactionHash: '0x1234',
-                        blockHash: '0x1345',
-                        logIndex: 4,
+                        blockNumber: 4,
+                        transactionHash: '0x1235',
+                        blockHash: '0x1346',
+                        logIndex: 1,
                         transactionIndex: 0,
                         raw: {
-                            data: '0x0000000000000000000000000000000000000000000000000000000000000002' +
-                                '0000000000000000000000000000000000000000000000000000000000000009',
-                            topics: topic1
+                            data: '0x0000000000000000000000000000000000000000000000000000000000000004' +
+                            '0000000000000000000000000000000000000000000000000000000000000005',
+                            topics: topic2
                         },
                         returnValues: {
                             0: address,
-                            1: '10',
-                            2: '2',
-                            3: '9',
+                            1: '3',
+                            2: '4',
+                            3: '5',
                             from: address,
-                            amount: '10',
-                            t1: '2',
-                            t2: '9'
+                            amount: '3',
+                            t1: '4',
+                            t2: '5'
                         }
-                    },
-                        {
-                            event: 'Changed',
-                            signature: '0xc00c1c37cc8b83163fb4fddc06c74d1d5c00d74648e7cb28c0ebada3e32fd62c',
-                            id: 'log_29c93e15',
-                            address: address,
-                            blockNumber: 4,
-                            transactionHash: '0x1235',
-                            blockHash: '0x1346',
-                            logIndex: 1,
-                            transactionIndex: 0,
-                            raw: {
-                                data: '0x0000000000000000000000000000000000000000000000000000000000000004' +
-                                    '0000000000000000000000000000000000000000000000000000000000000005',
-                                topics: topic2
-                            },
-                            returnValues: {
-                                0: address,
-                                1: '3',
-                                2: '4',
-                                3: '5',
-                                from: address,
-                                amount: '3',
-                                t1: '4',
-                                t2: '5'
-                            }
-                        }]);
+                    }]);
 
-                    done();
-                }).catch(done);
+                done();
+            }).catch(done);
 
         });
 
@@ -2871,7 +2864,7 @@ var runTests = function (contractFactory) {
                         '0000000000000000000000000000000000000000000000000000000000000003',
                     to: addressLowercase
                 },
-                    'latest'
+                'latest'
                 ]);
             });
 
@@ -2879,10 +2872,10 @@ var runTests = function (contractFactory) {
 
             var contract = contractFactory(abi, address, provider);
             contract.methods.testArr([3]).call()
-                .then(function (result) {
-                    assert.deepEqual(result, '5');
-                    done();
-                });
+            .then(function (result) {
+                assert.deepEqual(result, '5');
+                done();
+            });
 
         });
 
@@ -2899,7 +2892,7 @@ var runTests = function (contractFactory) {
                         '0000000000000000000000000000000000000000000000000000000000000003',
                     to: addressLowercase
                 },
-                    'latest'
+                'latest'
                 ]);
             });
             provider.injectResult('0x0000000000000000000000000000000000000000000000000000000000000005');
@@ -2927,7 +2920,7 @@ var runTests = function (contractFactory) {
                     'latest'
                 ]);
             });
-            provider.injectResult('0x000000000000000000000000' + addressLowercase.replace('0x', ''));
+            provider.injectResult('0x000000000000000000000000'+ addressLowercase.replace('0x',''));
 
             var contract = contractFactory(abi, address, provider);
 
@@ -2956,7 +2949,7 @@ var runTests = function (contractFactory) {
 
             var contract = contractFactory(abi, address, provider);
 
-            contract.methods.listOfNestedStructs('0x9CC9a2c777605Af16872E0997b3Aeb91d96D5D8c').call().then(function (result) {
+            contract.methods.listOfNestedStructs('0x9CC9a2c777605Af16872E0997b3Aeb91d96D5D8c').call().then(function(result) {
                 var expectedArray = [];
                 expectedArray[0] = true;
                 expectedArray['status'] = true;
@@ -3000,14 +2993,14 @@ var runTests = function (contractFactory) {
             provider.injectValidation(function (payload) {
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: '0x1234567000000000000000000000000555456789012345678901234567890123456789100000000000000000000000000000000000000000000000000000000000000c8',
+                    data: '0x1234567000000000000000000000000555456789012345678901234567890123456789100000000000000000000000000000000000000000000000000000000000000c8' ,
                     from: addressLowercase,
                     gas: '0xc350',
                     gasPrice: '0xbb8'
                 }]);
             });
 
-            var contract = contractFactory(abi, '', provider);
+            var contract = contractFactory(abi, provider);
 
             contract.deploy({
                 data: '0x1234567',
@@ -3030,7 +3023,7 @@ var runTests = function (contractFactory) {
 
                 assert.equal(payload.method, 'eth_sendTransaction');
                 assert.deepEqual(payload.params, [{
-                    data: '0x1234567000000000000000000000000' + addressLowercase.replace('0x', '') + '00000000000000000000000000000000000000000000000000000000000000c8',
+                    data: '0x1234567000000000000000000000000'+ addressLowercase.replace('0x','') +'00000000000000000000000000000000000000000000000000000000000000c8' ,
                     from: addressLowercase,
                     gas: '0xc350',
                     gasPrice: '0xbb8'
@@ -3078,7 +3071,7 @@ var runTests = function (contractFactory) {
             provider.injectResult('0x321');
 
 
-            var contract = contractFactory(abi, '', provider);
+            var contract = contractFactory(abi, provider);
 
             contract.deploy({
                 data: '0x1234567',
@@ -3088,21 +3081,21 @@ var runTests = function (contractFactory) {
                 gas: 50000,
                 gasPrice: 3000
             })
-                .on('transactionHash', function (value) {
-                    assert.equal('0x5550000000000000000000000000000000000000000000000000000000000032', value);
-                })
-                .on('receipt', function (receipt) {
-                    assert.equal(address, receipt.contractAddress);
-                    assert.isNull(contract.options.address);
-                })
-                .then(function (newContract) {
-                    assert.equal(newContract.options.address, address);
-                    assert.isTrue(newContract !== contract, 'contract objects shouldn\'t the same');
+            .on('transactionHash', function (value) {
+                assert.equal('0x5550000000000000000000000000000000000000000000000000000000000032', value);
+            })
+            .on('receipt', function (receipt) {
+                assert.equal(address, receipt.contractAddress);
+                assert.isNull(contract.options.address);
+            })
+            .then(function(newContract) {
+                assert.equal(newContract.options.address, address);
+                assert.isTrue(newContract !== contract, 'contract objects shouldn\'t the same');
 
-                    setTimeout(function () {
-                        done();
-                    }, 1);
-                });
+                setTimeout(function () {
+                    done();
+                }, 1);
+            });
             // .on('error', function (value) {
             //     console.log('error', value);
             //     done();
@@ -3111,9 +3104,9 @@ var runTests = function (contractFactory) {
         });
 
     });
-};
+}
 
-describe('typical usage', function () {
+describe('typical usage', function() {
     runTests(getEthContractInstance);
 
     it('should update contract instance provider when assigned a provider to eth instance that contract instance came from', function () {
@@ -3133,7 +3126,6 @@ describe('typical usage', function () {
     it('should deploy a contract, sign transaction, and return contract instance', function (done) {
         var provider = new FakeIpcProvider();
         var eth = new Eth(provider);
-
         eth.accounts.wallet.add(account.privateKey);
 
         provider.injectValidation(function (payload) {
@@ -3226,9 +3218,11 @@ describe('typical usage', function () {
         //     console.log('error', value);
         //     done();
         // });
+
     }).timeout(10000);
+        // TODO add error check
 });
 
-describe('standalone usage', function () {
+describe('standalone usage', function() {
     runTests(getStandAloneContractInstance);
 });


### PR DESCRIPTION
## Description

**PR targets #3190**

(Part of ongoing #3190 review. Opening for further discussion.) 

PR reverts all the changes to test/contract.js except the three necessary to get the tests passing.

Diff vs. 1.x looks like this:

![Screen Shot 2020-01-10 at 4 15 46 PM](https://user-images.githubusercontent.com/7332026/72194971-fb3e6b80-33c4-11ea-9515-6482b9b2f95b.png)


Many tests fail unless the call to eth.setProvider is commented out in the test fixture. Why?
https://github.com/ethereum/web3.js/blob/5e1aec2f07c82d412123229bef8a865142a8668a/test/contract.js#L242-L244
