### PR TITLE
Make key length check optional, do not enforce on encrypt/decrypt (#3323)

### DIFF
--- a/docs/web3-eth-accounts.rst
+++ b/docs/web3-eth-accounts.rst
@@ -94,7 +94,7 @@ privateKeyToAccount
 
 .. code-block:: javascript
 
-    web3.eth.accounts.privateKeyToAccount(privateKey);
+    web3.eth.accounts.privateKeyToAccount(privateKey [, allowAnyKeyLength]);
 
 Creates an account object from a private key.
 
@@ -103,6 +103,7 @@ Parameters
 ----------
 
 1. ``privateKey`` - ``String``: The private key to convert.
+2. ``allowAnyKeyLength`` - ``Boolean``: When true, does not enforce 32 byte key length requirement
 
 -------
 Returns

--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -263,7 +263,7 @@ export class AccountsBase {
 
     create(entropy?: string): Account;
 
-    privateKeyToAccount(privateKey: string): Account;
+    privateKeyToAccount(privateKey: string, allowAnyKeyLength?: boolean): Account;
 
     signTransaction(
         transactionConfig: TransactionConfig,

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -120,13 +120,13 @@ Accounts.prototype.create = function create(entropy) {
     return this._addAccountFunctions(Account.create(entropy || utils.randomHex(32)));
 };
 
-Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey) {
+Accounts.prototype.privateKeyToAccount = function privateKeyToAccount(privateKey, allowAnyKeyLength) {
     if (!privateKey.startsWith('0x')) {
         privateKey = '0x' + privateKey;
     }
 
     // 64 hex characters + hex-prefix
-    if (privateKey.length !== 66) {
+    if (!allowAnyKeyLength && privateKey.length !== 66) {
         throw new Error("Private key must be 32 bytes long");
     }
 
@@ -389,12 +389,12 @@ Accounts.prototype.decrypt = function(v3Keystore, password, nonStrict) {
     var decipher = cryp.createDecipheriv(json.crypto.cipher, derivedKey.slice(0, 16), Buffer.from(json.crypto.cipherparams.iv, 'hex'));
     var seed = '0x' + Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('hex');
 
-    return this.privateKeyToAccount(seed);
+    return this.privateKeyToAccount(seed, true);
 };
 
 Accounts.prototype.encrypt = function(privateKey, password, options) {
     /* jshint maxcomplexity: 20 */
-    var account = this.privateKeyToAccount(privateKey);
+    var account = this.privateKeyToAccount(privateKey, true);
 
     options = options || {};
     var salt = options.salt || cryp.randomBytes(32);

--- a/test/eth.accounts.encrypt-decrypt.js
+++ b/test/eth.accounts.encrypt-decrypt.js
@@ -63,6 +63,52 @@ var staticTests = [{
     },
     "password": "testpassword",
         "priv": "7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d"
+}, {
+    "json": {
+        "crypto" : {
+            "cipher" : "aes-128-ctr",
+                "cipherparams" : {
+                "iv" : "e0c41130a323adc1446fc82f724bca2f"
+            },
+            "ciphertext" : "9517cd5bdbe69076f9bf5057248c6c050141e970efa36ce53692d5d59a3984",
+                "kdf" : "scrypt",
+                "kdfparams" : {
+                "dklen" : 32,
+                    "n" : 2,
+                    "r" : 8,
+                    "p" : 1,
+                    "salt" : "711f816911c92d649fb4c84b047915679933555030b3552c1212609b38208c63"
+            },
+            "mac" : "d5e116151c6aa71470e67a7d42c9620c75c4d23229847dcc127794f0732b0db5"
+        },
+        "id" : "fecfc4ce-e956-48fd-953b-30f8b52ed66c",
+            "version" : 3
+    },
+    "password": "foo",
+        "priv": "fa7b3db73dc7dfdf8c5fbdb796d741e4488628c41fc4febd9160a866ba0f35"
+},{
+    "json": {
+        "crypto" : {
+            "cipher" : "aes-128-ctr",
+                "cipherparams" : {
+                "iv" : "3ca92af36ad7c2cd92454c59cea5ef00"
+            },
+            "ciphertext" : "108b7d34f3442fc26ab1ab90ca91476ba6bfa8c00975a49ef9051dc675aa",
+                "kdf" : "scrypt",
+                "kdfparams" : {
+                "dklen" : 32,
+                    "n" : 2,
+                    "r" : 8,
+                    "p" : 1,
+                    "salt" : "d0769e608fb86cda848065642a9c6fa046845c928175662b8e356c77f914cd3b"
+            },
+            "mac" : "75d0e6759f7b3cefa319c3be41680ab6beea7d8328653474bd06706d4cc67420"
+        },
+        "id" : "a37e1559-5955-450d-8075-7b8931b392b2",
+            "version" : 3
+    },
+    "password": "foo",
+        "priv": "81c29e8142bb6a81bef5a92bda7a8328a5c85bb2f9542e76f9b0f94fc018"
 }];
 
 describe("eth", function () {


### PR DESCRIPTION
## Description

**PR targets #3323** 

Restores existing non-standard key length encrypt/decrypt tests and has accounts.encrypt / decrypt skip the key length check. 

<!--- 
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

- [x] PR Review suggestion

