### PR TITLE
Security patch changes applied on 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,14 +125,23 @@ Released with 1.0.0-beta.37 code base.
 - fix: export bloom functions on the index.js
 - Prefer receipt status to code availability on contract deployment (#3298)
 
-## [Unreleased]
-
 ## [1.2.6]
 
 ### Added
 
-- ENS module extended with the possibility to add a custom registry (#3301)
 - Görli testnet ENS registry added to the known registries (#3338)
+
+### Changed
+
+- ENS registry addresses updated (#3353, https://medium.com/the-ethereum-name-service/ens-registry-migration-bug-fix-new-features-64379193a5a)
+
+## [Unreleased]
+
+## [1.2.7]
+
+### Added
+
+- ENS module extended with the possibility to add a custom registry (#3301)
 
 ### Changed
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "namespace": "ethereum",
   "name": "web3",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Ethereum JavaScript API",
   "license": "LGPL-3.0",
   "main": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "web3",
     "private": true,
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Ethereum JavaScript API wrapper repository",
     "license": "LGPL-3.0",
     "engines": {

--- a/packages/web3-bzz/package-lock.json
+++ b/packages/web3-bzz/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-bzz",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -38,9 +38,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.17.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-			"integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+			"version": "10.17.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+			"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -493,9 +493,9 @@
 			}
 		},
 		"defer-to-connect": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
-			"integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
 		},
 		"definitelytyped-header-parser": {
 			"version": "1.2.0",
@@ -543,7 +543,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -1893,9 +1893,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"ultron": {

--- a/packages/web3-bzz/package.json
+++ b/packages/web3-bzz/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-bzz",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to interact with the Swarm network.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-bzz",
     "license": "LGPL-3.0",

--- a/packages/web3-core-helpers/package-lock.json
+++ b/packages/web3-core-helpers/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core-helpers",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,9 +25,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-			"integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
+			"version": "12.12.26",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+			"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
 			"dev": true
 		},
 		"@types/parsimmon": {
@@ -140,7 +140,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -380,9 +380,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-core-helpers/package.json
+++ b/packages/web3-core-helpers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-core-helpers",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 core tools helper for sub packages. This is an internal package.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-core-helpers",
     "license": "LGPL-3.0",
@@ -14,8 +14,8 @@
     "main": "src/index.js",
     "dependencies": {
         "underscore": "1.9.1",
-        "web3-eth-iban": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-eth-iban": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "@types/node": "^12.12.5",

--- a/packages/web3-core-method/package-lock.json
+++ b/packages/web3-core-method/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core-method",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -134,7 +134,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -374,9 +374,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-core-method/package.json
+++ b/packages/web3-core-method/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-core-method",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Creates the methods on the web3 modules. This is an internal package.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-core-method",
     "license": "LGPL-3.0",
@@ -14,10 +14,10 @@
     "main": "src/index.js",
     "dependencies": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.5",
-        "web3-core-promievent": "1.2.5",
-        "web3-core-subscriptions": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core-helpers": "1.2.6",
+        "web3-core-promievent": "1.2.6",
+        "web3-core-subscriptions": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-core-promievent/package-lock.json
+++ b/packages/web3-core-promievent/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core-promievent",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/web3-core-promievent/package.json
+++ b/packages/web3-core-promievent/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-core-promievent",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "This package extends the EventEmitter with the Promise class to allow chaining as well as multiple final states of a function.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-core-promievent",
     "license": "LGPL-3.0",

--- a/packages/web3-core-requestmanager/package-lock.json
+++ b/packages/web3-core-requestmanager/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core-requestmanager",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/web3-core-requestmanager/package.json
+++ b/packages/web3-core-requestmanager/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-core-requestmanager",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to handle requests to external providers.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-core-requestmanager",
     "license": "LGPL-3.0",
@@ -10,9 +10,9 @@
     "main": "src/index.js",
     "dependencies": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.5",
-        "web3-providers-http": "1.2.5",
-        "web3-providers-ipc": "1.2.5",
-        "web3-providers-ws": "1.2.5"
+        "web3-core-helpers": "1.2.6",
+        "web3-providers-http": "1.2.6",
+        "web3-providers-ipc": "1.2.6",
+        "web3-providers-ws": "1.2.6"
     }
 }

--- a/packages/web3-core-subscriptions/package-lock.json
+++ b/packages/web3-core-subscriptions/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core-subscriptions",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -134,7 +134,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -379,9 +379,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-core-subscriptions/package.json
+++ b/packages/web3-core-subscriptions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-core-subscriptions",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Manages web3 subscriptions. This is an internal package.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-core-subscriptions",
     "license": "LGPL-3.0",
@@ -15,7 +15,7 @@
     "dependencies": {
         "eventemitter3": "3.1.2",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.5"
+        "web3-core-helpers": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-core/package-lock.json
+++ b/packages/web3-core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -33,9 +33,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-			"integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w=="
+			"version": "12.12.26",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+			"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -147,7 +147,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -387,9 +387,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-core",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 core tools for sub packages. This is an internal package.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-core",
     "license": "LGPL-3.0",
@@ -15,10 +15,10 @@
     "dependencies": {
         "@types/bn.js": "^4.11.4",
         "@types/node": "^12.6.1",
-        "web3-core-helpers": "1.2.5",
-        "web3-core-method": "1.2.5",
-        "web3-core-requestmanager": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core-helpers": "1.2.6",
+        "web3-core-method": "1.2.6",
+        "web3-core-requestmanager": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth-abi/package-lock.json
+++ b/packages/web3-eth-abi/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,9 +25,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.17.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-			"integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg=="
+			"version": "10.17.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
+			"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -154,7 +154,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -450,9 +450,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth-abi",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module encode and decode EVM in/output.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-eth-abi",
     "license": "LGPL-3.0",
@@ -15,7 +15,7 @@
     "dependencies": {
         "ethers": "4.0.0-beta.3",
         "underscore": "1.9.1",
-        "web3-utils": "1.2.5"
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -33,9 +33,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-			"integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+			"integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -372,7 +372,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -961,9 +961,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth-accounts",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to generate Ethereum accounts and sign data and transactions.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-eth-accounts",
     "license": "LGPL-3.0",
@@ -21,10 +21,10 @@
         "ethereumjs-tx": "^2.1.1",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.2.5",
-        "web3-core-helpers": "1.2.5",
-        "web3-core-method": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core": "1.2.6",
+        "web3-core-helpers": "1.2.6",
+        "web3-core-method": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth-contract/package-lock.json
+++ b/packages/web3-eth-contract/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -33,9 +33,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "13.5.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-			"integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+			"version": "13.7.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+			"integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -147,7 +147,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -387,9 +387,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth-contract",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to interact with Ethereum smart contracts.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-eth-contract",
     "license": "LGPL-3.0",
@@ -15,13 +15,13 @@
     "dependencies": {
         "@types/bn.js": "^4.11.4",
         "underscore": "1.9.1",
-        "web3-core": "1.2.5",
-        "web3-core-helpers": "1.2.5",
-        "web3-core-method": "1.2.5",
-        "web3-core-promievent": "1.2.5",
-        "web3-core-subscriptions": "1.2.5",
-        "web3-eth-abi": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core": "1.2.6",
+        "web3-core-helpers": "1.2.6",
+        "web3-core-method": "1.2.6",
+        "web3-core-promievent": "1.2.6",
+        "web3-core-subscriptions": "1.2.6",
+        "web3-eth-abi": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth-ens/package-lock.json
+++ b/packages/web3-eth-ens/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -134,7 +134,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -401,9 +401,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth-ens",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "ENS support for web3.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-eth-ens",
     "license": "LGPL-3.0",
@@ -15,12 +15,12 @@
     "dependencies": {
         "eth-ens-namehash": "2.0.8",
         "underscore": "1.9.1",
-        "web3-core": "1.2.5",
-        "web3-core-helpers": "1.2.5",
-        "web3-core-promievent": "1.2.5",
-        "web3-eth-abi": "1.2.5",
-        "web3-eth-contract": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core": "1.2.6",
+        "web3-core-helpers": "1.2.6",
+        "web3-core-promievent": "1.2.6",
+        "web3-eth-abi": "1.2.6",
+        "web3-eth-contract": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth-ens/src/config.js
+++ b/packages/web3-eth-ens/src/config.js
@@ -27,10 +27,10 @@
  */
 var config = {
     addresses: {
-        main: "0x314159265dD8dbb310642f98f50C066173C1259b",
-        ropsten: "0x112234455c3a32fd11230c42e7bccd4a84e02010",
-        rinkeby: "0xe7410170f87102df0055eb195163a03b7f2bff4a",
-        goerli: "0x112234455C3a32FD11230C42E7Bccd4A84e02010"
+        main: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        ropsten: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        rinkeby: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        goerli: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
     },
 };
 

--- a/packages/web3-eth-iban/package-lock.json
+++ b/packages/web3-eth-iban/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -139,7 +139,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -379,9 +379,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth-iban",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "This package converts Ethereum addresses to IBAN addresses a vice versa.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-eth-iban",
     "license": "LGPL-3.0",
@@ -14,7 +14,7 @@
     "main": "src/index.js",
     "dependencies": {
         "bn.js": "4.11.8",
-        "web3-utils": "1.2.5"
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth-personal/package-lock.json
+++ b/packages/web3-eth-personal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,9 +25,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-			"integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w=="
+			"version": "12.12.26",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+			"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -139,7 +139,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -379,9 +379,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth-personal",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-eth-personal",
     "license": "LGPL-3.0",
@@ -14,11 +14,11 @@
     "main": "src/index.js",
     "dependencies": {
         "@types/node": "^12.6.1",
-        "web3-core": "1.2.5",
-        "web3-core-helpers": "1.2.5",
-        "web3-core-method": "1.2.5",
-        "web3-net": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core": "1.2.6",
+        "web3-core-helpers": "1.2.6",
+        "web3-core-method": "1.2.6",
+        "web3-net": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-eth/package-lock.json
+++ b/packages/web3-eth/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -134,7 +134,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -374,9 +374,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-eth",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-eth",
     "license": "LGPL-3.0",
@@ -14,18 +14,18 @@
     "main": "src/index.js",
     "dependencies": {
         "underscore": "1.9.1",
-        "web3-core": "1.2.5",
-        "web3-core-helpers": "1.2.5",
-        "web3-core-method": "1.2.5",
-        "web3-core-subscriptions": "1.2.5",
-        "web3-eth-abi": "1.2.5",
-        "web3-eth-accounts": "1.2.5",
-        "web3-eth-contract": "1.2.5",
-        "web3-eth-ens": "1.2.5",
-        "web3-eth-iban": "1.2.5",
-        "web3-eth-personal": "1.2.5",
-        "web3-net": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core": "1.2.6",
+        "web3-core-helpers": "1.2.6",
+        "web3-core-method": "1.2.6",
+        "web3-core-subscriptions": "1.2.6",
+        "web3-eth-abi": "1.2.6",
+        "web3-eth-accounts": "1.2.6",
+        "web3-eth-contract": "1.2.6",
+        "web3-eth-ens": "1.2.6",
+        "web3-eth-iban": "1.2.6",
+        "web3-eth-personal": "1.2.6",
+        "web3-net": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-net/package-lock.json
+++ b/packages/web3-net/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -134,7 +134,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -374,9 +374,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-net",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to interact with the Ethereum nodes networking properties.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-net",
     "license": "LGPL-3.0",
@@ -13,9 +13,9 @@
     },
     "main": "src/index.js",
     "dependencies": {
-        "web3-core": "1.2.5",
-        "web3-core-method": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-core": "1.2.6",
+        "web3-core-method": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-providers-http/package-lock.json
+++ b/packages/web3-providers-http/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -139,7 +139,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -379,9 +379,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-providers-http",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Module to handle web3 RPC connections over HTTP.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-http",
     "license": "LGPL-3.0",
@@ -13,7 +13,7 @@
     "types": "types/index.d.ts",
     "main": "src/index.js",
     "dependencies": {
-        "web3-core-helpers": "1.2.5",
+        "web3-core-helpers": "1.2.6",
         "xhr2-cookies": "1.1.0"
     },
     "devDependencies": {

--- a/packages/web3-providers-ipc/package-lock.json
+++ b/packages/web3-providers-ipc/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,9 +25,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-			"integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
+			"version": "12.12.26",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+			"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
 			"dev": true
 		},
 		"@types/parsimmon": {
@@ -140,7 +140,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -393,9 +393,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-providers-ipc",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Module to handle web3 RPC connections over IPC sockets.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-ipc",
     "license": "LGPL-3.0",
@@ -15,7 +15,7 @@
     "dependencies": {
         "oboe": "2.1.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.5"
+        "web3-core-helpers": "1.2.6"
     },
     "devDependencies": {
         "@types/node": "^12.12.5",

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -163,7 +163,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -480,9 +480,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-providers-ws",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Module to handle web3 RPC connections over WebSockets.",
   "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-ws",
   "license": "LGPL-3.0",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@web3-js/websocket": "^1.0.29",
     "underscore": "1.9.1",
-    "web3-core-helpers": "1.2.5"
+    "web3-core-helpers": "1.2.6"
   },
   "devDependencies": {
     "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-shh/package-lock.json
+++ b/packages/web3-shh/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-shh",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,9 +25,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-			"integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
+			"version": "12.12.26",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+			"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
 			"dev": true
 		},
 		"@types/parsimmon": {
@@ -140,7 +140,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -380,9 +380,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3-shh/package.json
+++ b/packages/web3-shh/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-shh",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Web3 module to interact with the Whisper messaging protocol.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-shh",
     "license": "LGPL-3.0",
@@ -13,10 +13,10 @@
     },
     "main": "src/index.js",
     "dependencies": {
-        "web3-core": "1.2.5",
-        "web3-core-method": "1.2.5",
-        "web3-core-subscriptions": "1.2.5",
-        "web3-net": "1.2.5"
+        "web3-core": "1.2.6",
+        "web3-core-method": "1.2.6",
+        "web3-core-subscriptions": "1.2.6",
+        "web3-net": "1.2.6"
     },
     "devDependencies": {
         "@types/node": "^12.12.5",

--- a/packages/web3-utils/package-lock.json
+++ b/packages/web3-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-utils",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -167,7 +167,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -606,9 +606,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"underscore": {

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3-utils",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Collection of utility functions used in web3.js.",
     "repository": "https://github.com/ethereum/web3.js/tree/1.x/packages/web3-utils",
     "license": "LGPL-3.0",

--- a/packages/web3/package-lock.json
+++ b/packages/web3/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -25,9 +25,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.25",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-			"integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w=="
+			"version": "12.12.26",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+			"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -139,7 +139,7 @@
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200125"
+				"typescript": "^3.8.0-dev.20200201"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -379,9 +379,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.8.0-dev.20200125",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200125.tgz",
-			"integrity": "sha512-OuNrOBdkFIZ00TyNbuT+How+3Z4ENfFYA53J/vOk0HQ+J5RrCknd00PE5qwTczyq9gBsGrJQgvA34YIxNCfafA==",
+			"version": "3.8.0-dev.20200201",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
+			"integrity": "sha512-KhaK6J3dIg6p9t24UVhBLcBIav4MpMExlD6nf18cVwp9LELuqhWu0NDmnLdSN0ovsrbcIJNmobQ1xC7vLN21eg==",
 			"dev": true
 		},
 		"universalify": {

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web3",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Ethereum JavaScript API",
     "repository": "https://github.com/ethereum/web3.js",
     "license": "LGPL-3.0",
@@ -50,13 +50,13 @@
     ],
     "dependencies": {
         "@types/node": "^12.6.1",
-        "web3-bzz": "1.2.5",
-        "web3-core": "1.2.5",
-        "web3-eth": "1.2.5",
-        "web3-eth-personal": "1.2.5",
-        "web3-net": "1.2.5",
-        "web3-shh": "1.2.5",
-        "web3-utils": "1.2.5"
+        "web3-bzz": "1.2.6",
+        "web3-core": "1.2.6",
+        "web3-eth": "1.2.6",
+        "web3-eth-personal": "1.2.6",
+        "web3-net": "1.2.6",
+        "web3-shh": "1.2.6",
+        "web3-utils": "1.2.6"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",


### PR DESCRIPTION
## Description

This PR updates the registry address on 1.x, the CHANGELOG.md file, and the package.json / package-lock.json files of all packages. Those changes do come from the [release PR](https://github.com/ethereum/web3.js/pull/3353) we sadly can't merge back into 1.x.


## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Release changes

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the live network.
