### PR TITLE
Use registry uplink timeout & non-conflicting  package version

### DIFF
--- a/scripts/e2e.mosaic.sh
+++ b/scripts/e2e.mosaic.sh
@@ -31,9 +31,9 @@ echo "Installing updated web3 via virtual registry "
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 
 git submodule update --init --recursive
-yarn --registry http://localhost:4873 --network-timeout 100000
+yarn --registry http://localhost:4873
 
-yarn add web3@e2e --registry http://localhost:4873 --network-timeout 100000
+yarn add web3@e2e --registry http://localhost:4873
 
 yarn list web3
 yarn list web3-utils

--- a/scripts/e2e.npm.publish.sh
+++ b/scripts/e2e.npm.publish.sh
@@ -52,7 +52,7 @@ fi
 git checkout $BRANCH --
 
 # Lerna version
-lerna version patch \
+lerna version minor \
   --force-publish=* \
   --no-git-tag-version \
   --no-push \

--- a/scripts/js/resolutions.js
+++ b/scripts/js/resolutions.js
@@ -23,7 +23,7 @@ const targetPackagePath = path.join(process.cwd(), process.argv[2], 'package.jso
 const web3Package = require(web3PackagePath);
 const targetPackage = require(targetPackagePath);
 
-// Use pre-release version which isn't ever really
+// Use version least likely to conflict with what's been
 // published to npm. (Maps to `lerna version` command
 // in e2e.npm.publish.sh)
 const version = semver.inc(web3Package.version, 'minor');
@@ -59,4 +59,3 @@ console.log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
 console.log(JSON.stringify(targetPackage.resolutions, null, ' '));
 
 fs.writeFileSync(targetPackagePath, JSON.stringify(targetPackage, null, '    '));
-

--- a/scripts/js/resolutions.js
+++ b/scripts/js/resolutions.js
@@ -4,9 +4,9 @@
  * This script is a helper for running a buidler based e2e unit test target and is
  * used in combination with the npm virtual publishing script.
  *
- * It discovers the current web3 package version, gets its patch increment
+ * It discovers the current web3 package version, gets its minor increment
  * (also the value of the virtually published version) and attaches a yarn resolutions field
- * to the target's package.json to coerce any Web3 packages up to the patch when target is
+ * to the target's package.json to coerce any Web3 packages up when target is
  * installed.
  *
  * USAGE:    resolutions.js <target-folder-name>
@@ -23,30 +23,33 @@ const targetPackagePath = path.join(process.cwd(), process.argv[2], 'package.jso
 const web3Package = require(web3PackagePath);
 const targetPackage = require(targetPackagePath);
 
-const patch = semver.inc(web3Package.version, 'patch');
+// Use pre-release version which isn't ever really
+// published to npm. (Maps to `lerna version` command
+// in e2e.npm.publish.sh)
+const version = semver.inc(web3Package.version, 'minor');
 
 targetPackage.resolutions = {
-  "@nomiclabs/**/web3": `${patch}`,
-  "@nomiclabs/**/web3-bzz": `${patch}`,
-  "@nomiclabs/**/web3-core-helpers": `${patch}`,
-  "@nomiclabs/**/web3-core-method": `${patch}`,
-  "@nomiclabs/**/web3-core-promievent": `${patch}`,
-  "@nomiclabs/**/web3-core-requestmanager": `${patch}`,
-  "@nomiclabs/**/web3-core-subscriptions": `${patch}`,
-  "@nomiclabs/**/web3-core": `${patch}`,
-  "@nomiclabs/**/web3-eth-abi": `${patch}`,
-  "@nomiclabs/**/web3-eth-accounts": `${patch}`,
-  "@nomiclabs/**/web3-eth-contract": `${patch}`,
-  "@nomiclabs/**/web3-eth-ens": `${patch}`,
-  "@nomiclabs/**/web3-eth-iban": `${patch}`,
-  "@nomiclabs/**/web3-eth-personal": `${patch}`,
-  "@nomiclabs/**/web3-eth": `${patch}`,
-  "@nomiclabs/**/web3-net": `${patch}`,
-  "@nomiclabs/**/web3-providers-http": `${patch}`,
-  "@nomiclabs/**/web3-providers-ipc": `${patch}`,
-  "@nomiclabs/**/web3-providers-ws": `${patch}`,
-  "@nomiclabs/**/web3-shh": `${patch}`,
-  "@nomiclabs/**/web3-utils": `${patch}`
+  "@nomiclabs/**/web3": `${version}`,
+  "@nomiclabs/**/web3-bzz": `${version}`,
+  "@nomiclabs/**/web3-core-helpers": `${version}`,
+  "@nomiclabs/**/web3-core-method": `${version}`,
+  "@nomiclabs/**/web3-core-promievent": `${version}`,
+  "@nomiclabs/**/web3-core-requestmanager": `${version}`,
+  "@nomiclabs/**/web3-core-subscriptions": `${version}`,
+  "@nomiclabs/**/web3-core": `${version}`,
+  "@nomiclabs/**/web3-eth-abi": `${version}`,
+  "@nomiclabs/**/web3-eth-accounts": `${version}`,
+  "@nomiclabs/**/web3-eth-contract": `${version}`,
+  "@nomiclabs/**/web3-eth-ens": `${version}`,
+  "@nomiclabs/**/web3-eth-iban": `${version}`,
+  "@nomiclabs/**/web3-eth-personal": `${version}`,
+  "@nomiclabs/**/web3-eth": `${version}`,
+  "@nomiclabs/**/web3-net": `${version}`,
+  "@nomiclabs/**/web3-providers-http": `${version}`,
+  "@nomiclabs/**/web3-providers-ipc": `${version}`,
+  "@nomiclabs/**/web3-providers-ws": `${version}`,
+  "@nomiclabs/**/web3-shh": `${version}`,
+  "@nomiclabs/**/web3-utils": `${version}`
 }
 
 console.log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");

--- a/verdaccio.yml
+++ b/verdaccio.yml
@@ -5,6 +5,10 @@ auth:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    timeout: 25000ms
+  yarn:
+    url: https://registry.yarnpkg.com/
+    timeout: 25000ms
 packages:
   '@*/*':
     # scoped packages


### PR DESCRIPTION
## Description

PR tries to fix some ongoing problems with the virtual registry / Mosaic E2E tests:
+ Yarn keeps timing out when pulling resources from secondary, non-virtual registries. Initially tried to fix with #3322. In this PR the timeouts are transferred to the verdaccio config's [uplink][1] params (hopefully more effective). 
+  A verdaccio quirk is that the version you publish virtually should not match one you've already published to public registry. PR increases the size of the virtual increment to `minor` so that E2E will (usually) still work when a PR's version numbers lag a recent release. 

[1]: https://verdaccio.org/docs/en/uplinks#usage

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix for tests

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
