### PR TITLE
Add subscription tests for disconnect & setProvider (#3190)

### DIFF
--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -135,7 +135,6 @@ describe('subscription connect/reconnect', function () {
             web3.eth
                 .subscribe('newBlockHeaders')
                 .on("data", function (_) {
-                    emitterInstance = this;
                     counter++;
                 });
 

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -102,8 +102,7 @@ describe('subscription connect/reconnect', function () {
     });
 
     // The ganache unit tests are erroring under similar conditions -
-    // test verifies behavior is as expected.
-    it('does not error when client closes immediately after disconnect', async function(){
+    it('does not error when client closes after disconnect', async function(){
         this.timeout(7000);
 
         return new Promise(async function(resolve, reject) {
@@ -116,7 +115,12 @@ describe('subscription connect/reconnect', function () {
             // Let a couple blocks mine..
             await waitSeconds(2)
             web3.currentProvider.disconnect();
+
+            // This delay seems to be required (on Travis).
+            await waitSeconds(1);
+
             await pify(server.close)();
+
             await waitSeconds(1)
             resolve();
         });

--- a/test/helpers/test.utils.js
+++ b/test/helpers/test.utils.js
@@ -51,6 +51,11 @@ var getWebsocketPort = function(){
     return ( process.env.GANACHE || global.window ) ?  8545 : 8546;
 }
 
+// Delay
+var waitSeconds = async function(seconds=0){
+    return new Promise(resolve => setTimeout(() => resolve(), seconds * 1000))
+}
+
 module.exports = {
     methodExists: methodExists,
     propertyExists: propertyExists,
@@ -58,5 +63,6 @@ module.exports = {
     extractReceipt: extractReceipt,
     getWeb3: getWeb3,
     getWebsocketPort: getWebsocketPort,
+    waitSeconds: waitSeconds
 };
 

--- a/test/helpers/test.utils.js
+++ b/test/helpers/test.utils.js
@@ -52,7 +52,7 @@ var getWebsocketPort = function(){
 }
 
 // Delay
-var waitSeconds = async function(seconds=0){
+var waitSeconds = async function(seconds = 0){
     return new Promise(resolve => setTimeout(() => resolve(), seconds * 1000))
 }
 
@@ -65,4 +65,3 @@ module.exports = {
     getWebsocketPort: getWebsocketPort,
     waitSeconds: waitSeconds
 };
-


### PR DESCRIPTION
## Description

**PR targets #3329** (If you merge 3329 first, this should go into #3190 clean, but you'll have to change the target branch). 

Adds a couple final tests for #3190, describing expected behavior on `provider.disconnect` and `eth.setProvider`. 

The provider disconnect test reproduces the error triggered in the ganache E2E, and can be seen failing [in Travis here][1] in the first commit. When a delay added between disconnect and sever shutdown, the test succeeds. 

Have opened [ganache-core 545][2] to address their test failure - they should be able to bump to a higher patch version without problems after #3190 is published.

[1]: https://github.com/trufflesuite/ganache-core/blob/9d50099b08e630650e11fe7ccfcf66cf5d9789bf/test/events.js#L63
[2]: https://github.com/trufflesuite/ganache-core/pull/545

## Type of change

- [x] Tests 

## Checklist:

- [x] I have selected the correct base branch. **Based on #3329**
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
