### PR TITLE
Ensure '0x' prefix exists (web3-eth-accounts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,7 @@ Released with 1.0.0-beta.37 code base.
 ### Added
 
 - ENS module extended with the possibility to add a custom registry (#3301)
+
+### Changed
+
+- Ensure '0x' prefix is existing for Accounts.sign and Accounts.privateKeyToAccount (#3041)

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -121,6 +121,10 @@ Accounts.prototype.create = function create(entropy) {
 };
 
 Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey) {
+    if (!privateKey.startsWith('0x')) {
+        throw new Error('Required prefix "0x" is missing.');
+    }
+
     return this._addAccountFunctions(Account.fromPrivate(privateKey));
 };
 
@@ -294,6 +298,10 @@ Accounts.prototype.hashMessage = function hashMessage(data) {
 };
 
 Accounts.prototype.sign = function sign(data, privateKey) {
+    if (!privateKey.startsWith('0x')) {
+        throw new Error('Required prefix "0x" is missing for the given private key.');
+    }
+
     var hash = this.hashMessage(data);
     var signature = Account.sign(hash, privateKey);
     var vrs = Account.decodeSignature(signature);

--- a/test/eth.accounts.sign.js
+++ b/test/eth.accounts.sign.js
@@ -113,4 +113,22 @@ describe("eth", function () {
             });
         });
     });
+
+    it('should throw an error if a PK got passed to Accounts.sign without a "0x" prefix', function () {
+        try {
+            new Accounts().sign('DATA', 'be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
+            assert.fail();
+        } catch(err) {
+            assert(err.message.includes('Required prefix "0x" is missing for the given private key.'));
+        }
+    });
+
+    it('should throw an error if a PK got passed to Accounts.privateKeyToAccount without a "0x" prefix', function () {
+        try {
+            new Accounts().privateKeyToAccount('DATA', 'be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
+            assert.fail();
+        } catch(err) {
+            assert(err.message.includes('Required prefix "0x" is missing.'));
+        }
+    });
 });

--- a/test/eth.accounts.sign.js
+++ b/test/eth.accounts.sign.js
@@ -125,7 +125,7 @@ describe("eth", function () {
 
     it('should throw an error if a PK got passed to Accounts.privateKeyToAccount without a "0x" prefix', function () {
         try {
-            new Accounts().privateKeyToAccount('DATA', 'be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
+            new Accounts().privateKeyToAccount('be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
             assert.fail();
         } catch(err) {
             assert(err.message.includes('Required prefix "0x" is missing.'));


### PR DESCRIPTION
## Description

This PR ensures the '0x' prefix is always existing on a method call of the Accounts module.

Fixes #3041


## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
