### PR TITLE
Add network-timeout to fix Mosaic E2E

### DIFF
--- a/scripts/e2e.mosaic.sh
+++ b/scripts/e2e.mosaic.sh
@@ -33,7 +33,7 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 git submodule update --init --recursive
 yarn --registry http://localhost:4873
 
-yarn add web3@e2e --registry http://localhost:4873
+yarn add web3@e2e --registry http://localhost:4873 --network-timeout 100000
 
 yarn list web3
 yarn list web3-utils


### PR DESCRIPTION
## Description

The Mosaic run is constantly erroring with some kind of yarn network connectivity problem on install. According to [yarn 4890 comment][1] adding the --network-timeout <seconds> flag should help.

Looks like [it did][2] for this PR anyway...

[1]: https://github.com/yarnpkg/yarn/issues/4890#issuecomment-348479446
[2]: https://travis-ci.org/ethereum/web3.js/jobs/639803905?utm_medium=notification&utm_source=github_status
