### PR TITLE
package.json moving @types/node to devDependancy

### DIFF
--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -49,7 +49,6 @@
         }
     ],
     "dependencies": {
-        "@types/node": "^12.6.1",
         "web3-bzz": "1.2.4",
         "web3-core": "1.2.4",
         "web3-eth": "1.2.4",
@@ -61,5 +60,6 @@
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",
         "dtslint": "0.4.2"
+ 	"@types/node": "^12.6.1",
     }
 }


### PR DESCRIPTION
## Description
moving @types/node to a devDependency. It isn't needed at runtime, and if a library user is is targeting browser this dependency will give them incorrect type hints.

Fixes #2965 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the live network.
