### PR TITLE
regenerator-runtime readded to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -817,6 +817,7 @@
             "version": "0.3.11",
             "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.3.11.tgz",
             "integrity": "sha512-XqOWQYqdjZTZQA7vAJty9Bdw5er+K0KGLTkrMDBXuJj5yNSf2oM4cj+dW6RATA4Bwz5cBCH2mjA8EsOxa+8eDA==",
+            "dev": true,
             "requires": {
                 "bluebird": "^3.5.2",
                 "eth-ens-namehash": "^1.0.2",
@@ -830,12 +831,14 @@
                 "bluebird": {
                     "version": "3.7.2",
                     "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-                    "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+                    "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+                    "dev": true
                 },
                 "eth-ens-namehash": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-1.0.2.tgz",
                     "integrity": "sha1-Bezda6wtf9e8XKhKmTxrrZ2k7bk=",
+                    "dev": true,
                     "requires": {
                         "idna-uts46": "^1.0.1",
                         "js-sha3": "^0.5.7"
@@ -844,14 +847,16 @@
                 "js-sha3": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+                    "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+                    "dev": true
                 }
             }
         },
         "@ensdomains/resolver": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.1.13.tgz",
-            "integrity": "sha512-VcMygGO/b0H4AXkN4CRAHw0CZd5XvTJW8YdIdZEmpJGs/O3eMzBzxpgJJ7UerD7U098rbBDSJmj0zjGudV0/aQ=="
+            "integrity": "sha512-VcMygGO/b0H4AXkN4CRAHw0CZd5XvTJW8YdIdZEmpJGs/O3eMzBzxpgJJ7UerD7U098rbBDSJmj0zjGudV0/aQ==",
+            "dev": true
         },
         "@evocateur/libnpmaccess": {
             "version": "3.1.2",
@@ -2940,6 +2945,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
             "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+            "dev": true,
             "requires": {
                 "acorn": "^4.0.3"
             },
@@ -2947,7 +2953,8 @@
                 "acorn": {
                     "version": "4.0.13",
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+                    "dev": true
                 }
             }
         },
@@ -3010,6 +3017,7 @@
             "version": "6.10.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
             "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+            "dev": true,
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -3020,12 +3028,14 @@
         "ajv-keywords": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-            "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
+            "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+            "dev": true
         },
         "align-text": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -3036,6 +3046,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -3087,7 +3098,8 @@
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -3114,6 +3126,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
             "requires": {
                 "micromatch": "^3.1.4",
                 "normalize-path": "^2.1.1"
@@ -3122,7 +3135,8 @@
         "app-module-path": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-            "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU="
+            "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
+            "dev": true
         },
         "append-buffer": {
             "version": "1.0.2",
@@ -3167,7 +3181,8 @@
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
         },
         "arr-filter": {
             "version": "1.1.2",
@@ -3181,7 +3196,8 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
         },
         "arr-map": {
             "version": "2.0.2",
@@ -3195,7 +3211,8 @@
         "arr-union": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
         },
         "array-differ": {
             "version": "2.1.0",
@@ -3305,7 +3322,8 @@
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+            "dev": true
         },
         "arraybuffer.slice": {
             "version": "0.0.7",
@@ -3338,6 +3356,7 @@
             "version": "4.10.1",
             "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "inherits": "^2.0.1",
@@ -3348,6 +3367,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
             "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+            "dev": true,
             "requires": {
                 "object-assign": "^4.1.1",
                 "util": "0.10.3"
@@ -3356,12 +3376,14 @@
                 "inherits": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
                 },
                 "util": {
                     "version": "0.10.3",
                     "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
                     "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
                     "requires": {
                         "inherits": "2.0.1"
                     }
@@ -3383,12 +3405,7 @@
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-        },
-        "async": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-            "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
             "dev": true
         },
         "async": {
@@ -3412,7 +3429,8 @@
         "async-each": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
-            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "dev": true
         },
         "async-limiter": {
             "version": "1.0.1",
@@ -3438,7 +3456,8 @@
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
         },
         "atob-lite": {
             "version": "2.0.0",
@@ -3535,12 +3554,14 @@
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
         },
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
                 "class-utils": "^0.3.5",
@@ -3555,6 +3576,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -3563,6 +3585,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -3571,6 +3594,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -3579,6 +3603,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -3596,7 +3621,8 @@
         "base64-js": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+            "dev": true
         },
         "base64id": {
             "version": "1.0.0",
@@ -3631,7 +3657,8 @@
         "big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true
         },
         "bignumber.js": {
             "version": "4.1.0",
@@ -3642,7 +3669,8 @@
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+            "dev": true
         },
         "binaryextensions": {
             "version": "2.1.2",
@@ -3702,7 +3730,8 @@
         "bn.js": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
         },
         "body-parser": {
             "version": "1.19.0",
@@ -3740,6 +3769,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3749,6 +3779,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "dev": true,
             "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -3766,6 +3797,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -3775,7 +3807,8 @@
         "brorand": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
         },
         "brotli-size": {
             "version": "0.1.0",
@@ -3821,7 +3854,8 @@
         "browser-stdout": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
         },
         "browserify": {
             "version": "16.5.0",
@@ -3897,6 +3931,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
             "requires": {
                 "buffer-xor": "^1.0.3",
                 "cipher-base": "^1.0.0",
@@ -3910,6 +3945,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
             "requires": {
                 "browserify-aes": "^1.0.4",
                 "browserify-des": "^1.0.0",
@@ -3920,6 +3956,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.1",
                 "des.js": "^1.0.0",
@@ -3931,6 +3968,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "randombytes": "^2.0.1"
@@ -3958,6 +3996,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.1",
                 "browserify-rsa": "^4.0.0",
@@ -3972,6 +4011,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
             "requires": {
                 "pako": "~1.0.5"
             }
@@ -4046,22 +4086,26 @@
         "buffer-to-arraybuffer": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-            "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+            "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
+            "dev": true
         },
         "buffer-xor": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
         },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
         },
         "builtin-status-codes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
         },
         "builtins": {
             "version": "1.0.3",
@@ -4215,6 +4259,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
                 "component-emitter": "^1.2.1",
@@ -4344,7 +4389,8 @@
         "camelcase": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+            "dev": true
         },
         "camelcase-keys": {
             "version": "4.2.0",
@@ -4381,6 +4427,7 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
             "requires": {
                 "align-text": "^0.1.3",
                 "lazy-cache": "^1.0.3"
@@ -4421,6 +4468,7 @@
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
             "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+            "dev": true,
             "requires": {
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
@@ -4439,7 +4487,8 @@
                 "normalize-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
                 }
             }
         },
@@ -4465,6 +4514,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -4474,6 +4524,7 @@
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
@@ -4485,6 +4536,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -4564,6 +4616,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1",
@@ -4611,7 +4664,8 @@
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
         },
         "collection-map": {
             "version": "1.0.0",
@@ -4628,6 +4682,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
@@ -4733,7 +4788,8 @@
         "component-emitter": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
         },
         "component-inherit": {
             "version": "0.0.3",
@@ -4744,7 +4800,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "concat-stream": {
             "version": "1.5.2",
@@ -4811,6 +4868,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
             "requires": {
                 "date-now": "^0.1.4"
             }
@@ -4824,7 +4882,8 @@
         "constants-browserify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
         },
         "content-disposition": {
             "version": "0.5.3",
@@ -5109,7 +5168,8 @@
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
         },
         "copy-props": {
             "version": "2.0.4",
@@ -5148,7 +5208,8 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "cors": {
             "version": "2.8.5",
@@ -5233,6 +5294,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "elliptic": "^6.0.0"
@@ -5242,6 +5304,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.1",
                 "inherits": "^2.0.1",
@@ -5254,6 +5317,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
             "requires": {
                 "cipher-base": "^1.0.3",
                 "create-hash": "^1.1.0",
@@ -5280,6 +5344,7 @@
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
             "requires": {
                 "browserify-cipher": "^1.0.0",
                 "browserify-sign": "^4.0.0",
@@ -5331,6 +5396,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
             "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+            "dev": true,
             "requires": {
                 "es5-ext": "^0.10.50",
                 "type": "^1.0.1"
@@ -5369,7 +5435,8 @@
         "date-now": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
         },
         "dateformat": {
             "version": "3.0.3",
@@ -5381,6 +5448,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             }
@@ -5394,7 +5462,8 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decamelize-keys": {
             "version": "1.1.0",
@@ -5417,7 +5486,8 @@
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
         },
         "decompress": {
             "version": "4.2.0",
@@ -5447,6 +5517,7 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
             }
@@ -5615,6 +5686,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -5623,6 +5695,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
                 "isobject": "^3.0.1"
@@ -5632,6 +5705,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5640,6 +5714,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5648,6 +5723,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -5867,6 +5943,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
@@ -5920,12 +5997,14 @@
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
         },
         "diffie-hellman": {
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "miller-rabin": "^4.0.0",
@@ -5982,12 +6061,14 @@
         "dom-walk": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+            "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+            "dev": true
         },
         "domain-browser": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+            "dev": true
         },
         "domelementtype": {
             "version": "1.3.1",
@@ -6109,6 +6190,7 @@
             "version": "6.4.1",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
             "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -6128,7 +6210,8 @@
         "emojis-list": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+            "dev": true
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -6238,6 +6321,7 @@
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
             "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "memory-fs": "^0.4.0",
@@ -6273,6 +6357,7 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "dev": true,
             "requires": {
                 "prr": "~1.0.1"
             }
@@ -6281,6 +6366,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
@@ -6289,6 +6375,7 @@
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
             "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+            "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.0",
                 "function-bind": "^1.1.1",
@@ -6302,6 +6389,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -6312,6 +6400,7 @@
             "version": "0.10.50",
             "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
             "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+            "dev": true,
             "requires": {
                 "es6-iterator": "~2.0.3",
                 "es6-symbol": "~3.1.1",
@@ -6328,6 +6417,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "^0.10.35",
@@ -6338,6 +6428,7 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
             "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "~0.10.14",
@@ -6366,6 +6457,7 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
             "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "~0.10.14",
@@ -6378,6 +6470,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "~0.10.14"
@@ -6387,6 +6480,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
             "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "^0.10.46",
@@ -6403,12 +6497,14 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
         },
         "escope": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
             "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+            "dev": true,
             "requires": {
                 "es6-map": "^0.1.3",
                 "es6-weak-map": "^2.0.1",
@@ -6426,6 +6522,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
             "requires": {
                 "estraverse": "^4.1.0"
             }
@@ -6433,7 +6530,8 @@
         "estraverse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true
         },
         "esutils": {
             "version": "2.0.2",
@@ -6484,6 +6582,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
             "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
+            "dev": true,
             "requires": {
                 "js-sha3": "^0.8.0"
             },
@@ -6491,7 +6590,8 @@
                 "js-sha3": {
                     "version": "0.8.0",
                     "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-                    "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+                    "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+                    "dev": true
                 }
             }
         },
@@ -6505,6 +6605,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.3.tgz",
             "integrity": "sha512-lAxxsxDKK69Wuwqym2K49VpXtBvLEsXr1sryNG4AkvL5DomMdeCBbu3D87UEevKenLHBiT8GTjARwN6Yj039gA==",
+            "dev": true,
             "requires": {
                 "webpack": "^3.0.0"
             }
@@ -6631,6 +6732,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
             "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+            "dev": true,
             "requires": {
                 "bn.js": "4.11.6",
                 "number-to-bn": "1.7.0"
@@ -6639,12 +6741,14 @@
                 "bn.js": {
                     "version": "4.11.6",
                     "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+                    "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                    "dev": true
                 },
                 "number-to-bn": {
                     "version": "1.7.0",
                     "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
                     "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
                     "requires": {
                         "bn.js": "4.11.6",
                         "strip-hex-prefix": "1.0.0"
@@ -6666,6 +6770,7 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true,
             "requires": {
                 "d": "1",
                 "es5-ext": "~0.10.14"
@@ -6687,6 +6792,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
             "requires": {
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
@@ -6758,6 +6864,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "dev": true,
             "requires": {
                 "debug": "^2.3.3",
                 "define-property": "^0.2.5",
@@ -6772,6 +6879,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -6780,6 +6888,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6857,6 +6966,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
             "requires": {
                 "assign-symbols": "^1.0.0",
                 "is-extendable": "^1.0.1"
@@ -6866,6 +6976,7 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -6876,6 +6987,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "dev": true,
             "requires": {
                 "array-unique": "^0.3.2",
                 "define-property": "^1.0.0",
@@ -6891,6 +7003,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -6899,6 +7012,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6907,6 +7021,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -6915,6 +7030,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -6923,6 +7039,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -7002,7 +7119,8 @@
         "fast-deep-equal": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "dev": true
         },
         "fast-glob": {
             "version": "2.2.7",
@@ -7021,7 +7139,8 @@
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
         },
         "fastq": {
             "version": "1.6.0",
@@ -7072,6 +7191,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -7083,6 +7203,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -7137,6 +7258,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
             "requires": {
                 "path-exists": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
@@ -7236,6 +7358,7 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
             "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dev": true,
             "requires": {
                 "is-callable": "^1.1.3"
             }
@@ -7243,7 +7366,8 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
         },
         "for-own": {
             "version": "1.0.0",
@@ -7303,6 +7427,7 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
             }
@@ -7374,12 +7499,14 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
             "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+            "dev": true,
             "optional": true,
             "requires": {
                 "nan": "^2.12.1",
@@ -7390,24 +7517,28 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
                     "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                    "dev": true,
                     "optional": true
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true,
                     "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
                     "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                    "dev": true,
                     "optional": true
                 },
                 "are-we-there-yet": {
                     "version": "1.1.5",
                     "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
                     "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "delegates": "^1.0.0",
@@ -7418,12 +7549,14 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                    "dev": true,
                     "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
@@ -7434,36 +7567,42 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
                     "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+                    "dev": true,
                     "optional": true
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                    "dev": true,
                     "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                    "dev": true,
                     "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                     "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                    "dev": true,
                     "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                     "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "dev": true,
                     "optional": true
                 },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -7473,24 +7612,28 @@
                     "version": "0.6.0",
                     "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
                     "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                    "dev": true,
                     "optional": true
                 },
                 "delegates": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
                     "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                    "dev": true,
                     "optional": true
                 },
                 "detect-libc": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
                     "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                    "dev": true,
                     "optional": true
                 },
                 "fs-minipass": {
                     "version": "1.2.5",
                     "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
                     "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -7500,12 +7643,14 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                    "dev": true,
                     "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
                     "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "aproba": "^1.0.3",
@@ -7522,6 +7667,7 @@
                     "version": "7.1.3",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -7536,12 +7682,14 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
                     "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                    "dev": true,
                     "optional": true
                 },
                 "iconv-lite": {
                     "version": "0.4.24",
                     "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
@@ -7551,6 +7699,7 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
                     "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimatch": "^3.0.4"
@@ -7560,6 +7709,7 @@
                     "version": "1.0.6",
                     "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "once": "^1.3.0",
@@ -7570,18 +7720,21 @@
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true,
                     "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
                     "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
                     "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                    "dev": true,
                     "optional": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
@@ -7591,12 +7744,14 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true,
                     "optional": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
@@ -7606,12 +7761,14 @@
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true,
                     "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
@@ -7622,6 +7779,7 @@
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
                     "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minipass": "^2.2.1"
@@ -7631,6 +7789,7 @@
                     "version": "0.5.1",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
@@ -7640,12 +7799,14 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true,
                     "optional": true
                 },
                 "needle": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
                     "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "debug": "^4.1.0",
@@ -7657,6 +7818,7 @@
                     "version": "0.12.0",
                     "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
                     "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
@@ -7675,6 +7837,7 @@
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
                     "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "abbrev": "1",
@@ -7685,12 +7848,14 @@
                     "version": "1.0.6",
                     "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
                     "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
+                    "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.4.1",
                     "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
                     "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
@@ -7701,6 +7866,7 @@
                     "version": "4.1.2",
                     "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
                     "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "are-we-there-yet": "~1.1.2",
@@ -7713,18 +7879,21 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                    "dev": true,
                     "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true,
                     "optional": true
                 },
                 "once": {
                     "version": "1.4.0",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "wrappy": "1"
@@ -7734,18 +7903,21 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                     "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                    "dev": true,
                     "optional": true
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                     "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                    "dev": true,
                     "optional": true
                 },
                 "osenv": {
                     "version": "0.1.5",
                     "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
                     "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "os-homedir": "^1.0.0",
@@ -7756,18 +7928,21 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                    "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
                     "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+                    "dev": true,
                     "optional": true
                 },
                 "rc": {
                     "version": "1.2.8",
                     "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
                     "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "deep-extend": "^0.6.0",
@@ -7780,6 +7955,7 @@
                             "version": "1.2.0",
                             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                            "dev": true,
                             "optional": true
                         }
                     }
@@ -7788,6 +7964,7 @@
                     "version": "2.3.6",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -7803,6 +7980,7 @@
                     "version": "2.6.3",
                     "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "glob": "^7.1.3"
@@ -7812,42 +7990,49 @@
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true,
                     "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
                     "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                    "dev": true,
                     "optional": true
                 },
                 "sax": {
                     "version": "1.2.4",
                     "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                    "dev": true,
                     "optional": true
                 },
                 "semver": {
                     "version": "5.7.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
                     "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                    "dev": true,
                     "optional": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
                     "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                    "dev": true,
                     "optional": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
                     "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                    "dev": true,
                     "optional": true
                 },
                 "string-width": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
@@ -7859,6 +8044,7 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -7868,6 +8054,7 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
@@ -7877,12 +8064,14 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
                     "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                    "dev": true,
                     "optional": true
                 },
                 "tar": {
                     "version": "4.4.8",
                     "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
                     "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "chownr": "^1.1.1",
@@ -7898,12 +8087,14 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                     "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                    "dev": true,
                     "optional": true
                 },
                 "wide-align": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
                     "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+                    "dev": true,
                     "optional": true,
                     "requires": {
                         "string-width": "^1.0.2 || 2"
@@ -7913,12 +8104,14 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                    "dev": true,
                     "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
                     "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+                    "dev": true,
                     "optional": true
                 }
             }
@@ -7938,12 +8131,14 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
         },
         "ganache-cli": {
             "version": "6.7.0",
             "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.7.0.tgz",
             "integrity": "sha512-9CZsClo9hl5MxGL7hkk14mie89Q94P0idh92jcV7LmppTYTCG7SHatuwcfqN7emFHArMt3fneN4QbH2do2N6Ow==",
+            "dev": true,
             "requires": {
                 "ethereumjs-util": "6.1.0",
                 "source-map-support": "0.5.12",
@@ -7953,12 +8148,14 @@
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": false,
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
                 },
                 "ansi-styles": {
                     "version": "3.2.1",
                     "resolved": false,
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
                     "requires": {
                         "color-convert": "^1.9.0"
                     }
@@ -7967,6 +8164,7 @@
                     "version": "1.5.0",
                     "resolved": false,
                     "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+                    "dev": true,
                     "requires": {
                         "file-uri-to-path": "1.0.0"
                     }
@@ -7975,6 +8173,7 @@
                     "version": "1.1.5",
                     "resolved": false,
                     "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "^5.0.1"
                     }
@@ -7982,17 +8181,20 @@
                 "bn.js": {
                     "version": "4.11.8",
                     "resolved": false,
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+                    "dev": true
                 },
                 "brorand": {
                     "version": "1.1.0",
                     "resolved": false,
-                    "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+                    "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+                    "dev": true
                 },
                 "browserify-aes": {
                     "version": "1.2.0",
                     "resolved": false,
                     "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+                    "dev": true,
                     "requires": {
                         "buffer-xor": "^1.0.3",
                         "cipher-base": "^1.0.0",
@@ -8005,22 +8207,26 @@
                 "buffer-from": {
                     "version": "1.1.1",
                     "resolved": false,
-                    "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+                    "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+                    "dev": true
                 },
                 "buffer-xor": {
                     "version": "1.0.3",
                     "resolved": false,
-                    "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+                    "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+                    "dev": true
                 },
                 "camelcase": {
                     "version": "5.3.1",
                     "resolved": false,
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
                 },
                 "cipher-base": {
                     "version": "1.0.4",
                     "resolved": false,
                     "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.1",
                         "safe-buffer": "^5.0.1"
@@ -8030,6 +8236,7 @@
                     "version": "5.0.0",
                     "resolved": false,
                     "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
                     "requires": {
                         "string-width": "^3.1.0",
                         "strip-ansi": "^5.2.0",
@@ -8040,6 +8247,7 @@
                     "version": "1.9.3",
                     "resolved": false,
                     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
                     "requires": {
                         "color-name": "1.1.3"
                     }
@@ -8047,12 +8255,14 @@
                 "color-name": {
                     "version": "1.1.3",
                     "resolved": false,
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
                 },
                 "create-hash": {
                     "version": "1.2.0",
                     "resolved": false,
                     "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+                    "dev": true,
                     "requires": {
                         "cipher-base": "^1.0.1",
                         "inherits": "^2.0.1",
@@ -8065,6 +8275,7 @@
                     "version": "1.1.7",
                     "resolved": false,
                     "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+                    "dev": true,
                     "requires": {
                         "cipher-base": "^1.0.3",
                         "create-hash": "^1.1.0",
@@ -8078,6 +8289,7 @@
                     "version": "6.0.5",
                     "resolved": false,
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
                     "requires": {
                         "nice-try": "^1.0.4",
                         "path-key": "^2.0.1",
@@ -8089,12 +8301,14 @@
                 "decamelize": {
                     "version": "1.2.0",
                     "resolved": false,
-                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                    "dev": true
                 },
                 "drbg.js": {
                     "version": "1.0.1",
                     "resolved": false,
                     "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+                    "dev": true,
                     "requires": {
                         "browserify-aes": "^1.0.6",
                         "create-hash": "^1.1.2",
@@ -8105,6 +8319,7 @@
                     "version": "6.5.0",
                     "resolved": false,
                     "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+                    "dev": true,
                     "requires": {
                         "bn.js": "^4.4.0",
                         "brorand": "^1.0.1",
@@ -8118,12 +8333,14 @@
                 "emoji-regex": {
                     "version": "7.0.3",
                     "resolved": false,
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+                    "dev": true
                 },
                 "end-of-stream": {
                     "version": "1.4.1",
                     "resolved": false,
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+                    "dev": true,
                     "requires": {
                         "once": "^1.4.0"
                     }
@@ -8132,6 +8349,7 @@
                     "version": "6.1.0",
                     "resolved": false,
                     "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+                    "dev": true,
                     "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
@@ -8146,6 +8364,7 @@
                     "version": "0.1.6",
                     "resolved": false,
                     "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+                    "dev": true,
                     "requires": {
                         "is-hex-prefixed": "1.0.0",
                         "strip-hex-prefix": "1.0.0"
@@ -8155,6 +8374,7 @@
                     "version": "1.0.3",
                     "resolved": false,
                     "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+                    "dev": true,
                     "requires": {
                         "md5.js": "^1.3.4",
                         "safe-buffer": "^5.1.1"
@@ -8164,6 +8384,7 @@
                     "version": "1.0.0",
                     "resolved": false,
                     "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+                    "dev": true,
                     "requires": {
                         "cross-spawn": "^6.0.0",
                         "get-stream": "^4.0.0",
@@ -8177,12 +8398,14 @@
                 "file-uri-to-path": {
                     "version": "1.0.0",
                     "resolved": false,
-                    "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+                    "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+                    "dev": true
                 },
                 "find-up": {
                     "version": "3.0.0",
                     "resolved": false,
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
                     "requires": {
                         "locate-path": "^3.0.0"
                     }
@@ -8190,12 +8413,14 @@
                 "get-caller-file": {
                     "version": "2.0.5",
                     "resolved": false,
-                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+                    "dev": true
                 },
                 "get-stream": {
                     "version": "4.1.0",
                     "resolved": false,
                     "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
                     }
@@ -8204,6 +8429,7 @@
                     "version": "3.0.4",
                     "resolved": false,
                     "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.1",
                         "safe-buffer": "^5.0.1"
@@ -8213,6 +8439,7 @@
                     "version": "1.1.7",
                     "resolved": false,
                     "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "minimalistic-assert": "^1.0.1"
@@ -8222,6 +8449,7 @@
                     "version": "1.0.1",
                     "resolved": false,
                     "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+                    "dev": true,
                     "requires": {
                         "hash.js": "^1.0.3",
                         "minimalistic-assert": "^1.0.0",
@@ -8231,37 +8459,44 @@
                 "inherits": {
                     "version": "2.0.4",
                     "resolved": false,
-                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
                 },
                 "invert-kv": {
                     "version": "2.0.0",
                     "resolved": false,
-                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": false,
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
                 },
                 "is-hex-prefixed": {
                     "version": "1.0.0",
                     "resolved": false,
-                    "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+                    "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+                    "dev": true
                 },
                 "is-stream": {
                     "version": "1.1.0",
                     "resolved": false,
-                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+                    "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                    "dev": true
                 },
                 "isexe": {
                     "version": "2.0.0",
                     "resolved": false,
-                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+                    "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+                    "dev": true
                 },
                 "keccak": {
                     "version": "1.4.0",
                     "resolved": false,
                     "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+                    "dev": true,
                     "requires": {
                         "bindings": "^1.2.1",
                         "inherits": "^2.0.3",
@@ -8273,6 +8508,7 @@
                     "version": "2.0.0",
                     "resolved": false,
                     "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+                    "dev": true,
                     "requires": {
                         "invert-kv": "^2.0.0"
                     }
@@ -8281,6 +8517,7 @@
                     "version": "3.0.0",
                     "resolved": false,
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
                     "requires": {
                         "p-locate": "^3.0.0",
                         "path-exists": "^3.0.0"
@@ -8290,6 +8527,7 @@
                     "version": "0.1.3",
                     "resolved": false,
                     "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+                    "dev": true,
                     "requires": {
                         "p-defer": "^1.0.0"
                     }
@@ -8298,6 +8536,7 @@
                     "version": "1.3.5",
                     "resolved": false,
                     "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+                    "dev": true,
                     "requires": {
                         "hash-base": "^3.0.0",
                         "inherits": "^2.0.1",
@@ -8308,6 +8547,7 @@
                     "version": "4.3.0",
                     "resolved": false,
                     "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+                    "dev": true,
                     "requires": {
                         "map-age-cleaner": "^0.1.1",
                         "mimic-fn": "^2.0.0",
@@ -8317,32 +8557,38 @@
                 "mimic-fn": {
                     "version": "2.1.0",
                     "resolved": false,
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+                    "dev": true
                 },
                 "minimalistic-assert": {
                     "version": "1.0.1",
                     "resolved": false,
-                    "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+                    "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+                    "dev": true
                 },
                 "minimalistic-crypto-utils": {
                     "version": "1.0.1",
                     "resolved": false,
-                    "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+                    "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+                    "dev": true
                 },
                 "nan": {
                     "version": "2.14.0",
                     "resolved": false,
-                    "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+                    "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+                    "dev": true
                 },
                 "nice-try": {
                     "version": "1.0.5",
                     "resolved": false,
-                    "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+                    "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+                    "dev": true
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
                     "resolved": false,
                     "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+                    "dev": true,
                     "requires": {
                         "path-key": "^2.0.0"
                     }
@@ -8351,6 +8597,7 @@
                     "version": "1.4.0",
                     "resolved": false,
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "dev": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -8359,6 +8606,7 @@
                     "version": "3.1.0",
                     "resolved": false,
                     "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+                    "dev": true,
                     "requires": {
                         "execa": "^1.0.0",
                         "lcid": "^2.0.0",
@@ -8368,22 +8616,26 @@
                 "p-defer": {
                     "version": "1.0.0",
                     "resolved": false,
-                    "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+                    "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+                    "dev": true
                 },
                 "p-finally": {
                     "version": "1.0.0",
                     "resolved": false,
-                    "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+                    "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+                    "dev": true
                 },
                 "p-is-promise": {
                     "version": "2.1.0",
                     "resolved": false,
-                    "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+                    "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+                    "dev": true
                 },
                 "p-limit": {
                     "version": "2.2.0",
                     "resolved": false,
                     "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
                     }
@@ -8392,6 +8644,7 @@
                     "version": "3.0.0",
                     "resolved": false,
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
                     "requires": {
                         "p-limit": "^2.0.0"
                     }
@@ -8399,22 +8652,26 @@
                 "p-try": {
                     "version": "2.2.0",
                     "resolved": false,
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
                 },
                 "path-exists": {
                     "version": "3.0.0",
                     "resolved": false,
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
                 },
                 "path-key": {
                     "version": "2.0.1",
                     "resolved": false,
-                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                    "dev": true
                 },
                 "pump": {
                     "version": "3.0.0",
                     "resolved": false,
                     "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
                     "requires": {
                         "end-of-stream": "^1.1.0",
                         "once": "^1.3.1"
@@ -8423,17 +8680,20 @@
                 "require-directory": {
                     "version": "2.1.1",
                     "resolved": false,
-                    "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+                    "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+                    "dev": true
                 },
                 "require-main-filename": {
                     "version": "2.0.0",
                     "resolved": false,
-                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                    "dev": true
                 },
                 "ripemd160": {
                     "version": "2.0.2",
                     "resolved": false,
                     "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+                    "dev": true,
                     "requires": {
                         "hash-base": "^3.0.0",
                         "inherits": "^2.0.1"
@@ -8443,6 +8703,7 @@
                     "version": "2.2.3",
                     "resolved": false,
                     "integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
+                    "dev": true,
                     "requires": {
                         "bn.js": "^4.11.1",
                         "safe-buffer": "^5.1.1"
@@ -8451,12 +8712,14 @@
                 "safe-buffer": {
                     "version": "5.2.0",
                     "resolved": false,
-                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+                    "dev": true
                 },
                 "secp256k1": {
                     "version": "3.7.1",
                     "resolved": false,
                     "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+                    "dev": true,
                     "requires": {
                         "bindings": "^1.5.0",
                         "bip66": "^1.1.5",
@@ -8471,17 +8734,20 @@
                 "semver": {
                     "version": "5.7.0",
                     "resolved": false,
-                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+                    "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+                    "dev": true
                 },
                 "set-blocking": {
                     "version": "2.0.0",
                     "resolved": false,
-                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+                    "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                    "dev": true
                 },
                 "sha.js": {
                     "version": "2.4.11",
                     "resolved": false,
                     "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.1",
                         "safe-buffer": "^5.0.1"
@@ -8491,6 +8757,7 @@
                     "version": "1.2.0",
                     "resolved": false,
                     "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                    "dev": true,
                     "requires": {
                         "shebang-regex": "^1.0.0"
                     }
@@ -8498,22 +8765,26 @@
                 "shebang-regex": {
                     "version": "1.0.0",
                     "resolved": false,
-                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+                    "dev": true
                 },
                 "signal-exit": {
                     "version": "3.0.2",
                     "resolved": false,
-                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+                    "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": false,
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 },
                 "source-map-support": {
                     "version": "0.5.12",
                     "resolved": false,
                     "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+                    "dev": true,
                     "requires": {
                         "buffer-from": "^1.0.0",
                         "source-map": "^0.6.0"
@@ -8523,6 +8794,7 @@
                     "version": "3.1.0",
                     "resolved": false,
                     "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
                     "requires": {
                         "emoji-regex": "^7.0.1",
                         "is-fullwidth-code-point": "^2.0.0",
@@ -8533,6 +8805,7 @@
                     "version": "5.2.0",
                     "resolved": false,
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }
@@ -8540,12 +8813,14 @@
                 "strip-eof": {
                     "version": "1.0.0",
                     "resolved": false,
-                    "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+                    "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+                    "dev": true
                 },
                 "strip-hex-prefix": {
                     "version": "1.0.0",
                     "resolved": false,
                     "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+                    "dev": true,
                     "requires": {
                         "is-hex-prefixed": "1.0.0"
                     }
@@ -8554,6 +8829,7 @@
                     "version": "1.3.1",
                     "resolved": false,
                     "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "dev": true,
                     "requires": {
                         "isexe": "^2.0.0"
                     }
@@ -8561,12 +8837,14 @@
                 "which-module": {
                     "version": "2.0.0",
                     "resolved": false,
-                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
                 },
                 "wrap-ansi": {
                     "version": "5.1.0",
                     "resolved": false,
                     "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^3.2.0",
                         "string-width": "^3.0.0",
@@ -8576,17 +8854,20 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "resolved": false,
-                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                    "dev": true
                 },
                 "y18n": {
                     "version": "4.0.0",
                     "resolved": false,
-                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "13.2.4",
                     "resolved": false,
                     "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
+                    "dev": true,
                     "requires": {
                         "cliui": "^5.0.0",
                         "find-up": "^3.0.0",
@@ -8605,6 +8886,7 @@
                     "version": "13.1.1",
                     "resolved": false,
                     "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+                    "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",
                         "decamelize": "^1.2.0"
@@ -8643,7 +8925,8 @@
         "get-caller-file": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+            "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+            "dev": true
         },
         "get-func-name": {
             "version": "2.0.0",
@@ -8755,12 +9038,14 @@
         "get-stream": {
             "version": "3.0.0",
             "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
         },
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
         },
         "geth-dev-assistant": {
             "version": "0.1.3",
@@ -9044,6 +9329,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -9057,6 +9343,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
             "requires": {
                 "is-glob": "^3.1.0",
                 "path-dirname": "^1.0.0"
@@ -9066,6 +9353,7 @@
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                    "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.0"
                     }
@@ -9114,6 +9402,7 @@
             "version": "4.3.2",
             "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
             "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+            "dev": true,
             "requires": {
                 "min-document": "^2.19.0",
                 "process": "~0.5.1"
@@ -9122,7 +9411,8 @@
                 "process": {
                     "version": "0.5.2",
                     "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-                    "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+                    "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
+                    "dev": true
                 }
             }
         },
@@ -9189,7 +9479,8 @@
         "graceful-fs": {
             "version": "4.1.15",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+            "dev": true
         },
         "graceful-readlink": {
             "version": "1.0.1",
@@ -9200,7 +9491,8 @@
         "growl": {
             "version": "1.10.5",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
         },
         "gulp": {
             "version": "4.0.2",
@@ -9422,6 +9714,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
             }
@@ -9452,7 +9745,8 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
         },
         "has-gulplog": {
             "version": "0.1.0",
@@ -9472,7 +9766,8 @@
         "has-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
         },
         "has-to-string-tag-x": {
             "version": "1.4.1",
@@ -9493,6 +9788,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
@@ -9503,6 +9799,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "kind-of": "^4.0.0"
@@ -9512,6 +9809,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -9522,6 +9820,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -9531,6 +9830,7 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.1"
@@ -9561,6 +9861,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
             "requires": {
                 "hash.js": "^1.0.3",
                 "minimalistic-assert": "^1.0.0",
@@ -9579,7 +9880,8 @@
         "hosted-git-info": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "dev": true
         },
         "htmlescape": {
             "version": "1.1.1",
@@ -9705,7 +10007,8 @@
         "https-browserify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
         },
         "https-proxy-agent": {
             "version": "2.2.3",
@@ -9762,6 +10065,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/idna-uts46/-/idna-uts46-1.1.0.tgz",
             "integrity": "sha1-vgmLK3wcq/vvh6i4D2JvrDc2auo=",
+            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             },
@@ -9769,7 +10073,8 @@
                 "punycode": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
                 }
             }
         },
@@ -9793,7 +10098,8 @@
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
         },
         "iferr": {
             "version": "0.1.5",
@@ -9885,6 +10191,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -9893,7 +10200,8 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
         },
         "ini": {
             "version": "1.3.5",
@@ -10051,7 +10359,8 @@
         "interpret": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+            "dev": true
         },
         "invariant": {
             "version": "2.2.4",
@@ -10065,7 +10374,8 @@
         "invert-kv": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
         },
         "ip": {
             "version": "1.1.5",
@@ -10093,6 +10403,7 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -10101,6 +10412,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -10116,12 +10428,14 @@
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
         },
         "is-binary-path": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "dev": true,
             "requires": {
                 "binary-extensions": "^1.0.0"
             }
@@ -10129,12 +10443,14 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
         },
         "is-builtin-module": {
             "version": "1.0.0",
             "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true,
             "requires": {
                 "builtin-modules": "^1.0.0"
             }
@@ -10142,7 +10458,8 @@
         "is-callable": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+            "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+            "dev": true
         },
         "is-ci": {
             "version": "2.0.0",
@@ -10157,6 +10474,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -10165,6 +10483,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -10174,12 +10493,14 @@
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+            "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+            "dev": true
         },
         "is-descriptor": {
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -10189,7 +10510,8 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
                 }
             }
         },
@@ -10208,12 +10530,14 @@
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
         },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
         },
         "is-finite": {
             "version": "1.0.2",
@@ -10228,6 +10552,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -10235,12 +10560,14 @@
         "is-function": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-            "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+            "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+            "dev": true
         },
         "is-glob": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -10248,7 +10575,8 @@
         "is-hex-prefixed": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-            "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+            "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+            "dev": true
         },
         "is-natural-number": {
             "version": "4.0.1",
@@ -10266,6 +10594,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -10274,6 +10603,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -10326,6 +10656,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -10340,6 +10671,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+            "dev": true,
             "requires": {
                 "has": "^1.0.1"
             }
@@ -10371,12 +10703,14 @@
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
         },
         "is-symbol": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.0"
             }
@@ -10408,7 +10742,8 @@
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
         },
         "is-valid-glob": {
             "version": "1.0.0",
@@ -10419,7 +10754,8 @@
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
         },
         "is-wsl": {
             "version": "2.1.1",
@@ -10430,7 +10766,8 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
         },
         "isbinaryfile": {
             "version": "3.0.3",
@@ -10444,12 +10781,14 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
         },
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
         },
         "isstream": {
             "version": "0.1.2",
@@ -10549,7 +10888,8 @@
         "json-loader": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-            "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+            "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+            "dev": true
         },
         "json-parse-better-errors": {
             "version": "1.0.2",
@@ -10566,7 +10906,8 @@
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "json-stable-stringify": {
             "version": "0.0.1",
@@ -10874,12 +11215,14 @@
         "kind-of": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "dev": true
         },
         "klaw": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
             "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.9"
             }
@@ -10907,7 +11250,8 @@
         "lazy-cache": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true
         },
         "lazystream": {
             "version": "1.0.0",
@@ -10922,6 +11266,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true,
             "requires": {
                 "invert-kv": "^1.0.0"
             }
@@ -10986,6 +11331,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^2.2.0",
@@ -11005,12 +11351,14 @@
         "loader-runner": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-            "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
+            "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+            "dev": true
         },
         "loader-utils": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
             "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+            "dev": true,
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^2.0.0",
@@ -11021,6 +11369,7 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "dev": true,
                     "requires": {
                         "minimist": "^1.2.0"
                     }
@@ -11031,6 +11380,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
             "requires": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -11039,14 +11389,16 @@
                 "path-exists": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
                 }
             }
         },
         "lodash": {
             "version": "4.17.15",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "dev": true
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
@@ -11057,7 +11409,8 @@
         "lodash.assign": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+            "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+            "dev": true
         },
         "lodash.clonedeep": {
             "version": "4.5.0",
@@ -11192,7 +11545,8 @@
         "longest": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -11223,6 +11577,7 @@
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
             "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dev": true,
             "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -11321,7 +11676,8 @@
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
         },
         "map-obj": {
             "version": "2.0.0",
@@ -11333,6 +11689,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
             }
@@ -11376,6 +11733,7 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "dev": true,
             "requires": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1",
@@ -11392,6 +11750,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
             }
@@ -11400,6 +11759,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+            "dev": true,
             "requires": {
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
@@ -11408,7 +11768,8 @@
         "memorystream": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-            "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
+            "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+            "dev": true
         },
         "meow": {
             "version": "4.0.1",
@@ -11535,6 +11896,7 @@
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -11555,6 +11917,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.0.0",
                 "brorand": "^1.0.1"
@@ -11584,17 +11947,20 @@
         "mimic-fn": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
         },
         "mimic-response": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+            "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+            "dev": true
         },
         "min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
             "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "dev": true,
             "requires": {
                 "dom-walk": "^0.1.0"
             }
@@ -11602,17 +11968,20 @@
         "minimalistic-assert": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
         },
         "minimalistic-crypto-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -11620,7 +11989,8 @@
         "minimist": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
         },
         "minimist-options": {
             "version": "3.0.2",
@@ -11693,6 +12063,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -11702,6 +12073,7 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -11712,6 +12084,7 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             },
@@ -11719,7 +12092,8 @@
                 "minimist": {
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
                 }
             }
         },
@@ -12058,7 +12432,8 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "multimatch": {
             "version": "3.0.0",
@@ -12098,7 +12473,8 @@
         "nan": {
             "version": "2.14.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+            "dev": true
         },
         "nano-json-stream-parser": {
             "version": "0.1.2",
@@ -12110,6 +12486,7 @@
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -12145,7 +12522,8 @@
         "neo-async": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+            "dev": true
         },
         "nested-error-stacks": {
             "version": "2.1.0",
@@ -12162,7 +12540,8 @@
         "next-tick": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+            "dev": true
         },
         "nice-try": {
             "version": "1.0.5",
@@ -12254,6 +12633,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
             "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+            "dev": true,
             "requires": {
                 "assert": "^1.1.1",
                 "browserify-zlib": "^0.2.0",
@@ -12284,6 +12664,7 @@
                     "version": "4.9.2",
                     "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
                     "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+                    "dev": true,
                     "requires": {
                         "base64-js": "^1.0.2",
                         "ieee754": "^1.1.4",
@@ -12293,12 +12674,14 @@
                 "events": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
-                    "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
+                    "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
+                    "dev": true
                 },
                 "stream-http": {
                     "version": "2.8.3",
                     "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
                     "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+                    "dev": true,
                     "requires": {
                         "builtin-status-codes": "^3.0.0",
                         "inherits": "^2.0.1",
@@ -12311,6 +12694,7 @@
                     "version": "2.0.11",
                     "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
                     "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+                    "dev": true,
                     "requires": {
                         "setimmediate": "^1.0.4"
                     }
@@ -12318,12 +12702,14 @@
                 "tty-browserify": {
                     "version": "0.0.0",
                     "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-                    "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+                    "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+                    "dev": true
                 },
                 "util": {
                     "version": "0.11.1",
                     "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
                     "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+                    "dev": true,
                     "requires": {
                         "inherits": "2.0.3"
                     }
@@ -12366,6 +12752,7 @@
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
                 "is-builtin-module": "^1.0.0",
@@ -12377,6 +12764,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
             "requires": {
                 "remove-trailing-separator": "^1.0.1"
             }
@@ -12455,6 +12843,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
             "requires": {
                 "path-key": "^2.0.0"
             }
@@ -12474,7 +12863,8 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
         },
         "number-to-bn": {
             "version": "1.1.0",
@@ -12871,7 +13261,8 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
         },
         "object-component": {
             "version": "0.0.3",
@@ -12883,6 +13274,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
             "requires": {
                 "copy-descriptor": "^0.1.0",
                 "define-property": "^0.2.5",
@@ -12893,6 +13285,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -12901,6 +13294,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -12916,12 +13310,14 @@
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
         },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
             }
@@ -12974,6 +13370,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -13016,6 +13413,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -13065,12 +13463,14 @@
         "original-require": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
-            "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA="
+            "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA=",
+            "dev": true
         },
         "os-browserify": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
         },
         "os-homedir": {
             "version": "1.0.2",
@@ -13082,6 +13482,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true,
             "requires": {
                 "lcid": "^1.0.0"
             }
@@ -13127,12 +13528,14 @@
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
         },
         "p-limit": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "dev": true,
             "requires": {
                 "p-try": "^1.0.0"
             }
@@ -13141,6 +13544,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
             "requires": {
                 "p-limit": "^1.1.0"
             }
@@ -13193,7 +13597,8 @@
         "p-try": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
         },
         "p-waterfall": {
             "version": "1.0.0",
@@ -13219,7 +13624,8 @@
         "pako": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-            "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
+            "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+            "dev": true
         },
         "parallel-transform": {
             "version": "1.2.0",
@@ -13245,6 +13651,7 @@
             "version": "5.1.4",
             "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
             "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+            "dev": true,
             "requires": {
                 "asn1.js": "^4.0.0",
                 "browserify-aes": "^1.0.0",
@@ -13275,6 +13682,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
             "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
+            "dev": true,
             "requires": {
                 "for-each": "^0.3.3",
                 "string.prototype.trim": "^1.1.2"
@@ -13284,6 +13692,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
             "requires": {
                 "error-ex": "^1.2.0"
             }
@@ -13357,22 +13766,26 @@
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
         },
         "path-browserify": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+            "dev": true
         },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
         },
         "path-exists": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
             "requires": {
                 "pinkie-promise": "^2.0.0"
             }
@@ -13380,7 +13793,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -13391,7 +13805,8 @@
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
         },
         "path-parse": {
             "version": "1.0.6",
@@ -13430,6 +13845,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "pify": "^2.0.0",
@@ -13439,7 +13855,8 @@
                 "pify": {
                     "version": "2.3.0",
                     "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
@@ -13453,6 +13870,7 @@
             "version": "3.0.17",
             "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
             "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+            "dev": true,
             "requires": {
                 "create-hash": "^1.1.2",
                 "create-hmac": "^1.1.4",
@@ -13488,12 +13906,14 @@
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -13637,7 +14057,8 @@
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
         },
         "prebuild-install": {
             "version": "5.3.3",
@@ -13758,12 +14179,14 @@
         "process": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
         },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
         },
         "progress": {
             "version": "2.0.3",
@@ -13849,12 +14272,14 @@
         "prr": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true
         },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
         },
         "psl": {
             "version": "1.1.32",
@@ -13866,6 +14291,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
             "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "dev": true,
             "requires": {
                 "bn.js": "^4.1.0",
                 "browserify-rsa": "^4.0.0",
@@ -13899,7 +14325,8 @@
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
         },
         "puppeteer": {
             "version": "1.20.0",
@@ -13971,6 +14398,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
             "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+            "dev": true,
             "requires": {
                 "decode-uri-component": "^0.2.0",
                 "object-assign": "^4.1.0",
@@ -13980,12 +14408,14 @@
         "querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
         },
         "querystring-es3": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
         },
         "quick-lru": {
             "version": "1.1.0",
@@ -13997,6 +14427,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
             }
@@ -14005,6 +14436,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
             "requires": {
                 "randombytes": "^2.0.5",
                 "safe-buffer": "^5.1.0"
@@ -14124,6 +14556,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
             "requires": {
                 "load-json-file": "^1.0.0",
                 "normalize-package-data": "^2.3.2",
@@ -14134,6 +14567,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
             "requires": {
                 "find-up": "^1.0.0",
                 "read-pkg": "^1.0.0"
@@ -14143,6 +14577,7 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -14157,6 +14592,7 @@
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -14179,6 +14615,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
             "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "micromatch": "^3.1.10",
@@ -14222,8 +14659,7 @@
         "regenerator-runtime": {
             "version": "0.13.3",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-            "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-            "dev": true
+            "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         },
         "regenerator-transform": {
             "version": "0.14.1",
@@ -14238,6 +14674,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
@@ -14322,17 +14759,20 @@
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
         },
         "repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "dev": true
         },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
         },
         "repeating": {
             "version": "2.0.1",
@@ -14402,12 +14842,14 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
         },
         "require-from-string": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-            "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg="
+            "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+            "dev": true
         },
         "require-like": {
             "version": "0.1.2",
@@ -14418,7 +14860,8 @@
         "require-main-filename": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
         },
         "requires-port": {
             "version": "1.0.0",
@@ -14480,7 +14923,8 @@
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
         },
         "responselike": {
             "version": "1.0.2",
@@ -14504,7 +14948,8 @@
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
         },
         "retry": {
             "version": "0.10.1",
@@ -14534,6 +14979,7 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
             "requires": {
                 "align-text": "^0.1.1"
             }
@@ -14542,6 +14988,7 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
             "requires": {
                 "glob": "^7.0.5"
             }
@@ -14550,6 +14997,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
             "requires": {
                 "hash-base": "^3.0.0",
                 "inherits": "^2.0.1"
@@ -14601,12 +15049,14 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "safe-regex": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
@@ -14703,7 +15153,8 @@
         "semver": {
             "version": "5.6.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "dev": true
         },
         "semver-greatest-satisfied-range": {
             "version": "1.1.0",
@@ -14771,12 +15222,14 @@
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
         },
         "set-value": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
             "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -14788,6 +15241,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -14797,7 +15251,8 @@
         "setimmediate": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-            "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+            "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+            "dev": true
         },
         "setprototypeof": {
             "version": "1.1.1",
@@ -14809,6 +15264,7 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -14845,6 +15301,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -14852,7 +15309,8 @@
         "shebang-regex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "shell-quote": {
             "version": "1.7.2",
@@ -14869,17 +15327,20 @@
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
         },
         "simple-concat": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+            "dev": true
         },
         "simple-get": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
             "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+            "dev": true,
             "requires": {
                 "decompress-response": "^3.3.0",
                 "once": "^1.3.1",
@@ -14908,6 +15369,7 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
             "requires": {
                 "base": "^0.11.1",
                 "debug": "^2.2.0",
@@ -14923,6 +15385,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -14931,6 +15394,7 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -14941,6 +15405,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
@@ -14951,6 +15416,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -14959,6 +15425,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -14967,6 +15434,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -14975,6 +15443,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -14987,6 +15456,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
             },
@@ -14995,6 +15465,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -15140,6 +15611,7 @@
             "version": "0.4.26",
             "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.26.tgz",
             "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
+            "dev": true,
             "requires": {
                 "fs-extra": "^0.30.0",
                 "memorystream": "^0.3.1",
@@ -15152,6 +15624,7 @@
                     "version": "0.30.0",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
                     "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "jsonfile": "^2.1.0",
@@ -15164,6 +15637,7 @@
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.6"
                     }
@@ -15171,12 +15645,14 @@
                 "window-size": {
                     "version": "0.2.0",
                     "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-                    "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+                    "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "4.8.1",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
                     "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+                    "dev": true,
                     "requires": {
                         "cliui": "^3.2.0",
                         "decamelize": "^1.1.1",
@@ -15198,6 +15674,7 @@
                     "version": "2.4.1",
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
                     "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+                    "dev": true,
                     "requires": {
                         "camelcase": "^3.0.0",
                         "lodash.assign": "^4.0.6"
@@ -15217,17 +15694,20 @@
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+            "dev": true
         },
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
         },
         "source-map-resolve": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+            "dev": true,
             "requires": {
                 "atob": "^2.1.1",
                 "decode-uri-component": "^0.2.0",
@@ -15239,7 +15719,8 @@
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
         },
         "sparkles": {
             "version": "1.0.1",
@@ -15265,6 +15746,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
             "requires": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -15273,12 +15755,14 @@
         "spdx-exceptions": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
         },
         "spdx-expression-parse": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
             "requires": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
@@ -15287,7 +15771,8 @@
         "spdx-license-ids": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-            "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
+            "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+            "dev": true
         },
         "split": {
             "version": "1.0.1",
@@ -15302,6 +15787,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             }
@@ -15348,6 +15834,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
             "requires": {
                 "define-property": "^0.2.5",
                 "object-copy": "^0.1.0"
@@ -15357,6 +15844,7 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -15373,6 +15861,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
             "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+            "dev": true,
             "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "^2.0.2"
@@ -15498,12 +15987,14 @@
         "strict-uri-encode": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
         },
         "string-width": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -15514,6 +16005,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
             "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
+            "dev": true,
             "requires": {
                 "define-properties": "^1.1.3",
                 "es-abstract": "^1.13.0",
@@ -15524,6 +16016,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.2.0"
             },
@@ -15531,7 +16024,8 @@
                 "safe-buffer": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+                    "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+                    "dev": true
                 }
             }
         },
@@ -15539,6 +16033,7 @@
             "version": "3.0.1",
             "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -15547,6 +16042,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
             "requires": {
                 "is-utf8": "^0.2.0"
             }
@@ -15563,12 +16059,14 @@
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
         },
         "strip-hex-prefix": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
             "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+            "dev": true,
             "requires": {
                 "is-hex-prefixed": "1.0.0"
             }
@@ -15778,7 +16276,8 @@
         "tapable": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.9.tgz",
-            "integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A=="
+            "integrity": "sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==",
+            "dev": true
         },
         "tar": {
             "version": "4.4.13",
@@ -16036,7 +16535,8 @@
         "testrpc": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/testrpc/-/testrpc-0.0.1.tgz",
-            "integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA=="
+            "integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==",
+            "dev": true
         },
         "text-extensions": {
             "version": "2.0.0",
@@ -16103,7 +16603,8 @@
         "timed-out": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+            "dev": true
         },
         "timers-browserify": {
             "version": "1.4.2",
@@ -16142,7 +16643,8 @@
         "to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
         },
         "to-buffer": {
             "version": "1.1.1",
@@ -16160,6 +16662,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -16168,6 +16671,7 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -16184,6 +16688,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
                 "extend-shallow": "^3.0.2",
@@ -16195,6 +16700,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -16258,6 +16764,7 @@
             "version": "5.1.8",
             "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.8.tgz",
             "integrity": "sha512-/r2ul1mtoNO2obGZmfQX3kjTPQdWRfIjW4sm5x35VJVxsdPif5WZXsDluPAlcbqJcqP6vwLZNmWoZHMLUE5Y8w==",
+            "dev": true,
             "requires": {
                 "app-module-path": "^2.2.0",
                 "mocha": "5.2.0",
@@ -16267,12 +16774,14 @@
                 "commander": {
                     "version": "2.15.1",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+                    "dev": true
                 },
                 "debug": {
                     "version": "3.1.0",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
                     "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -16281,6 +16790,7 @@
                     "version": "7.1.2",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
                         "inflight": "^1.0.4",
@@ -16293,12 +16803,14 @@
                 "he": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+                    "dev": true
                 },
                 "mocha": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
                     "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+                    "dev": true,
                     "requires": {
                         "browser-stdout": "1.3.1",
                         "commander": "2.15.1",
@@ -16317,6 +16829,7 @@
                     "version": "5.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
                     }
@@ -16353,7 +16866,8 @@
         "type": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
-            "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw=="
+            "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+            "dev": true
         },
         "type-detect": {
             "version": "4.0.8",
@@ -16420,12 +16934,14 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
             "optional": true
         },
         "uglifyjs-webpack-plugin": {
             "version": "0.4.6",
             "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
             "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+            "dev": true,
             "requires": {
                 "source-map": "^0.5.6",
                 "uglify-js": "^2.8.29",
@@ -16435,12 +16951,14 @@
                 "camelcase": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                    "dev": true
                 },
                 "cliui": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                    "dev": true,
                     "requires": {
                         "center-align": "^0.1.1",
                         "right-align": "^0.1.1",
@@ -16451,6 +16969,7 @@
                     "version": "2.8.29",
                     "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+                    "dev": true,
                     "requires": {
                         "source-map": "~0.5.1",
                         "uglify-to-browserify": "~1.0.0",
@@ -16461,6 +16980,7 @@
                     "version": "3.10.0",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                    "dev": true,
                     "requires": {
                         "camelcase": "^1.0.2",
                         "cliui": "^2.1.0",
@@ -16526,7 +17046,8 @@
         "underscore": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+            "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+            "dev": true
         },
         "undertaker": {
             "version": "1.2.1",
@@ -16583,6 +17104,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
             "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
@@ -16643,6 +17165,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
             "requires": {
                 "has-value": "^0.3.1",
                 "isobject": "^3.0.0"
@@ -16652,6 +17175,7 @@
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
                     "requires": {
                         "get-value": "^2.0.3",
                         "has-values": "^0.1.4",
@@ -16662,6 +17186,7 @@
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -16671,19 +17196,22 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
                 }
             }
         },
         "upath": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q=="
+            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+            "dev": true
         },
         "uri-js": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             },
@@ -16691,19 +17219,22 @@
                 "punycode": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
                 }
             }
         },
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
         },
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
             "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
             "requires": {
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
@@ -16712,7 +17243,8 @@
                 "punycode": {
                     "version": "1.3.2",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
                 }
             }
         },
@@ -16734,7 +17266,8 @@
         "url-set-query": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-            "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+            "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
+            "dev": true
         },
         "url-to-options": {
             "version": "1.0.1",
@@ -16745,7 +17278,8 @@
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
         },
         "useragent": {
             "version": "2.3.0",
@@ -16760,7 +17294,8 @@
         "utf8": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-            "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+            "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+            "dev": true
         },
         "util": {
             "version": "0.10.4",
@@ -16774,7 +17309,8 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "util-promisify": {
             "version": "2.1.0",
@@ -16832,6 +17368,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
             "requires": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -16956,7 +17493,8 @@
         "vm-browserify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
-            "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
+            "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+            "dev": true
         },
         "void-elements": {
             "version": "2.0.1",
@@ -17002,6 +17540,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+            "dev": true,
             "requires": {
                 "chokidar": "^2.0.2",
                 "graceful-fs": "^4.1.2",
@@ -17454,6 +17993,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
             "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+            "dev": true,
             "requires": {
                 "bn.js": "4.11.8",
                 "eth-lib": "0.2.7",
@@ -17469,6 +18009,7 @@
                     "version": "0.2.7",
                     "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
                     "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
                         "elliptic": "^6.4.0",
@@ -17479,6 +18020,7 @@
                     "version": "1.7.0",
                     "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
                     "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
                     "requires": {
                         "bn.js": "4.11.6",
                         "strip-hex-prefix": "1.0.0"
@@ -17487,7 +18029,8 @@
                         "bn.js": {
                             "version": "4.11.6",
                             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
                         }
                     }
                 }
@@ -17503,6 +18046,7 @@
             "version": "3.12.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.12.0.tgz",
             "integrity": "sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==",
+            "dev": true,
             "requires": {
                 "acorn": "^5.0.0",
                 "acorn-dynamic-import": "^2.0.0",
@@ -17531,17 +18075,20 @@
                 "acorn": {
                     "version": "5.7.3",
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "dev": true
                 },
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
                 },
                 "async": {
                     "version": "2.6.3",
                     "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
                     "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
                     "requires": {
                         "lodash": "^4.17.14"
                     }
@@ -17549,12 +18096,14 @@
                 "camelcase": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
                 },
                 "cross-spawn": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
                     "requires": {
                         "lru-cache": "^4.0.1",
                         "shebang-command": "^1.2.0",
@@ -17565,6 +18114,7 @@
                     "version": "0.7.0",
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "dev": true,
                     "requires": {
                         "cross-spawn": "^5.0.1",
                         "get-stream": "^3.0.0",
@@ -17579,6 +18129,7 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
                     "requires": {
                         "locate-path": "^2.0.0"
                     }
@@ -17586,22 +18137,26 @@
                 "has-flag": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
                 },
                 "json5": {
                     "version": "0.5.1",
                     "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true
                 },
                 "load-json-file": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.2",
                         "parse-json": "^2.2.0",
@@ -17613,6 +18168,7 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "dev": true,
                     "requires": {
                         "execa": "^0.7.0",
                         "lcid": "^1.0.0",
@@ -17623,6 +18179,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "dev": true,
                     "requires": {
                         "pify": "^2.0.0"
                     }
@@ -17630,12 +18187,14 @@
                 "pify": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 },
                 "read-pkg": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "dev": true,
                     "requires": {
                         "load-json-file": "^2.0.0",
                         "normalize-package-data": "^2.3.2",
@@ -17646,6 +18205,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "dev": true,
                     "requires": {
                         "find-up": "^2.0.0",
                         "read-pkg": "^2.0.0"
@@ -17655,6 +18215,7 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
                     "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
                         "strip-ansi": "^4.0.0"
@@ -17664,6 +18225,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
@@ -17671,12 +18233,14 @@
                 "strip-bom": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "4.5.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^2.0.0"
                     }
@@ -17684,12 +18248,14 @@
                 "which-module": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
                 },
                 "yargs": {
                     "version": "8.0.2",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
                     "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "dev": true,
                     "requires": {
                         "camelcase": "^4.1.0",
                         "cliui": "^3.2.0",
@@ -17710,6 +18276,7 @@
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
                     "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "dev": true,
                     "requires": {
                         "camelcase": "^4.1.0"
                     }
@@ -17720,6 +18287,7 @@
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
             "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+            "dev": true,
             "requires": {
                 "source-list-map": "^2.0.0",
                 "source-map": "~0.6.1"
@@ -17728,7 +18296,8 @@
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
                 }
             }
         },
@@ -17759,6 +18328,7 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
             }
@@ -17766,7 +18336,8 @@
         "which-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
         },
         "which-pm-runs": {
             "version": "1.0.0",
@@ -17786,7 +18357,8 @@
         "window-size": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true
         },
         "windows-release": {
             "version": "3.2.0",
@@ -17829,12 +18401,14 @@
         "wordwrap": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+            "dev": true
         },
         "wrap-ansi": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.1",
                 "strip-ansi": "^3.0.1"
@@ -17843,7 +18417,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "2.4.3",
@@ -17941,6 +18516,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
             "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+            "dev": true,
             "requires": {
                 "global": "~4.3.0",
                 "is-function": "^1.0.1",
@@ -17952,6 +18528,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
             "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+            "dev": true,
             "requires": {
                 "buffer-to-arraybuffer": "^0.0.5",
                 "object-assign": "^4.1.1",
@@ -17966,6 +18543,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
             "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
+            "dev": true,
             "requires": {
                 "xhr-request": "^1.0.1"
             }
@@ -17994,12 +18572,14 @@
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
         },
         "y18n": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
         },
         "yaeti": {
             "version": "0.0.6",
@@ -18010,7 +18590,8 @@
         "yallist": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
         },
         "yargs": {
             "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
         "wait-port": "^0.2.6",
         "@ensdomains/ens": "^0.3.11",
         "@ensdomains/resolver": "^0.1.13",
-        "truffle": "^5.1.8"
+        "truffle": "^5.1.8",
+        "regenerator-runtime": "^0.13.3"
     }
 }


### PR DESCRIPTION
## Description

The ``regenerator-runtime`` dependency dropped out while doing a merge here on GitHub with the online merge tool.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Dependency

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
