### PR TITLE
back-ports privateKey validation of the 2.x Accounts module to 1.x

### DIFF
--- a/docs/web3-eth-accounts.rst
+++ b/docs/web3-eth-accounts.rst
@@ -94,7 +94,7 @@ privateKeyToAccount
 
 .. code-block:: javascript
 
-    web3.eth.accounts.privateKeyToAccount(privateKey);
+    web3.eth.accounts.privateKeyToAccount(privateKey [, ignoreLength ]);
 
 Creates an account object from a private key.
 
@@ -103,6 +103,7 @@ Parameters
 ----------
 
 1. ``privateKey`` - ``String``: The private key to convert.
+1. ``ignoreLength`` - ``Boolean``: If set to true does the ``privateKey`` length not get validated.
 
 -------
 Returns

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -263,7 +263,7 @@ export class AccountsBase {
 
     create(entropy?: string): Account;
 
-    privateKeyToAccount(privateKey: string): Account;
+    privateKeyToAccount(privateKey: string, ignoreLength?: boolean): Account;
 
     signTransaction(
         transactionConfig: TransactionConfig,

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -120,13 +120,13 @@ Accounts.prototype.create = function create(entropy) {
     return this._addAccountFunctions(Account.create(entropy || utils.randomHex(32)));
 };
 
-Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey) {
+Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey, ignoreLength) {
     if (!privateKey.startsWith('0x')) {
         privateKey = '0x' + privateKey;
     }
 
     // 64 hex characters + hex-prefix
-    if (privateKey.length !== 66) {
+    if (!ignoreLength && privateKey.length !== 66) {
         throw new Error("Private key must be 32 bytes long");
     }
 
@@ -389,12 +389,12 @@ Accounts.prototype.decrypt = function(v3Keystore, password, nonStrict) {
     var decipher = cryp.createDecipheriv(json.crypto.cipher, derivedKey.slice(0, 16), Buffer.from(json.crypto.cipherparams.iv, 'hex'));
     var seed = '0x' + Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('hex');
 
-    return this.privateKeyToAccount(seed);
+    return this.privateKeyToAccount(seed, true);
 };
 
 Accounts.prototype.encrypt = function(privateKey, password, options) {
     /* jshint maxcomplexity: 20 */
-    var account = this.privateKeyToAccount(privateKey);
+    var account = this.privateKeyToAccount(privateKey, true);
 
     options = options || {};
     var salt = options.salt || cryp.randomBytes(32);

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -122,7 +122,12 @@ Accounts.prototype.create = function create(entropy) {
 
 Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey) {
     if (!privateKey.startsWith('0x')) {
-        throw new Error('Required prefix "0x" is missing.');
+        privateKey = '0x' + privateKey;
+    }
+
+    // 64 hex characters + hex-prefix
+    if (privateKey.length !== 66) {
+        throw new Error("Private key must be 32 bytes long");
     }
 
     return this._addAccountFunctions(Account.fromPrivate(privateKey));
@@ -299,7 +304,12 @@ Accounts.prototype.hashMessage = function hashMessage(data) {
 
 Accounts.prototype.sign = function sign(data, privateKey) {
     if (!privateKey.startsWith('0x')) {
-        throw new Error('Required prefix "0x" is missing for the given private key.');
+        privateKey = '0x' + privateKey;
+    }
+
+    // 64 hex characters + hex-prefix
+    if (privateKey.length !== 66) {
+        throw new Error("Private key must be 32 bytes long");
     }
 
     var hash = this.hashMessage(data);

--- a/packages/web3-eth-accounts/types/tests/accounts-tests.ts
+++ b/packages/web3-eth-accounts/types/tests/accounts-tests.ts
@@ -45,6 +45,12 @@ accounts.privateKeyToAccount(
     '0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709'
 );
 
+// $ExpectType Account
+accounts.privateKeyToAccount(
+    '0x348ce564d427a3311b6536bbcff9390d69395b06ed6c486954e971d960fe8709',
+    true
+);
+
 // $ExpectType Promise<SignedTransaction>
 accounts.signTransaction(
     {

--- a/test/eth.accounts.encrypt-decrypt.js
+++ b/test/eth.accounts.encrypt-decrypt.js
@@ -18,52 +18,100 @@ var uuid = Buffer.from('ff31ddc3e2791ac53f3f19b125c18fff', 'hex');
 var pw = 'test';
 
 // tests from https://github.com/Gustav-Simonsson/go-ethereum/blob/7cc6b801e0967e5ebfa26b9f670675acea6e3a20/accounts/testdata/v3_test_vector.json
-var staticTests = [{
-    "json": {
-        "crypto" : {
-            "cipher" : "aes-128-ctr",
-            "cipherparams" : {
-                "iv" : "83dbcc02d8ccb40e466191a123791e0e"
-            },
-            "ciphertext" : "d172bf743a674da9cdad04534d56926ef8358534d458fffccd4e6ad2fbde479c",
-            "kdf" : "scrypt",
-            "kdfparams" : {
-                "dklen" : 32,
-                "n" : 262144,
-                "r" : 1,
-                "p" : 8,
-                "salt" : "ab0c7876052600dd703518d6fc3fe8984592145b591fc8fb5c6d43190334ba19"
-            },
-            "mac" : "2103ac29920d71da29f15d75b4a16dbe95cfd7ff8faea1056c33131d846e3097"
-        },
-        "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
-        "version" : 3
-    },
-    "password": "testpassword",
-    "priv": "7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d"
-}, {
-    "json": {
-        "crypto" : {
-            "cipher" : "aes-128-ctr",
+var staticTests = [
+    {
+        "json": {
+            "crypto" : {
+                "cipher" : "aes-128-ctr",
                 "cipherparams" : {
-                "iv" : "6087dab2f9fdbbfaddc31a909735c1e6"
+                    "iv" : "83dbcc02d8ccb40e466191a123791e0e"
+                },
+                "ciphertext" : "d172bf743a674da9cdad04534d56926ef8358534d458fffccd4e6ad2fbde479c",
+                "kdf" : "scrypt",
+                "kdfparams" : {
+                    "dklen" : 32,
+                    "n" : 262144,
+                    "r" : 1,
+                    "p" : 8,
+                    "salt" : "ab0c7876052600dd703518d6fc3fe8984592145b591fc8fb5c6d43190334ba19"
+                },
+                "mac" : "2103ac29920d71da29f15d75b4a16dbe95cfd7ff8faea1056c33131d846e3097"
             },
-            "ciphertext" : "5318b4d5bcd28de64ee5559e671353e16f075ecae9f99c7a79a38af5f869aa46",
+            "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+            "version" : 3
+        },
+        "password": "testpassword",
+        "priv": "7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d"
+    }, {
+        "json": {
+            "crypto" : {
+                "cipher" : "aes-128-ctr",
+                "cipherparams" : {
+                    "iv" : "6087dab2f9fdbbfaddc31a909735c1e6"
+                },
+                "ciphertext" : "5318b4d5bcd28de64ee5559e671353e16f075ecae9f99c7a79a38af5f869aa46",
                 "kdf" : "pbkdf2",
                 "kdfparams" : {
-                "c" : 262144,
+                    "c" : 262144,
                     "dklen" : 32,
                     "prf" : "hmac-sha256",
                     "salt" : "ae3cd4e7013836a3df6bd7241b12db061dbe2c6785853cce422d148a624ce0bd"
+                },
+                "mac" : "517ead924a9d0dc3124507e3393d175ce3ff7c1e96529c6c555ce9e51205e9b2"
             },
-            "mac" : "517ead924a9d0dc3124507e3393d175ce3ff7c1e96529c6c555ce9e51205e9b2"
-        },
-        "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+            "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
             "version" : 3
-    },
-    "password": "testpassword",
+        },
+        "password": "testpassword",
         "priv": "7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d"
-}];
+    }, {
+        "json": {
+            "crypto" : {
+                "cipher" : "aes-128-ctr",
+                "cipherparams" : {
+                    "iv" : "e0c41130a323adc1446fc82f724bca2f"
+                },
+                "ciphertext" : "9517cd5bdbe69076f9bf5057248c6c050141e970efa36ce53692d5d59a3984",
+                "kdf" : "scrypt",
+                "kdfparams" : {
+                    "dklen" : 32,
+                    "n" : 2,
+                    "r" : 8,
+                    "p" : 1,
+                    "salt" : "711f816911c92d649fb4c84b047915679933555030b3552c1212609b38208c63"
+                },
+                "mac" : "d5e116151c6aa71470e67a7d42c9620c75c4d23229847dcc127794f0732b0db5"
+            },
+            "id" : "fecfc4ce-e956-48fd-953b-30f8b52ed66c",
+            "version" : 3
+        },
+        "password": "foo",
+        "priv": "fa7b3db73dc7dfdf8c5fbdb796d741e4488628c41fc4febd9160a866ba0f35"
+    },{
+        "json": {
+            "crypto" : {
+                "cipher" : "aes-128-ctr",
+                "cipherparams" : {
+                    "iv" : "3ca92af36ad7c2cd92454c59cea5ef00"
+                },
+                "ciphertext" : "108b7d34f3442fc26ab1ab90ca91476ba6bfa8c00975a49ef9051dc675aa",
+                "kdf" : "scrypt",
+                "kdfparams" : {
+                    "dklen" : 32,
+                    "n" : 2,
+                    "r" : 8,
+                    "p" : 1,
+                    "salt" : "d0769e608fb86cda848065642a9c6fa046845c928175662b8e356c77f914cd3b"
+                },
+                "mac" : "75d0e6759f7b3cefa319c3be41680ab6beea7d8328653474bd06706d4cc67420"
+            },
+            "id" : "a37e1559-5955-450d-8075-7b8931b392b2",
+            "version" : 3
+        },
+        "password": "foo",
+        "priv": "81c29e8142bb6a81bef5a92bda7a8328a5c85bb2f9542e76f9b0f94fc018"
+    }
+];
 
 describe("eth", function () {
     describe("accounts", function () {

--- a/test/eth.accounts.encrypt-decrypt.js
+++ b/test/eth.accounts.encrypt-decrypt.js
@@ -63,52 +63,6 @@ var staticTests = [{
     },
     "password": "testpassword",
         "priv": "7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d"
-}, {
-    "json": {
-        "crypto" : {
-            "cipher" : "aes-128-ctr",
-                "cipherparams" : {
-                "iv" : "e0c41130a323adc1446fc82f724bca2f"
-            },
-            "ciphertext" : "9517cd5bdbe69076f9bf5057248c6c050141e970efa36ce53692d5d59a3984",
-                "kdf" : "scrypt",
-                "kdfparams" : {
-                "dklen" : 32,
-                    "n" : 2,
-                    "r" : 8,
-                    "p" : 1,
-                    "salt" : "711f816911c92d649fb4c84b047915679933555030b3552c1212609b38208c63"
-            },
-            "mac" : "d5e116151c6aa71470e67a7d42c9620c75c4d23229847dcc127794f0732b0db5"
-        },
-        "id" : "fecfc4ce-e956-48fd-953b-30f8b52ed66c",
-            "version" : 3
-    },
-    "password": "foo",
-        "priv": "fa7b3db73dc7dfdf8c5fbdb796d741e4488628c41fc4febd9160a866ba0f35"
-},{
-    "json": {
-        "crypto" : {
-            "cipher" : "aes-128-ctr",
-                "cipherparams" : {
-                "iv" : "3ca92af36ad7c2cd92454c59cea5ef00"
-            },
-            "ciphertext" : "108b7d34f3442fc26ab1ab90ca91476ba6bfa8c00975a49ef9051dc675aa",
-                "kdf" : "scrypt",
-                "kdfparams" : {
-                "dklen" : 32,
-                    "n" : 2,
-                    "r" : 8,
-                    "p" : 1,
-                    "salt" : "d0769e608fb86cda848065642a9c6fa046845c928175662b8e356c77f914cd3b"
-            },
-            "mac" : "75d0e6759f7b3cefa319c3be41680ab6beea7d8328653474bd06706d4cc67420"
-        },
-        "id" : "a37e1559-5955-450d-8075-7b8931b392b2",
-            "version" : 3
-    },
-    "password": "foo",
-        "priv": "81c29e8142bb6a81bef5a92bda7a8328a5c85bb2f9542e76f9b0f94fc018"
 }];
 
 describe("eth", function () {

--- a/test/eth.accounts.sign.js
+++ b/test/eth.accounts.sign.js
@@ -31,7 +31,7 @@ describe("eth", function () {
     describe("accounts", function () {
 
         tests.forEach(function (test, i) {
-            it("sign data using a string", function() {
+            it("sign data using a string", function () {
                 var ethAccounts = new Accounts();
 
                 var data = ethAccounts.sign(test.data, test.privateKey);
@@ -39,7 +39,7 @@ describe("eth", function () {
                 assert.equal(data.signature, test.signature);
             });
 
-            it("sign data using a utf8 encoded hex string", function() {
+            it("sign data using a utf8 encoded hex string", function () {
                 var ethAccounts = new Accounts();
 
                 var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
@@ -49,7 +49,7 @@ describe("eth", function () {
             });
 
 
-            it("recover signature using a string", function() {
+            it("recover signature using a string", function () {
                 var ethAccounts = new Accounts();
 
                 var address = ethAccounts.recover(test.data, test.signature);
@@ -57,7 +57,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a string and preFixed", function() {
+            it("recover signature using a string and preFixed", function () {
                 var ethAccounts = new Accounts();
 
                 var address = ethAccounts.recover(ethAccounts.hashMessage(test.data), test.signature, true);
@@ -65,7 +65,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a hash and r s v values and preFixed", function() {
+            it("recover signature using a hash and r s v values and preFixed", function () {
                 var ethAccounts = new Accounts();
 
                 var sig = ethAccounts.sign(test.data, test.privateKey);
@@ -74,7 +74,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature (pre encoded) using a signature object", function() {
+            it("recover signature (pre encoded) using a signature object", function () {
                 var ethAccounts = new Accounts();
 
                 var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
@@ -84,7 +84,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a signature object", function() {
+            it("recover signature using a signature object", function () {
                 var ethAccounts = new Accounts();
 
                 var sig = ethAccounts.sign(test.data, test.privateKey);
@@ -93,7 +93,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature (pre encoded) using a hash and r s v values", function() {
+            it("recover signature (pre encoded) using a hash and r s v values", function () {
                 var ethAccounts = new Accounts();
 
                 var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
@@ -103,7 +103,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a hash and r s v values", function() {
+            it("recover signature using a hash and r s v values", function () {
                 var ethAccounts = new Accounts();
 
                 var sig = ethAccounts.sign(test.data, test.privateKey);
@@ -114,21 +114,35 @@ describe("eth", function () {
         });
     });
 
-    it('should throw an error if a PK got passed to Accounts.sign without a "0x" prefix', function () {
+    it('should add the "0x" prefix and sign the given message correctly', function () {
+        assert.equal(
+            '0xa8037a6116c176a25e6fc224947fde9e79a2deaa0dd8b67b366fbdfdbffc01f953e41351267b20d4a89ebfe9c8f03c04de9b345add4a52f15bd026b63c8fb1501b',
+            new Accounts().sign('Some data', 'be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728').signature
+        );
+    });
+
+    it('should add the "0x" prefix to the privateKey', function () {
+        assert.equal(
+            '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728',
+            new Accounts().privateKeyToAccount('be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728').privateKey
+        );
+    });
+
+    it('should throw if a privateKey is given with a invalid length', function () {
         try {
-            new Accounts().sign('DATA', 'be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
+            new Accounts().privateKeyToAccount('0000be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
             assert.fail();
         } catch(err) {
-            assert(err.message.includes('Required prefix "0x" is missing for the given private key.'));
+            assert(err.message.includes('Private key must be 32 bytes long'));
         }
     });
 
-    it('should throw an error if a PK got passed to Accounts.privateKeyToAccount without a "0x" prefix', function () {
+    it('should throw if a privateKey is given with a invalid length', function () {
         try {
-            new Accounts().privateKeyToAccount('be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
+            new Accounts().sign('data', '00be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
             assert.fail();
         } catch(err) {
-            assert(err.message.includes('Required prefix "0x" is missing.'));
+            assert(err.message.includes('Private key must be 32 bytes long'));
         }
     });
 });

--- a/test/eth.accounts.sign.js
+++ b/test/eth.accounts.sign.js
@@ -31,7 +31,7 @@ describe("eth", function () {
     describe("accounts", function () {
 
         tests.forEach(function (test, i) {
-            it("sign data using a string", function () {
+            it("sign data using a string", function() {
                 var ethAccounts = new Accounts();
 
                 var data = ethAccounts.sign(test.data, test.privateKey);
@@ -39,7 +39,7 @@ describe("eth", function () {
                 assert.equal(data.signature, test.signature);
             });
 
-            it("sign data using a utf8 encoded hex string", function () {
+            it("sign data using a utf8 encoded hex string", function() {
                 var ethAccounts = new Accounts();
 
                 var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
@@ -49,7 +49,7 @@ describe("eth", function () {
             });
 
 
-            it("recover signature using a string", function () {
+            it("recover signature using a string", function() {
                 var ethAccounts = new Accounts();
 
                 var address = ethAccounts.recover(test.data, test.signature);
@@ -57,7 +57,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a string and preFixed", function () {
+            it("recover signature using a string and preFixed", function() {
                 var ethAccounts = new Accounts();
 
                 var address = ethAccounts.recover(ethAccounts.hashMessage(test.data), test.signature, true);
@@ -65,7 +65,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a hash and r s v values and preFixed", function () {
+            it("recover signature using a hash and r s v values and preFixed", function() {
                 var ethAccounts = new Accounts();
 
                 var sig = ethAccounts.sign(test.data, test.privateKey);
@@ -74,7 +74,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature (pre encoded) using a signature object", function () {
+            it("recover signature (pre encoded) using a signature object", function() {
                 var ethAccounts = new Accounts();
 
                 var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
@@ -84,7 +84,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a signature object", function () {
+            it("recover signature using a signature object", function() {
                 var ethAccounts = new Accounts();
 
                 var sig = ethAccounts.sign(test.data, test.privateKey);
@@ -93,7 +93,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature (pre encoded) using a hash and r s v values", function () {
+            it("recover signature (pre encoded) using a hash and r s v values", function() {
                 var ethAccounts = new Accounts();
 
                 var data = web3.utils.isHexStrict(test.data) ? test.data : web3.utils.utf8ToHex(test.data);
@@ -103,7 +103,7 @@ describe("eth", function () {
                 assert.equal(address, test.address);
             });
 
-            it("recover signature using a hash and r s v values", function () {
+            it("recover signature using a hash and r s v values", function() {
                 var ethAccounts = new Accounts();
 
                 var sig = ethAccounts.sign(test.data, test.privateKey);
@@ -114,21 +114,21 @@ describe("eth", function () {
         });
     });
 
-    it('should add the "0x" prefix and sign the given message correctly', function () {
+    it('should add the "0x" prefix and sign the given message correctly', function() {
         assert.equal(
             '0xa8037a6116c176a25e6fc224947fde9e79a2deaa0dd8b67b366fbdfdbffc01f953e41351267b20d4a89ebfe9c8f03c04de9b345add4a52f15bd026b63c8fb1501b',
             new Accounts().sign('Some data', 'be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728').signature
         );
     });
 
-    it('should add the "0x" prefix to the privateKey', function () {
+    it('should add the "0x" prefix to the privateKey', function() {
         assert.equal(
             '0xbe6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728',
             new Accounts().privateKeyToAccount('be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728').privateKey
         );
     });
 
-    it('should throw if a privateKey is given with a invalid length', function () {
+    it('should throw if a privateKey is given with a invalid length', function() {
         try {
             new Accounts().privateKeyToAccount('0000be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
             assert.fail();
@@ -137,7 +137,7 @@ describe("eth", function () {
         }
     });
 
-    it('should throw if a privateKey is given with a invalid length', function () {
+    it('should throw if a privateKey is given with a invalid length', function() {
         try {
             new Accounts().sign('data', '00be6383dad004f233317e46ddb46ad31b16064d14447a95cc1d8c8d4bc61c3728');
             assert.fail();


### PR DESCRIPTION
## Description

Thanks to @DalderupMaurice to give me a hint about the more advanced solution in the 2.x branch.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Enhancement

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
