### PR TITLE
URL of the coveralls badge in the root readme file corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ The contribution guidelines are provided in [CONTRIBUTIONS](./CONTRIBUTIONS.md)
 [dep-url]: https://david-dm.org/ethereum/web3.js
 [dep-dev-image]: https://david-dm.org/ethereum/web3.js/dev-status.svg
 [dep-dev-url]: https://david-dm.org/ethereum/web3.js#info=devDependencies
-[coveralls-image]: https://coveralls.io/repos/ethereum/web3.js/badge.svg?branch=master
+[coveralls-image]: https://coveralls.io/repos/ethereum/web3.js/badge.svg?branch=1.x
 [coveralls-url]: https://coveralls.io/r/ethereum/web3.js?branch=1.x
 [waffle-image]: https://badge.waffle.io/ethereum/web3.js.svg?label=ready&title=Ready
 [waffle-url]: https://waffle.io/ethereum/web3.js


### PR DESCRIPTION
## Description

Corrects the URL of the coveralls badge in the root README file of this GitHub repository.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Documentation

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the live network.
