### PR TITLE
WebsocketProvider - Error Handling

### DIFF
--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -31,8 +31,8 @@ module.exports = {
     InvalidNumberOfParams: function (got, expected, method) {
         return new Error('Invalid number of parameters for "'+ method +'". Got '+ got +' expected '+ expected +'!');
     },
-    InvalidConnection: function (host){
-        return new Error('CONNECTION ERROR: Couldn\'t connect to node '+ host +'.');
+    InvalidConnection: function (host, event){
+        return this.ConnectionError('CONNECTION ERROR: Couldn\'t connect to node '+ host +'.', event);
     },
     InvalidProvider: function () {
         return new Error('Provider not set or invalid');
@@ -44,8 +44,8 @@ module.exports = {
     ConnectionTimeout: function (ms){
         return new Error('CONNECTION TIMEOUT: timeout of ' + ms + ' ms achived');
     },
-    ConnectionNotOpenError: function (){
-        return new Error('connection not open on send()');
+    ConnectionNotOpenError: function (event){
+        return this.ConnectionError('connection not open on send()', event);
     },
     MaxAttemptsReachedOnReconnectingError: function (){
         return new Error('Maximum number of reconnect attempts reached!');
@@ -53,8 +53,14 @@ module.exports = {
     PendingRequestsOnReconnectingError: function (){
         return new Error('CONNECTION ERROR: Provider started to reconnect before the response got received!');
     },
-    ConnectionClosedError: function (event){
-        return new Error('CONNECTION ERROR: The connection got closed with close code `' + event.code + '` and the following reason string `' + event.reason + '`');
+    ConnectionError: function (msg, event){
+        const error = new Error(msg);
+        if (event) {
+            error.code = event.code;
+            error.reason = event.reason;
+        }
+
+        return error;
     },
     RevertInstructionError: function(reason, signature) {
         var error = new Error('Your request got reverted with the following reason string: ' + reason);

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -64,14 +64,14 @@ export class errors {
         expected: number,
         method: string
     ): Error;
-    static InvalidConnection(host: string): Error;
+    static InvalidConnection(host: string, event?: WebSocketEvent): ConnectionError;
     static InvalidProvider(): Error;
     static InvalidResponse(result: Error): Error;
     static ConnectionTimeout(ms: string): Error;
     static ConnectionNotOpenError(): Error;
     static MaxAttemptsReachedOnReconnectingError(): Error;
     static PendingRequestsOnReconnectingError(): Error;
-    static ConnectionClosedError(event: {code: number, reason: string}): Error;
+    static ConnectionError(msg: string, event?: WebSocketEvent): ConnectionError;
     static RevertInstructionError(reason: string, signature: string): RevertInstructionError
     static TransactionRevertInstructionError(reason: string, signature: string, receipt: object): TransactionRevertInstructionError
     static TransactionError(message: string, receipt: object): TransactionError
@@ -228,4 +228,14 @@ export interface TransactionRevertInstructionError extends Error {
 
 export interface TransactionError extends Error {
     receipt: object;
+}
+
+export interface ConnectionError extends Error {
+    code: string | undefined;
+    reason: string | undefined;
+}
+
+export interface WebSocketEvent {
+    code?: number;
+    reason?: string;
 }

--- a/packages/web3-core-helpers/types/tests/errors-test.ts
+++ b/packages/web3-core-helpers/types/tests/errors-test.ts
@@ -17,7 +17,7 @@
  * @date 2019
  */
 
-import { errors } from 'web3-core-helpers';
+import { errors, WebSocketEvent } from 'web3-core-helpers';
 
 // $ExpectType Error
 errors.ErrorResponse(new Error('hey'));
@@ -25,7 +25,7 @@ errors.ErrorResponse(new Error('hey'));
 // $ExpectType Error
 errors.InvalidNumberOfParams(1, 3, 'method');
 
-// $ExpectType Error
+// $ExpectType ConnectionError
 errors.InvalidConnection('https://localhost:2345432');
 
 // $ExpectType Error
@@ -46,8 +46,9 @@ errors.MaxAttemptsReachedOnReconnectingError();
 // $ExpectType Error
 errors.PendingRequestsOnReconnectingError();
 
-// $ExpectType Error
-errors.ConnectionClosedError({code: 100, reason: 'reason'});
+const event: WebSocketEvent = {code: 100, reason: 'reason'};
+// $ExpectType ConnectionError
+errors.ConnectionError('msg', event);
 
 // $ExpectType RevertInstructionError
 errors.RevertInstructionError('reason', 'signature');

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -185,7 +185,7 @@ WebsocketProvider.prototype._onClose = function (event) {
 
     if (this.responseQueue.size > 0) {
         this.responseQueue.forEach(function (request, key) {
-            request.callback(errors.InvalidConnection(_this.url, event));
+            request.callback(errors.InvalidConnection('on WS', event));
             _this.responseQueue.delete(key);
         });
     }

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -178,14 +178,14 @@ WebsocketProvider.prototype._onClose = function (event) {
 
     if (this.requestQueue.size > 0) {
         this.requestQueue.forEach(function (request, key) {
-            request.callback(errors.ConnectionNotOpenError());
+            request.callback(errors.ConnectionNotOpenError(event));
             _this.requestQueue.delete(key);
         });
     }
 
     if (this.responseQueue.size > 0) {
         this.responseQueue.forEach(function (request, key) {
-            request.callback(errors.ConnectionClosedError(event));
+            request.callback(errors.InvalidConnection(_this.url, event));
             _this.responseQueue.delete(key);
         });
     }

--- a/test/websocket.ganache.js
+++ b/test/websocket.ganache.js
@@ -26,6 +26,8 @@ describe('WebsocketProvider (ganache)', function () {
             await web3.eth.getBlockNumber();
             assert.fail();
         } catch (err) {
+            assert(err.code, 1006);
+            assert(err.reason, 'connection failed');
             assert(err.message.includes('connection not open on send'));
         }
     });
@@ -36,12 +38,17 @@ describe('WebsocketProvider (ganache)', function () {
         web3 = new Web3(host + 8777);
 
         try { await web3.eth.getBlockNumber() } catch (err) {
+            assert(err.message.includes('connection not open on send'));
+            assert(err.code, 1006);
+            assert(err.reason, 'connection failed');
 
             try {
                 await web3.eth.getBlockNumber();
                 assert.fail();
             } catch (err){
                 assert(err.message.includes('connection not open on send'));
+                assert(typeof err.code === 'undefined');
+                assert(typeof err.reason === 'undefined');
             }
         }
     });
@@ -61,6 +68,8 @@ describe('WebsocketProvider (ganache)', function () {
             assert.fail();
         } catch(err){
             assert(err.message.includes('connection not open on send'));
+            assert(typeof err.code === 'undefined');
+            assert(typeof err.reason === 'undefined');
         }
     });
 
@@ -229,6 +238,9 @@ describe('WebsocketProvider (ganache)', function () {
                 } catch (err) {
                     await pify(server.close)();
                     assert(err.message.includes('connection not open on send'));
+                    assert(typeof err.code === 'undefined');
+                    assert(typeof err.reason === 'undefined');
+
                     resolve();
                 }
             });


### PR DESCRIPTION
## Description

I've compared the current errors with the errors we do throw in the refactored ``WebsocketProvider`` and adjusted those who would introduce a breaking change. 

During the comparison of those did I notice that the old ``WebsocketProvider`` does have two different timeouts. The first place the old provider does check for a timeout is in the ``_parseResponse`` method and is per chunk and the other configurable timeout in ``_addResponseCallback`` is on a per ``request`` base. I will check that closer to be sure it won't break anything.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Error Handling

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
