### PR TITLE
Add types for subscription.on(connected)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,3 +137,7 @@ Released with 1.0.0-beta.37 code base.
 ### Changed
 
 - Ensure '0x' prefix is existing for Accounts.sign and Accounts.privateKeyToAccount (#3041)
+
+### Fixed
+
+- Add missing subscription.on('connected') TS type definition (#3319)

--- a/packages/web3-core-subscriptions/types/index.d.ts
+++ b/packages/web3-core-subscriptions/types/index.d.ts
@@ -35,6 +35,8 @@ export class Subscription<T> {
 
     on(type: 'changed', handler: (data: T) => void): Subscription<T>;
 
+    on(type: 'connected', handler: (subscriptionId: string) => void): Subscription<T>;
+
     on(type: 'error', handler: (data: Error) => void): Subscription<T>;
 }
 

--- a/packages/web3-core-subscriptions/types/tests/subscriptions.tests.ts
+++ b/packages/web3-core-subscriptions/types/tests/subscriptions.tests.ts
@@ -83,3 +83,6 @@ subscription.on('changed', () => {});
 
 // $ExpectType Subscription<unknown>
 subscription.on('error', () => {});
+
+// $ExpectType Subscription<unknown>
+subscription.on('connected', () => {});

--- a/scripts/e2e.mosaic.sh
+++ b/scripts/e2e.mosaic.sh
@@ -31,7 +31,7 @@ echo "Installing updated web3 via virtual registry "
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 
 git submodule update --init --recursive
-yarn --registry http://localhost:4873
+yarn --registry http://localhost:4873 --network-timeout 100000
 
 yarn add web3@e2e --registry http://localhost:4873 --network-timeout 100000
 


### PR DESCRIPTION
## Description

Adds type definition for the subscription 'connected' event. 

Don't see a unit test verifying that the value passed to the connected callback is a string but I checked this manually and looks right. 

Fixes #3319

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
