### PR TITLE
Add tests for eth-contract errors

### DIFF
--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -119,19 +119,16 @@ module.exports = {
     ContractEventDoesNotExistError: function(eventName) {
         return new Error('Event "' + eventName + '" doesn\'t exist in this contract.');
     },
-    ContractUnsetContractAddressError: function() {
-        return new Error('This contract object doesn\'t have address set yet, please set an address first.');
-    },
     ContractReservedEventError: function(type) {
         return new Error('The event "'+ type +'" is a reserved event name, you can\'t use it.');
     },
     ContractMissingDeployDataError: function() {
         return new Error('No "data" specified in neither the given options, nor the default options.');
     },
-    ContractMissingToAddressError: function() {
+    ContractNoAddressDefinedError: function() {
         return new Error('This contract object doesn\'t have address set yet, please set an address first.');
     },
-    ContractMissingFromAddressError: function() {
+    ContractNoFromAddressDefinedError: function() {
         return new Error('No "from" address specified in neither the given options, nor the default options.');
     }
 };

--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -109,5 +109,29 @@ module.exports = {
     },
     ResolverMethodMissingError: function(address, name) {
         return new Error('The resolver at ' + address + 'does not implement requested method: "' + name + '".');
+    },
+    ContractMissingABIError: function() {
+        return new Error('You must provide the json interface of the contract when instantiating a contract object.');
+    },
+    ContractOnceRequiresCallbackError: function() {
+        return new Error('Once requires a callback as the second parameter.');
+    },
+    ContractEventDoesNotExistError: function(eventName) {
+        return new Error('Event "' + eventName + '" doesn\'t exist in this contract.');
+    },
+    ContractUnsetContractAddressError: function() {
+        return new Error('This contract object doesn\'t have address set yet, please set an address first.');
+    },
+    ContractReservedEventError: function(type) {
+        return new Error('The event "'+ type +'" is a reserved event name, you can\'t use it.');
+    },
+    ContractMissingDeployDataError: function() {
+        return new Error('No "data" specified in neither the given options, nor the default options.');
+    },
+    ContractMissingToAddressError: function() {
+        return new Error('This contract object doesn\'t have address set yet, please set an address first.');
+    },
+    ContractMissingFromAddressError: function() {
+        return new Error('No "from" address specified in neither the given options, nor the default options.');
     }
 };

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -84,11 +84,10 @@ export class errors {
     static ContractMissingABIError(): Error
     static ContractOnceRequiresCallbackError(): Error
     static ContractEventDoesNotExistError(eventName: string): Error
-    static ContractUnsetContractAddressError(): Error
     static ContractReservedEventError(type: string): Error
     static ContractMissingDeployDataError(): Error
-    static ContractMissingToAddressError(): Error
-    static ContractMissingFromAddressError(): Error
+    static ContractNoAddressDefinedError(): Error
+    static ContractNoFromAddressDefinedError(): Error
 }
 
 export class WebsocketProviderBase {

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -81,6 +81,14 @@ export class errors {
     static TransactionRevertedWithoutReasonError(receipt: object): TransactionError
     static TransactionOutOfGasError(receipt: object): TransactionError
     static ResolverMethodMissingError(address: string, name: string): Error
+    static ContractMissingABIError(): Error
+    static ContractOnceRequiresCallbackError(): Error
+    static ContractEventDoesNotExistError(eventName: string): Error
+    static ContractUnsetContractAddressError(): Error
+    static ContractReservedEventError(type: string): Error
+    static ContractMissingDeployDataError(): Error
+    static ContractMissingToAddressError(): Error
+    static ContractMissingFromAddressError(): Error
 }
 
 export class WebsocketProviderBase {

--- a/packages/web3-core-helpers/types/tests/errors-test.ts
+++ b/packages/web3-core-helpers/types/tests/errors-test.ts
@@ -90,16 +90,13 @@ errors.ContractOnceRequiresCallbackError();
 errors.ContractEventDoesNotExistError('nonEvent');
 
 // $ExpectType Error
-errors.ContractUnsetContractAddressError();
-
-// $ExpectType Error
 errors.ContractReservedEventError('newListener');
 
 // $ExpectType Error
 errors.ContractMissingDeployDataError();
 
 // $ExpectType Error
-errors.ContractMissingToAddressError();
+errors.ContractNoAddressDefinedError();
 
 // $ExpectType Error
-errors.ContractMissingFromAddressError();
+errors.ContractNoFromAddressDefinedError();

--- a/packages/web3-core-helpers/types/tests/errors-test.ts
+++ b/packages/web3-core-helpers/types/tests/errors-test.ts
@@ -79,3 +79,27 @@ errors.TransactionOutOfGasError({});
 
 // $ExpectType Error
 errors.ResolverMethodMissingError('0x0000000000000000000000000000000000000001', 'content');
+
+// $ExpectType Error
+errors.ContractMissingABIError();
+
+// $ExpectType Error
+errors.ContractOnceRequiresCallbackError();
+
+// $ExpectType Error
+errors.ContractEventDoesNotExistError('nonEvent');
+
+// $ExpectType Error
+errors.ContractUnsetContractAddressError();
+
+// $ExpectType Error
+errors.ContractReservedEventError('newListener');
+
+// $ExpectType Error
+errors.ContractMissingDeployDataError();
+
+// $ExpectType Error
+errors.ContractMissingToAddressError();
+
+// $ExpectType Error
+errors.ContractMissingFromAddressError();

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -71,7 +71,7 @@ var Contract = function Contract(jsonInterface, address, options) {
     this.clearSubscriptions = this._requestManager.clearSubscriptions;
 
     if(!jsonInterface || !(Array.isArray(jsonInterface))) {
-        throw new Error('You must provide the json interface of the contract when instantiating a contract object.');
+        throw errors.ContractMissingABIError();
     }
 
     // create the options object
@@ -342,7 +342,7 @@ Contract.prototype._getCallback = function getCallback(args) {
  */
 Contract.prototype._checkListener = function(type, event){
     if(event === type) {
-        throw new Error('The event "'+ type +'" is a reserved event name, you can\'t use it.');
+        throw errors.ContractReservedEventError(type);
     }
 };
 
@@ -598,9 +598,13 @@ Contract.prototype.deploy = function(options, callback){
     options = this._getOrSetDefaultOptions(options);
 
 
-    // return error, if no "data" is specified
+    // throw error, if no "data" is specified
     if(!options.data) {
-        return utils._fireError(new Error('No "data" specified in neither the given options, nor the default options.'), null, null, callback);
+        if (typeof callback === 'function'){
+            callback(errors.ContractMissingDeployDataError());
+        } else {
+            throw errors.ContractMissingDeployDataError();
+        }
     }
 
     var constructor = _.find(this.options.jsonInterface, function (method) {
@@ -644,11 +648,11 @@ Contract.prototype._generateEventOptions = function() {
         });
 
     if (!event) {
-        throw new Error('Event "' + eventName + '" doesn\'t exist in this contract.');
+        throw errors.ContractEventDoesNotExistError(eventName);
     }
 
     if (!utils.isAddress(this.options.address)) {
-        throw new Error('This contract object doesn\'t have address set yet, please set an address first.');
+        throw errors.ContractUnsetContractAddressError();
     }
 
     return {
@@ -685,7 +689,7 @@ Contract.prototype.once = function(event, options, callback) {
     callback = this._getCallback(args);
 
     if (!callback) {
-        throw new Error('Once requires a callback as the second parameter.');
+        throw errors.ContractOnceRequiresCallbackError();
     }
 
     // don't allow fromBlock
@@ -856,7 +860,7 @@ Contract.prototype._processExecuteArguments = function _processExecuteArguments(
 
     // add contract address
     if(!this._deployData && !utils.isAddress(this._parent.options.address))
-        throw new Error('This contract object doesn\'t have address set yet, please set an address first.');
+        throw errors.ContractMissingToAddressError();
 
     if(!this._deployData)
         processedArgs.options.to = this._parent.options.address;
@@ -945,7 +949,7 @@ Contract.prototype._executeMethod = function _executeMethod(){
 
             // return error, if no "from" is specified
             if(!utils.isAddress(args.options.from)) {
-                return utils._fireError(new Error('No "from" address specified in neither the given options, nor the default options.'), defer.eventEmitter, defer.reject, args.callback);
+                return utils._fireError(errors.ContractMissingFromAddressError(), defer.eventEmitter, defer.reject, args.callback);
             }
 
             if (_.isBoolean(this._method.payable) && !this._method.payable && args.options.value && args.options.value > 0) {

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -601,10 +601,9 @@ Contract.prototype.deploy = function(options, callback){
     // throw error, if no "data" is specified
     if(!options.data) {
         if (typeof callback === 'function'){
-            callback(errors.ContractMissingDeployDataError());
-        } else {
-            throw errors.ContractMissingDeployDataError();
+            return callback(errors.ContractMissingDeployDataError());
         }
+        throw errors.ContractMissingDeployDataError();
     }
 
     var constructor = _.find(this.options.jsonInterface, function (method) {

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -651,7 +651,7 @@ Contract.prototype._generateEventOptions = function() {
     }
 
     if (!utils.isAddress(this.options.address)) {
-        throw errors.ContractUnsetContractAddressError();
+        throw errors.ContractNoAddressDefinedError();
     }
 
     return {
@@ -859,7 +859,7 @@ Contract.prototype._processExecuteArguments = function _processExecuteArguments(
 
     // add contract address
     if(!this._deployData && !utils.isAddress(this._parent.options.address))
-        throw errors.ContractMissingToAddressError();
+        throw errors.ContractNoAddressDefinedError();
 
     if(!this._deployData)
         processedArgs.options.to = this._parent.options.address;
@@ -948,7 +948,7 @@ Contract.prototype._executeMethod = function _executeMethod(){
 
             // return error, if no "from" is specified
             if(!utils.isAddress(args.options.from)) {
-                return utils._fireError(errors.ContractMissingFromAddressError(), defer.eventEmitter, defer.reject, args.callback);
+                return utils._fireError(errors.ContractNoFromAddressDefinedError(), defer.eventEmitter, defer.reject, args.callback);
             }
 
             if (_.isBoolean(this._method.payable) && !this._method.payable && args.options.value && args.options.value > 0) {

--- a/test/contract.errors.js
+++ b/test/contract.errors.js
@@ -98,8 +98,8 @@ describe('contract: errors', function () {
             "type": "event"
         }];
 
-        const address = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
-        const contract = new eth.Contract(newListenerEventAbi, address);
+        const contractAddress = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
+        const contract = new eth.Contract(newListenerEventAbi, contractAddress);
 
         try {
             contract.once('newListener', () => {});
@@ -137,7 +137,7 @@ describe('contract: errors', function () {
         });
     })
 
-    it('errors when send is called without a contract address set', function(){
+    it('errors when send is called without a *contract address* set', function(){
         const expected = 'This contract object doesn\'t have address set yet, ' +
                          'please set an address first.';
 
@@ -150,12 +150,12 @@ describe('contract: errors', function () {
         }
     });
 
-    it('errors when send is called without a from address being set', async function(){
+    it('errors when send is called without a *from address* being set', async function(){
         const expected = 'No "from" address specified in neither the given options, '
                          'nor the default options.';
 
-        const address = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
-        const contract = new eth.Contract(abi, address);
+        const contractAddress = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
+        const contract = new eth.Contract(abi, contractAddress);
         try {
             await contract.methods.simpleMethod("0xaaa").send({});
             assert.fail();

--- a/test/contract.errors.js
+++ b/test/contract.errors.js
@@ -15,58 +15,62 @@ const abi = [{
 describe('contract: errors', function () {
     let provider;
     let eth;
+    const contractAddress = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
 
-    before(function(){
+    before(function () {
         provider = new FakeIpcProvider();
         eth = new Eth(provider);
     })
 
-    it('errors when no ABI is provided / ABI is not array', function () {
+    it('errors when no ABI is provided', function () {
         const expected = 'You must provide the json interface of the ' +
                          'contract when instantiating a contract object.';
 
-        // Existence check
         try {
             new eth.Contract();
             assert.fail();
-        } catch(err){
-            assert(err.message.includes(expected));
-        }
-
-        // Array check
-        try {
-            new eth.Contract({});
-            assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
     })
 
-    it('errors when event listener is not provided with callback', function(){
+    it('errors when provided ABI is not array', function () {
+        const expected = 'You must provide the json interface of the ' +
+                         'contract when instantiating a contract object.';
+
+        try {
+            new eth.Contract({});
+            assert.fail();
+        } catch (err) {
+            assert(err.message.includes(expected));
+        }
+    })
+
+    it('errors when event listener is not provided with callback', function () {
         const expected = 'Once requires a callback as the second parameter';
         const contract = new eth.Contract(abi);
 
         try {
             contract.once('data');
             assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
     })
 
-    it('errors when a non-existant event is listened for', function(){
+    it('errors when a non-existant event is listened for', function () {
         const expected = 'Event "void" doesn\'t exist in this contract';
         const contract = new eth.Contract(abi);
 
         try {
             contract.once('void', () => {});
             assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
     })
 
-    it('errors when listening for event without setting address', function(){
+    it('errors when listening for event without setting address', function () {
         const expected = 'This contract object doesn\'t have address set yet, ' +
                          'please set an address first';
 
@@ -82,12 +86,12 @@ describe('contract: errors', function () {
         try {
             contract.once('BasicEvent', () => {});
             assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
     })
 
-    it('errors when an event name is reserved', function(){
+    it('errors when an event name is reserved', function () {
         const expected = 'The event "newListener" is a reserved event name, ' +
                          'you can\'t use it.';
 
@@ -98,46 +102,44 @@ describe('contract: errors', function () {
             "type": "event"
         }];
 
-        const contractAddress = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
         const contract = new eth.Contract(newListenerEventAbi, contractAddress);
 
         try {
             contract.once('newListener', () => {});
             assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
     })
 
-    it('errors when deploy is called without data', function(done){
+    it('errors when deploy is called without data (throw)', function () {
         const expected = 'No "data" specified in neither the given options, ' +
                          'nor the default options.';
 
-        const newAbi = [{
-          "inputs": [],
-          "payable": false,
-          "stateMutability": "nonpayable",
-          "type": "constructor"
-        }];
+        const contract = new eth.Contract(abi);
 
-        const contract = new eth.Contract(newAbi);
-
-        // Thrown error format
         try {
             contract.deploy();
             assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
+    });
+
+    it('errors when deploy is called without data (callback)', function (done) {
+        const expected = 'No "data" specified in neither the given options, ' +
+                         'nor the default options.';
+
+        const contract = new eth.Contract(abi);
 
         // Callback format
-        contract.deploy({}, function(err){
+        contract.deploy({}, function (err) {
             assert(err.message.includes(expected));
             done();
         });
     })
 
-    it('errors when send is called without a *contract address* set', function(){
+    it('errors when send is called without a *contract address* set', function () {
         const expected = 'This contract object doesn\'t have address set yet, ' +
                          'please set an address first.';
 
@@ -145,22 +147,33 @@ describe('contract: errors', function () {
         try {
             contract.methods.simpleMethod("0xaaa").send();
             assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
     });
 
-    it('errors when send is called without a *from address* being set', async function(){
+    it('errors when send is called without a *from address* being set (promise)', async function () {
         const expected = 'No "from" address specified in neither the given options, '
                          'nor the default options.';
 
-        const contractAddress = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
         const contract = new eth.Contract(abi, contractAddress);
         try {
             await contract.methods.simpleMethod("0xaaa").send({});
             assert.fail();
-        } catch(err){
+        } catch (err) {
             assert(err.message.includes(expected));
         }
+    });
+
+    it('errors when send is called without a *from address* being set (callback)', function (done) {
+        const expected = 'No "from" address specified in neither the given options, '
+                         'nor the default options.';
+
+        const contract = new eth.Contract(abi, contractAddress);
+
+        contract.methods.simpleMethod("0xaaa").send({}, function (err) {
+            assert(err.message.includes(expected))
+            done();
+        });
     });
 });

--- a/test/contract.errors.js
+++ b/test/contract.errors.js
@@ -1,0 +1,166 @@
+const assert = require('assert');
+const Eth = require('../packages/web3-eth');
+const FakeIpcProvider = require('./helpers/FakeIpcProvider');
+
+const abi = [{
+    name: "simpleMethod",
+    payable: false,
+    constant: true,
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "a", type: "bytes32" }],
+    outputs: [{ name: "b", type: "bytes32" }],
+}];
+
+describe('contract: errors', function () {
+    let provider;
+    let eth;
+
+    before(function(){
+        provider = new FakeIpcProvider();
+        eth = new Eth(provider);
+    })
+
+    it('errors when no ABI is provided / ABI is not array', function () {
+        const expected = 'You must provide the json interface of the ' +
+                         'contract when instantiating a contract object.';
+
+        // Existence check
+        try {
+            new eth.Contract();
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+
+        // Array check
+        try {
+            new eth.Contract({});
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+    })
+
+    it('errors when event listener is not provided with callback', function(){
+        const expected = 'Once requires a callback as the second parameter';
+        const contract = new eth.Contract(abi);
+
+        try {
+            contract.once('data');
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+    })
+
+    it('errors when a non-existant event is listened for', function(){
+        const expected = 'Event "void" doesn\'t exist in this contract';
+        const contract = new eth.Contract(abi);
+
+        try {
+            contract.once('void', () => {});
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+    })
+
+    it('errors when listening for event without setting address', function(){
+        const expected = 'This contract object doesn\'t have address set yet, ' +
+                         'please set an address first';
+
+        const eventAbi = [{
+            "anonymous": false,
+            "inputs": [],
+            "name": "BasicEvent",
+            "type": "event"
+        }];
+
+        const contract = new eth.Contract(eventAbi);
+
+        try {
+            contract.once('BasicEvent', () => {});
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+    })
+
+    it('errors when an event name is reserved', function(){
+        const expected = 'The event "newListener" is a reserved event name, ' +
+                         'you can\'t use it.';
+
+        const newListenerEventAbi = [{
+            "anonymous": false,
+            "inputs": [],
+            "name": "newListener",
+            "type": "event"
+        }];
+
+        const address = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
+        const contract = new eth.Contract(newListenerEventAbi, address);
+
+        try {
+            contract.once('newListener', () => {});
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+    })
+
+    it('errors when deploy is called without data', function(done){
+        const expected = 'No "data" specified in neither the given options, ' +
+                         'nor the default options.';
+
+        const newAbi = [{
+          "inputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        }];
+
+        const contract = new eth.Contract(newAbi);
+
+        // Thrown error format
+        try {
+            contract.deploy();
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+
+        // Callback format
+        contract.deploy({}, function(err){
+            assert(err.message.includes(expected));
+            done();
+        });
+    })
+
+    it('errors when send is called without a contract address set', function(){
+        const expected = 'This contract object doesn\'t have address set yet, ' +
+                         'please set an address first.';
+
+        const contract = new eth.Contract(abi);
+        try {
+            contract.methods.simpleMethod("0xaaa").send();
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+    });
+
+    it('errors when send is called without a from address being set', async function(){
+        const expected = 'No "from" address specified in neither the given options, '
+                         'nor the default options.';
+
+        const address = '0xEE221E529cF6DB20179E7bAeb4442e9CbdCa83d7';
+        const contract = new eth.Contract(abi, address);
+        try {
+            await contract.methods.simpleMethod("0xaaa").send({});
+            assert.fail();
+        } catch(err){
+            assert(err.message.includes(expected));
+        }
+    });
+});


### PR DESCRIPTION
## Description

Part of #3309 . 

Adds tests for errors thrown in the web3-eth-contract module. Per discussion in #3309, where an error is newly covered, its text is also migrated to web3-core-helpers so that these messages start to get consolidated in one place. 

There are some uncovered cases here...

In `_encodeMethodABI` and `_processExecuteArguments`, there are errors for missing deployment data and method param correctness which don't look reachable - those problems are checked in the `deploy` and `_createTxObject` calls which sit earlier in the call chain. 

Haven't removed this logic because it seems more risky than necessary but they could probably be addressed in a later code cleanup.

## Type of change

- [x] Tests

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
