### PR TITLE
Add ts config info to docs

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -37,3 +37,28 @@ If this property is ``null`` you should connect to a remote/local node.
     var web3 = new Web3(Web3.givenProvider || "ws://localhost:8545");
 
 That's it! now you can use the ``web3`` object.
+
+
+Usage with TypeScript
+=====================
+
+We support types within the repo itself. Please open an issue here if you find any wrong types.
+
+You can use ``web3.js`` as follows:
+
+.. code-block:: typescript
+
+    import Web3 from 'web3';
+    const web3 = new Web3('ws://localhost:8546');
+
+
+If you are using the types in a ``commonjs`` module like a Node app you need to enable
+``esModuleInterop`` in your `tsconfig` compile option. Also enable ``allowSyntheticDefaultImports``
+for typesystem compatibility:
+
+.. code-block:: javascript
+
+    "compilerOptions": {
+      "allowSyntheticDefaultImports": true,
+      "esModuleInterop": true,
+      ....


### PR DESCRIPTION
## Description

PR adds the current TS config guidelines to the `Getting Started` section of the docs. At the moment these are in the GitHub README where fewer people might see them.
 
#2363 
#3198 
#3215 

There are several issues where TS users report difficulty importing Web3 modules because the underlying JS exports like this: (example)
```
module.exports = Accounts;
```
but the types don't define a default export. This does not affect people who configure their tsconfig with `esModuleInterop: true`. This setting is the default in a tsconfig generated with `tsc --init`. 

The issue affects 16 of 20 Web3 modules. It does not affect the main module or utils.  

In #3125 @alcuadrado comments:
> what is happening right now is that type declarations use named exports, and the actual js files just reassign module.exports. They should use this pattern instead: https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-class-d-ts.html

> ...Note that fixing this is a breaking change for TS users

**Questions**:

+ @joshstevens19, how do you see this issue? 
+ @nivida has suggested it might be possible to export in both styles and satisfy everyone. Is this possible or does any change necessarily break one party or another? 
+ how problematic is `esModuleInterop`? Does it cause significant levels of inconvenience or break other common packages for users?

## Type of change

- [x] Documentation

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
