### PR TITLE
Add core-method tests for http confirmations & wallet chain options 

### DIFF
--- a/scripts/e2e.geth.automine.sh
+++ b/scripts/e2e.geth.automine.sh
@@ -27,7 +27,7 @@ echo " "
 geth-dev-assistant --period 2 --accounts 1 --tag 'stable'
 
 # Test
-nyc --no-clean --silent _mocha -- \
+GETH_AUTOMINE=true nyc --no-clean --silent _mocha -- \
   --reporter spec \
   --grep 'E2E' \
   --timeout 15000 \

--- a/scripts/e2e.npm.publish.sh
+++ b/scripts/e2e.npm.publish.sh
@@ -21,7 +21,7 @@ fi
 # To model publication correctly, this script needs to run
 # without web3's dev deps being installed. It installs
 # what it needs here.
-npm install -g verdaccio@4.3.4
+npm install -g verdaccio@4.4.2
 npm install -g npm-auth-to-token@1.0.0
 npm install -g lerna@3.18.3
 

--- a/test/e2e.contract.deploy.js
+++ b/test/e2e.contract.deploy.js
@@ -123,6 +123,29 @@ describe('contract.deploy [ @E2E ]', function() {
                 assert(err.receipt.status === false);
             }
         });
+
+        it('fires the confirmation handler', function(){
+            // Http confirmations poll at 1s interval.
+            // Automine has a 2s interval.
+            if (!process.env.GETH_AUTOMINE) return;
+
+            return new Promise(async (resolve, reject) => {
+                var startBlock = await web3.eth.getBlockNumber();
+
+                await basic
+                    .deploy()
+                    .send({from: accounts[0]})
+                    .on('confirmation', async (number, receipt) => {
+                        assert(receipt.contractAddress);
+
+                        if (number === 1) { // Confirmation numbers are zero indexed
+                            var endBlock = await web3.eth.getBlockNumber();
+                            assert(endBlock >= (startBlock + 2));
+                            resolve();
+                        }
+                    })
+            });
+        });
     });
 
     describe('ws', function() {


### PR DESCRIPTION
## Description

Adds some additional test coverage to web3-core-method for:
+ confirmations over http
+ method calls made with a wallet address using the default chain, hardfork and common options

Because of the 1s polling interval, am only testing confirmations with geth automine. 

## Type of change

- [x] Tests

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
