### PR TITLE
Add ganache-core E2E test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - node_js: 10
       env: TEST=unit_and_e2e_clients
     - node_js: 10
-      env: TEST=e2e_truffle
+      env: TEST=e2e_ganache
     - node_js: 10
       env: TEST=e2e_mosaic
     - node_js: 10
@@ -27,7 +27,7 @@ matrix:
         firefox: latest
   allow_failures:
     - node_js: 10
-      env: TEST=e2e_truffle
+      env: TEST=e2e_ganache
     - node_js: 10
       env: TEST=e2e_mosaic
 
@@ -49,7 +49,7 @@ before_install:
   - export DISPLAY=:99.0
   - export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 install:
-  - if [[ $TEST != "e2e_truffle" ]] && [[ $TEST != "e2e_mosaic" ]]; then
+  - if [[ $TEST != "e2e_ganache" ]] && [[ $TEST != "e2e_mosaic" ]]; then
       npm install;
     fi
 script:

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "test:e2e:publish": "./scripts/e2e.npm.publish.sh",
         "test:e2e:truffle": "./scripts/e2e.truffle.sh",
         "test:e2e:mosaic": "./scripts/e2e.mosaic.sh",
+        "test:e2e:ganache:core": "./scripts/e2e.ganache.core.sh",
         "ci": "./scripts/ci.sh",
         "coveralls": "./scripts/coveralls.sh"
     },

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -196,7 +196,6 @@ Method.prototype.toPayload = function (args) {
 
 
 Method.prototype._confirmTransaction = function (defer, result, payload) {
-    console.log('Inside web3@e2e published in Travis')
     var method = this,
         promiseResolved = false,
         canUnsubscribe = true,

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -196,6 +196,7 @@ Method.prototype.toPayload = function (args) {
 
 
 Method.prototype._confirmTransaction = function (defer, result, payload) {
+    console.log('Inside web3@e2e published in Travis')
     var method = this,
         promiseResolved = false,
         canUnsubscribe = true,

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -44,4 +44,9 @@ elif [ "$TEST" = "e2e_mosaic" ]; then
   npm run test:e2e:publish
   npm run test:e2e:mosaic
 
+elif [ "$TEST" = "e2e_ganache" ]; then
+
+  npm run test:e2e:publish
+  npm run test:e2e:ganache:core
+
 fi

--- a/scripts/e2e.ganache.core.sh
+++ b/scripts/e2e.ganache.core.sh
@@ -1,0 +1,48 @@
+# ----------------------------------------------------------------------------------------
+# Run trufflesuite/ganache-core using a candidate branch of web3 which has been published
+# to a proxy npm registry in `e2e.npm.publish.sh`
+#
+# This test's purpose is to watch web3 execute a long, complex test suite
+# ----------------------------------------------------------------------------------------
+
+# Exit immediately on error
+set -o errexit
+
+# Install ganache-core
+git clone https://github.com/trufflesuite/ganache-core
+cd ganache-core
+
+# Install via registry and verify
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "Installing updated web3 via virtual registry "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+
+npm install
+npm uninstall --save-dev web3
+npm install --save-dev web3@e2e --registry http://localhost:4873
+
+npm list web3
+npm list web3-utils
+npm list web3-core
+npm list web3-core-promievent
+
+cat ./package.json
+
+# Test
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "Running trufflesuite/ganache-core unit tests.      "
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+
+npm run build
+
+# NB: there's one failing ganache test, which checks
+# whether the object returned by the server is an
+# instanceof StateManager. Also fails locally & doesn't
+# seem web3 related. Skipping it with grep / invert.
+TEST_BUILD=node npx mocha \
+  --grep "instance of" \
+  --invert \
+  --check-leaks \
+  --recursive \
+  --globals _scratch \
+  --opts ./test/.mocharc

--- a/scripts/e2e.truffle.sh
+++ b/scripts/e2e.truffle.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# --------------------------------------------------------------------------------
+# NB: This script temporarily removed from CI while truffle remains on Web3@1.2.1.
+#     To re-enable, add a `env: TEST=e2e_truffle` job to the matrix in travis.yml.
+# --------------------------------------------------------------------------------
+
 # -------------------------------------------------------------------------
 # Run @truffle/contract's unit tests using a candidate branch of web3
 # which has been published to a proxy npm registry in `e2e.npm.publish.sh`


### PR DESCRIPTION
## Description

Adds ganache-core as an E2E published target. Their unit tests (~500) use a range of Web3's modules, esp. different provider packages. This might be a useful check to run against #3190 since there are many changes to the WS provider there. Ganache has uncovered provider bugs here [in the past][2].

Temporarily removes the Truffle E2E tests from the Travis run because they are on 1.2.1 and unclear when they will upgrade. `tsc` errors prevent Truffle from installing newer Web3 (they had to rework their types a bit when they ran 1.2.2). #3274 added a large Buidler project test suite as a Truffle substitute as well. 

Commit fa8eedfc4a6ab14ae7266feaa597cad2afc387e7 contains a [proof][1] that the published branch is being used to run the tests.

[1]: https://travis-ci.org/ethereum/web3.js/jobs/635574756#L2179-L2190
[2]: https://github.com/ethereum/web3.js/pull/1191

## Type of change

- [X] E2E test

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
