### PR TITLE
Implement FakeIpcProvider.reset (#3190)

### DIFF
--- a/test/contract.js
+++ b/test/contract.js
@@ -240,7 +240,7 @@ var getEthContractInstance = function(abi, address, options, provider) {
     }
 
     var eth = new Eth(provider);
-    //eth.setProvider(provider);
+    eth.setProvider(provider);
     return new eth.Contract(abi, address, options);
 }
 

--- a/test/helpers/FakeIpcProvider.js
+++ b/test/helpers/FakeIpcProvider.js
@@ -68,7 +68,7 @@ FakeIpcProvider.prototype.on = function (type, callback) {
     }
 };
 
-FakeIpcProvider.prototype.reset = function (type, callback) {
+FakeIpcProvider.prototype.reset = function () {
     this.notificationCallbacks = [];
 };
 

--- a/test/helpers/FakeIpcProvider.js
+++ b/test/helpers/FakeIpcProvider.js
@@ -31,6 +31,7 @@ var FakeIpcProvider = function IpcProvider() {
     this.error = [];
     this.validation = [];
     this.notificationCallbacks = [];
+    this.connected = true;
 };
 
 
@@ -65,6 +66,10 @@ FakeIpcProvider.prototype.on = function (type, callback) {
     if(type === 'data') {
         this.notificationCallbacks.push(callback);
     }
+};
+
+FakeIpcProvider.prototype.reset = function (type, callback) {
+    this.notificationCallbacks = [];
 };
 
 FakeIpcProvider.prototype.getResponseOrError = function (type, payload) {


### PR DESCRIPTION
## Description

**PR targets #3190**

This tries to make sure the injection-based tests in `contract.js` run the subscriptions clearing correctly when RequestManager.setProvider is called. 

In #3303 there was quite a bit of confusion about whether or not additional listeners are being attached on a double-call to setProvider...but it looks like the test fixture might just not reflect the code path correctly. 

## Type of change

- [x] Review recommendation

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
