### PR TITLE
Check for error codes on close in RequestManager (#3190)

### DIFF
--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -48,17 +48,16 @@ module.exports = {
         return this.ConnectionError('connection not open on send()', event);
     },
     ConnectionCloseError: function (event){
-        let msg = 'CONNECTION ERROR: The connection closed unexpectedly';
-
         if (typeof event === 'object' && event.code && event.reason) {
-            msg = 'CONNECTION ERROR: The connection got closed with ' +
+            return this.ConnectionError(
+                'CONNECTION ERROR: The connection got closed with ' +
                 'the close code `' + event.code + '` and the following ' +
-                'reason string `' + event.reason + '`';
-
-            return this.ConnectionError(msg, event);
+                'reason string `' + event.reason + '`',
+                event
+            );
         }
 
-        return new Error(msg);
+        return new Error('CONNECTION ERROR: The connection closed unexpectedly');
     },
     MaxAttemptsReachedOnReconnectingError: function (){
         return new Error('Maximum number of reconnect attempts reached!');

--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -47,6 +47,17 @@ module.exports = {
     ConnectionNotOpenError: function (event){
         return this.ConnectionError('connection not open on send()', event);
     },
+    ConnectionCloseError: function (event){
+        const msg = (typeof event === 'object' && event.code && event.reason)
+
+            ? 'CONNECTION ERROR: The connection got closed with ' +
+              'the close code `' + event.code + '` and the following ' +
+              'reason string `' + event.reason + '`'
+
+            : 'CONNECTION ERROR: The connection closed unexpectedly';
+
+        return new Error(msg);
+    },
     MaxAttemptsReachedOnReconnectingError: function (){
         return new Error('Maximum number of reconnect attempts reached!');
     },

--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -48,13 +48,15 @@ module.exports = {
         return this.ConnectionError('connection not open on send()', event);
     },
     ConnectionCloseError: function (event){
-        const msg = (typeof event === 'object' && event.code && event.reason)
+        let msg = 'CONNECTION ERROR: The connection closed unexpectedly';
 
-            ? 'CONNECTION ERROR: The connection got closed with ' +
-              'the close code `' + event.code + '` and the following ' +
-              'reason string `' + event.reason + '`'
+        if (typeof event === 'object' && event.code && event.reason) {
+            msg = 'CONNECTION ERROR: The connection got closed with ' +
+                'the close code `' + event.code + '` and the following ' +
+                'reason string `' + event.reason + '`';
 
-            : 'CONNECTION ERROR: The connection closed unexpectedly';
+            return this.ConnectionError(msg, event);
+        }
 
         return new Error(msg);
     },

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -69,7 +69,7 @@ export class errors {
     static InvalidResponse(result: Error): Error;
     static ConnectionTimeout(ms: string): Error;
     static ConnectionNotOpenError(): Error;
-    static ConnectionCloseError(event: WebSocketEvent | boolean): Error;
+    static ConnectionCloseError(event: WebSocketEvent | boolean): Error | ConnectionError;
     static MaxAttemptsReachedOnReconnectingError(): Error;
     static PendingRequestsOnReconnectingError(): Error;
     static ConnectionError(msg: string, event?: WebSocketEvent): ConnectionError;

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -69,6 +69,7 @@ export class errors {
     static InvalidResponse(result: Error): Error;
     static ConnectionTimeout(ms: string): Error;
     static ConnectionNotOpenError(): Error;
+    static ConnectionCloseError(event: WebSocketEvent | boolean): Error;
     static MaxAttemptsReachedOnReconnectingError(): Error;
     static PendingRequestsOnReconnectingError(): Error;
     static ConnectionError(msg: string, event?: WebSocketEvent): ConnectionError;

--- a/packages/web3-core-helpers/types/tests/errors-test.ts
+++ b/packages/web3-core-helpers/types/tests/errors-test.ts
@@ -50,6 +50,12 @@ const event: WebSocketEvent = {code: 100, reason: 'reason'};
 // $ExpectType ConnectionError
 errors.ConnectionError('msg', event);
 
+// $ExpectType Error
+errors.ConnectionCloseError(event);
+
+// $ExpectType Error
+errors.ConnectionCloseError(true);
+
 // $ExpectType RevertInstructionError
 errors.RevertInstructionError('reason', 'signature');
 

--- a/packages/web3-core-helpers/types/tests/errors-test.ts
+++ b/packages/web3-core-helpers/types/tests/errors-test.ts
@@ -50,10 +50,10 @@ const event: WebSocketEvent = {code: 100, reason: 'reason'};
 // $ExpectType ConnectionError
 errors.ConnectionError('msg', event);
 
-// $ExpectType Error
+// $ExpectType Error | ConnectionError
 errors.ConnectionCloseError(event);
 
-// $ExpectType Error
+// $ExpectType Error | ConnectionError
 errors.ConnectionCloseError(true);
 
 // $ExpectType RevertInstructionError

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -279,9 +279,9 @@ RequestManager.prototype.clearSubscriptions = function (keepIsSyncing) {
  * Evaluates WS close event
  *
  * @method _isCleanClose
- * @param event close event
+ * @param {object | boolean} event WS close event or exception flag
  *
- * @returns boolean
+ * @returns {boolean}
  */
 RequestManager.prototype._isCleanCloseEvent = function (event) {
     return typeof event === 'object' && ([1000].includes(event.code) || event.wasClean === true);
@@ -291,9 +291,9 @@ RequestManager.prototype._isCleanCloseEvent = function (event) {
  * Detects Ipc close error. The node.net module emits ('close', isException)
  *
  * @method _isIpcCloseError
- * @param event close event
+ * @param {object | boolean} event WS close event or exception flag
  *
- * @returns boolean
+ * @returns {boolean}
  */
 RequestManager.prototype._isIpcCloseError = function (event) {
     return typeof event === 'boolean' && event;

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -279,20 +279,21 @@ RequestManager.prototype.clearSubscriptions = function (keepIsSyncing) {
  * Evaluates WS close event
  *
  * @method _isCleanClose
+ * @param event close event
  *
- * @returns {boolean}
+ * @returns boolean
  */
 RequestManager.prototype._isCleanCloseEvent = function (event) {
-    return typeof event === 'object' &&
-           ([1000].includes(event.code) || event.wasClean === true);
+    return typeof event === 'object' && ([1000].includes(event.code) || event.wasClean === true);
 };
 
 /**
  * Detects Ipc close error. The node.net module emits ('close', isException)
  *
  * @method _isIpcCloseError
+ * @param event close event
  *
- * @returns {boolean}
+ * @returns boolean
  */
 RequestManager.prototype._isIpcCloseError = function (event) {
     return typeof event === 'boolean' && event;

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -279,7 +279,8 @@ RequestManager.prototype.clearSubscriptions = function (keepIsSyncing) {
  * Evaluates WS close event
  *
  * @method _isCleanClose
- * @param {object | boolean} event WS close event or exception flag
+ *
+ * @param {CloseEvent | boolean} event WS close event or exception flag
  *
  * @returns {boolean}
  */
@@ -291,7 +292,8 @@ RequestManager.prototype._isCleanCloseEvent = function (event) {
  * Detects Ipc close error. The node.net module emits ('close', isException)
  *
  * @method _isIpcCloseError
- * @param {object | boolean} event WS close event or exception flag
+ *
+ * @param {CloseEvent | boolean} event WS close event or exception flag
  *
  * @returns {boolean}
  */

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -123,7 +123,7 @@ RequestManager.prototype.setProvider = function (provider, net) {
             });
         });
 
-        // notify all subscriptions about bad close conditions and unsubscribe
+        // notify all subscriptions about bad close conditions
         this.provider.on('close', function close(event) {
             if (![1000, 1001].includes(event.code) || event.wasClean === false) {
                 _this.subscriptions.forEach(function (subscription) {

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -123,11 +123,13 @@ RequestManager.prototype.setProvider = function (provider, net) {
             });
         });
 
-        // notify all subscriptions about the close condition
+        // notify all subscriptions about bad close conditions and unsubscribe
         this.provider.on('close', function close(event) {
-            _this.subscriptions.forEach(function (subscription) {
-                subscription.callback(new Error('CONNECTION ERROR: The connection got closed with the close code `' + event.code + '` and the following reason string `' + event.reason + '`'));
-            });
+            if (![1000, 1001].includes(event.code) || event.wasClean === false) {
+                _this.subscriptions.forEach(function (subscription) {
+                    subscription.callback(new Error('CONNECTION ERROR: The connection got closed with the close code `' + event.code + '` and the following reason string `' + event.reason + '`'));
+                });
+            }
         });
 
         // TODO add end, timeout??

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -74,6 +74,8 @@ describe('contract.events [ @E2E ]', function() {
     });
 
     it('should not hear the error handler when connection.closed() called', function(){
+        this.timeout(15000);
+
         let failed = false;
 
         return new Promise(async (resolve, reject) => {
@@ -84,7 +86,6 @@ describe('contract.events [ @E2E ]', function() {
                     toBlock: 'latest'
                 })
                 .on('error', function(err) {
-                    console.log('err --> ' + err);
                     failed = true;
                     this.removeAllListeners();
                     reject(new Error('err listener should not hear connection.close'));
@@ -103,6 +104,8 @@ describe('contract.events [ @E2E ]', function() {
     });
 
     it('should not hear the error handler when provider.disconnect() called', function(){
+        this.timeout(15000);
+
         let failed = false;
 
         return new Promise(async (resolve, reject) => {
@@ -113,7 +116,6 @@ describe('contract.events [ @E2E ]', function() {
                     toBlock: 'latest'
                 })
                 .on('error', function(err) {
-                    console.log('err --> ' + err)
                     failed = true;
                     this.removeAllListeners();
                     reject(new Error('err listener should not hear provider.disconnect'));

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -28,7 +28,7 @@ describe('subscription connect/reconnect', function () {
     it('subscribes (baseline)', function (done) {
         web3.eth
             .subscribe('newBlockHeaders')
-            .on('data', function (result) {
+            .once('data', function (result) {
                 assert(result.parentHash);
                 done();
             });
@@ -128,9 +128,8 @@ describe('subscription connect/reconnect', function () {
 
         web3.eth
             .subscribe('newBlockHeaders')
-            .on("error", function (err) {
+            .once("error", function (err) {
                 assert(err.message.includes('No provider set'));
-                this.removeAllListeners();
                 done();
             });
     });
@@ -149,9 +148,8 @@ describe('subscription connect/reconnect', function () {
 
         web3.eth
             .subscribe('newBlockHeaders')
-            .on("error", function (err) {
+            .once("error", function (err) {
                 assert(err.message.includes("provider doesn't support subscriptions: HttpProvider"));
-                this.removeAllListeners();
                 done();
             });
     });
@@ -162,31 +160,24 @@ describe('subscription connect/reconnect', function () {
         return new Promise(async function (resolve) {
             web3.eth
                 .subscribe('newBlockHeaders')
-                .on('error', function (err) {
+                .once('error', function (err) {
                     assert(err.message.includes('CONNECTION ERROR: Couldn\'t connect to node on WS'));
-                    this.removeAllListeners();
                     resolve();
                 });
         });
     });
 
     it('errors when the subscription got established (is running) and the connection does get closed', function () {
-        let stage = 0; // Required to not trigger server.close a second time
-
         return new Promise(async function (resolve) {
             web3.eth
                 .subscribe('newBlockHeaders')
-                .on('data', async function () {
-                    if (stage === 0) {
-                        stage = 1;
-                        await pify(server.close)();
-                    }
+                .once('data', async function () {
+                    await pify(server.close)();
                 })
-                .on('error', function (err) {
+                .once('error', function (err) {
                     assert(err.message.includes('CONNECTION ERROR'));
                     assert(err.message.includes('close code `1006`'));
                     assert(err.message.includes('Connection dropped by remote peer.'));
-                    this.removeAllListeners();
                     resolve();
                 });
         });

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -130,6 +130,7 @@ describe('subscription connect/reconnect', function () {
             .subscribe('newBlockHeaders')
             .on("error", function (err) {
                 assert(err.message.includes('No provider set'));
+                this.removeAllListeners();
                 done();
             });
     });
@@ -150,6 +151,7 @@ describe('subscription connect/reconnect', function () {
             .subscribe('newBlockHeaders')
             .on("error", function (err) {
                 assert(err.message.includes("provider doesn't support subscriptions: HttpProvider"));
+                this.removeAllListeners();
                 done();
             });
     });
@@ -162,6 +164,7 @@ describe('subscription connect/reconnect', function () {
                 .subscribe('newBlockHeaders')
                 .on('error', function (err) {
                     assert(err.message.includes('CONNECTION ERROR: Couldn\'t connect to node on WS'));
+                    this.removeAllListeners();
                     resolve();
                 });
         });
@@ -182,7 +185,8 @@ describe('subscription connect/reconnect', function () {
                 .on('error', function (err) {
                     assert(err.message.includes('CONNECTION ERROR'));
                     assert(err.message.includes('close code `1006`'));
-                    assert(err.message.includes('Connection dropped by remote peer.'))
+                    assert(err.message.includes('Connection dropped by remote peer.'));
+                    this.removeAllListeners();
                     resolve();
                 });
         });
@@ -205,7 +209,7 @@ describe('subscription connect/reconnect', function () {
                     // Exit point, flag set below
                     if (stage === 1) {
                         web3.currentProvider.disconnect();
-
+                        this.removeAllListeners();
                         resolve();
                     }
                 });
@@ -235,7 +239,7 @@ describe('subscription connect/reconnect', function () {
                     // Exit point, flag set below
                     if (stage === 1) {
                         web3.currentProvider.disconnect();
-
+                        this.removeAllListeners();
                         resolve();
                     }
                 });

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -135,7 +135,6 @@ describe('subscription connect/reconnect', function () {
             web3.eth
                 .subscribe('newBlockHeaders')
                 .on("data", function (_) {
-                    emitterInstance = this;
                     counter++;
                 });
 

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -161,7 +161,7 @@ describe('subscription connect/reconnect', function () {
             web3.eth
                 .subscribe('newBlockHeaders')
                 .on('error', function (err) {
-                    assert(err.message.includes('CONNECTION ERROR'));
+                    assert(err.message.includes('CONNECTION ERROR: Couldn\'t connect to node on WS'));
                     resolve();
                 });
         });
@@ -181,6 +181,8 @@ describe('subscription connect/reconnect', function () {
                 })
                 .on('error', function (err) {
                     assert(err.message.includes('CONNECTION ERROR'));
+                    assert(err.message.includes('close code `1006`'));
+                    assert(err.message.includes('Connection dropped by remote peer.'))
                     resolve();
                 });
         });

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -102,8 +102,7 @@ describe('subscription connect/reconnect', function () {
     });
 
     // The ganache unit tests are erroring under similar conditions -
-    // test verifies behavior is as expected.
-    it('does not error when client closes immediately after disconnect', async function(){
+    it('does not error when client closes after disconnect', async function(){
         this.timeout(7000);
 
         return new Promise(async function(resolve, reject) {
@@ -116,7 +115,12 @@ describe('subscription connect/reconnect', function () {
             // Let a couple blocks mine..
             await waitSeconds(2)
             web3.currentProvider.disconnect();
+
+            // This delay seems to be required (on Travis).
+            await waitSeconds(1);
+
             await pify(server.close)();
+
             await waitSeconds(1)
             resolve();
         });

--- a/test/helpers/test.utils.js
+++ b/test/helpers/test.utils.js
@@ -51,6 +51,11 @@ var getWebsocketPort = function(){
     return ( process.env.GANACHE || global.window ) ?  8545 : 8546;
 }
 
+// Delay
+var waitSeconds = async function(seconds=0){
+    return new Promise(resolve => setTimeout(() => resolve(), seconds * 1000))
+}
+
 module.exports = {
     methodExists: methodExists,
     propertyExists: propertyExists,
@@ -58,5 +63,6 @@ module.exports = {
     extractReceipt: extractReceipt,
     getWeb3: getWeb3,
     getWebsocketPort: getWebsocketPort,
+    waitSeconds: waitSeconds
 };
 

--- a/test/helpers/test.utils.js
+++ b/test/helpers/test.utils.js
@@ -52,7 +52,7 @@ var getWebsocketPort = function(){
 }
 
 // Delay
-var waitSeconds = async function(seconds=0){
+var waitSeconds = async function(seconds = 0){
     return new Promise(resolve => setTimeout(() => resolve(), seconds * 1000))
 }
 
@@ -65,4 +65,3 @@ module.exports = {
     getWebsocketPort: getWebsocketPort,
     waitSeconds: waitSeconds
 };
-

--- a/test/websocket.ganache.js
+++ b/test/websocket.ganache.js
@@ -115,9 +115,8 @@ describe('WebsocketProvider (ganache)', function () {
             );
 
         await new Promise(resolve => {
-            web3.currentProvider.on('error', function(err){
+            web3.currentProvider.once('error', function(err){
                 assert(err.message.includes('CONNECTION TIMEOUT: timeout of 1000 ms achived'))
-                this.removeAllListeners();
                 resolve();
             });
 
@@ -183,9 +182,8 @@ describe('WebsocketProvider (ganache)', function () {
                 )
             );
 
-            web3.currentProvider.on('connect', async function () {
+            web3.currentProvider.once('connect', async function () {
                 await pify(server.close)();
-                this.removeAllListeners();
                 resolve();
             });
 
@@ -208,13 +206,12 @@ describe('WebsocketProvider (ganache)', function () {
                 )
             );
 
-            web3.currentProvider.on('connect', async function () {
+            web3.currentProvider.once('connect', async function () {
                 await pify(server.close)();
             });
 
-            web3.currentProvider.on('error', function (error) {
+            web3.currentProvider.once('error', function (error) {
                 assert(error.message.includes('Maximum number of reconnect attempts reached!'));
-                this.removeAllListeners();
                 resolve();
             });
         });
@@ -234,7 +231,7 @@ describe('WebsocketProvider (ganache)', function () {
                 )
             );
 
-            web3.currentProvider.on('connect', async function () {
+            web3.currentProvider.once('connect', async function () {
                 web3.currentProvider.disconnect();
 
                 try {
@@ -245,7 +242,6 @@ describe('WebsocketProvider (ganache)', function () {
                     assert(err.message.includes('connection not open on send'));
                     assert(typeof err.code === 'undefined');
                     assert(typeof err.reason === 'undefined');
-                    this.removeAllListeners();
                     resolve();
                 }
             });
@@ -300,16 +296,15 @@ describe('WebsocketProvider (ganache)', function () {
                 )
             );
 
-            web3.currentProvider.on('connect', async function () {
+            web3.currentProvider.once('connect', async function () {
                 await pify(server.close)();
                 timeout = setTimeout(function () {
                     reject(new Error('Test Failed: Configured delay is not applied!'));
                 }, 3100);
             });
 
-            web3.currentProvider.on('reconnect', function () {
+            web3.currentProvider.once('reconnect', function () {
                 clearTimeout(timeout);
-                this.removeAllListeners();
                 resolve();
             });
         });
@@ -330,17 +325,16 @@ describe('WebsocketProvider (ganache)', function () {
                 )
             );
 
-            web3.currentProvider.on('connect', async function () {
+            web3.currentProvider.once('connect', async function () {
                 await pify(server.close)();
             });
 
-            web3.currentProvider.on('reconnect', async function () {
+            web3.currentProvider.once('reconnect', async function () {
                 try {
                     await web3.eth.getBlockNumber();
                     assert.fail();
                 } catch (err) {
                     assert(err.message.includes('Maximum number of reconnect attempts'))
-                    this.removeAllListeners();
                     resolve();
                 }
             });
@@ -410,9 +404,8 @@ describe('WebsocketProvider (ganache)', function () {
             );
 
         await new Promise(async resolve => {
-            web3.currentProvider.on('error', function(err){
+            web3.currentProvider.once('error', function(err){
                 assert(err.message.includes('Maximum number of reconnect attempts reached'))
-                this.removeAllListeners();
                 resolve();
             })
 

--- a/test/websocket.ganache.js
+++ b/test/websocket.ganache.js
@@ -37,7 +37,7 @@ describe('WebsocketProvider (ganache)', function () {
     it('errors when requests continue after socket closed', async function () {
         web3 = new Web3(host + 8777);
 
-        try { await web3.eth.getBlockNumber() } catch (err) {
+        try { await web3.eth.getBlockNumber(); } catch (err) {
             assert(err.message.includes('connection not open on send'));
             assert(err.code, 1006);
             assert(err.reason, 'connection failed');
@@ -116,7 +116,7 @@ describe('WebsocketProvider (ganache)', function () {
 
         await new Promise(resolve => {
             web3.currentProvider.once('error', function(err){
-                assert(err.message.includes('CONNECTION TIMEOUT: timeout of 1000 ms achived'))
+                assert(err.message.includes('CONNECTION TIMEOUT: timeout of 1000 ms achived'));
                 resolve();
             });
 
@@ -334,7 +334,7 @@ describe('WebsocketProvider (ganache)', function () {
                     await web3.eth.getBlockNumber();
                     assert.fail();
                 } catch (err) {
-                    assert(err.message.includes('Maximum number of reconnect attempts'))
+                    assert(err.message.includes('Maximum number of reconnect attempts'));
                     resolve();
                 }
             });
@@ -344,7 +344,6 @@ describe('WebsocketProvider (ganache)', function () {
     it('queues requests made while connection is lost / executes on reconnect', function () {
         this.timeout(10000);
         let stage = 0;
-        let emitterInstance; // Assigned for cleanup
 
         return new Promise(async function (resolve) {
             server = ganache.server({port: port});
@@ -358,8 +357,6 @@ describe('WebsocketProvider (ganache)', function () {
             );
 
             web3.currentProvider.on('connect', async function () {
-                emitterInstance = this;
-
                 if (stage === 0){
                     await pify(server.close)();
                     stage = 1;
@@ -377,7 +374,7 @@ describe('WebsocketProvider (ganache)', function () {
                 const blockNumber = await deferred;
                 assert(blockNumber === 0);
 
-                emitterInstance.removeAllListeners();
+                web3.currentProvider.removeAllListeners();
                 resolve();
             },2500);
         });
@@ -405,9 +402,9 @@ describe('WebsocketProvider (ganache)', function () {
 
         await new Promise(async resolve => {
             web3.currentProvider.once('error', function(err){
-                assert(err.message.includes('Maximum number of reconnect attempts reached'))
+                assert(err.message.includes('Maximum number of reconnect attempts reached'));
                 resolve();
-            })
+            });
 
             await pify(server.close)();
             web3.currentProvider._parseResponse('abc|--|dedf');

--- a/test/websocket.ganache.js
+++ b/test/websocket.ganache.js
@@ -117,6 +117,7 @@ describe('WebsocketProvider (ganache)', function () {
         await new Promise(resolve => {
             web3.currentProvider.on('error', function(err){
                 assert(err.message.includes('CONNECTION TIMEOUT: timeout of 1000 ms achived'))
+                this.removeAllListeners();
                 resolve();
             });
 
@@ -140,6 +141,7 @@ describe('WebsocketProvider (ganache)', function () {
                     stage = 1;
                 } else {
                     await pify(server.close)();
+                    this.removeAllListeners();
                     resolve();
                 }
             });
@@ -165,6 +167,7 @@ describe('WebsocketProvider (ganache)', function () {
                     stage = 1;
                 } else {
                     await pify(server.close)();
+                    this.removeAllListeners();
                     resolve();
                 }
             });
@@ -182,6 +185,7 @@ describe('WebsocketProvider (ganache)', function () {
 
             web3.currentProvider.on('connect', async function () {
                 await pify(server.close)();
+                this.removeAllListeners();
                 resolve();
             });
 
@@ -210,6 +214,7 @@ describe('WebsocketProvider (ganache)', function () {
 
             web3.currentProvider.on('error', function (error) {
                 assert(error.message.includes('Maximum number of reconnect attempts reached!'));
+                this.removeAllListeners();
                 resolve();
             });
         });
@@ -240,7 +245,7 @@ describe('WebsocketProvider (ganache)', function () {
                     assert(err.message.includes('connection not open on send'));
                     assert(typeof err.code === 'undefined');
                     assert(typeof err.reason === 'undefined');
-
+                    this.removeAllListeners();
                     resolve();
                 }
             });
@@ -304,6 +309,7 @@ describe('WebsocketProvider (ganache)', function () {
 
             web3.currentProvider.on('reconnect', function () {
                 clearTimeout(timeout);
+                this.removeAllListeners();
                 resolve();
             });
         });
@@ -334,6 +340,7 @@ describe('WebsocketProvider (ganache)', function () {
                     assert.fail();
                 } catch (err) {
                     assert(err.message.includes('Maximum number of reconnect attempts'))
+                    this.removeAllListeners();
                     resolve();
                 }
             });
@@ -343,6 +350,7 @@ describe('WebsocketProvider (ganache)', function () {
     it('queues requests made while connection is lost / executes on reconnect', function () {
         this.timeout(10000);
         let stage = 0;
+        let emitterInstance; // Assigned for cleanup
 
         return new Promise(async function (resolve) {
             server = ganache.server({port: port});
@@ -356,6 +364,8 @@ describe('WebsocketProvider (ganache)', function () {
             );
 
             web3.currentProvider.on('connect', async function () {
+                emitterInstance = this;
+
                 if (stage === 0){
                     await pify(server.close)();
                     stage = 1;
@@ -373,6 +383,7 @@ describe('WebsocketProvider (ganache)', function () {
                 const blockNumber = await deferred;
                 assert(blockNumber === 0);
 
+                emitterInstance.removeAllListeners();
                 resolve();
             },2500);
         });
@@ -401,6 +412,7 @@ describe('WebsocketProvider (ganache)', function () {
         await new Promise(async resolve => {
             web3.currentProvider.on('error', function(err){
                 assert(err.message.includes('Maximum number of reconnect attempts reached'))
+                this.removeAllListeners();
                 resolve();
             })
 


### PR DESCRIPTION
## Description
**PR targets #3190**

Addresses an issue exposed by the ganache E2E tests: clean closes are throwing errors to all attached error listeners. 

Adds logic to the `.on("close")` listener in the RequestManager to check the event code and only run errored callbacks if something definitely went wrong. 

Commit 044a4d5c3a07ea880a3a6ea87b7f025824410e2c contains failing tests that show the [problem in Travis][1].

Commit b1a71b27b7cdc89e5d346f49dd9c20167a124708 passes.

NB: the ganache test continues to fail because their close is `1006` even though they run `connection.close` before shutting the client down. Tried to duplicate their failure within Web3's suite and was unable to reproduce. Am forking them to get to the root of the problem. 

[1]: https://travis-ci.org/ethereum/web3.js/jobs/640668821#L602-L609
## Type of change

- [x] Review suggestion
