### PR TITLE
Add npm alias scripts for generating html cov report locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "lint": "jshint *.js packages",
         "test": "mocha --grep E2E --invert; jshint *.js packages",
         "test:unit": "nyc --no-clean --silent _mocha -- -R spec --grep E2E --invert",
+        "test:cov": "npm run cov:clean; npm run test:unit; npm run test:e2e:clients; npm run cov:html",
         "dtslint": "lerna run dtslint",
         "depcheck": "lerna exec dependency-check -- --missing --verbose .",
         "bundlesize": "bundlesize",
@@ -49,7 +50,9 @@
         "test:e2e:ens": "./scripts/e2e.ens.sh",
         "test:e2e:ganache:core": "./scripts/e2e.ganache.core.sh",
         "ci": "./scripts/ci.sh",
-        "coveralls": "./scripts/coveralls.sh"
+        "coveralls": "./scripts/coveralls.sh",
+        "cov:clean": "rm -rf .nyc_output; rm -rf coverage",
+        "cov:html": "nyc report --reporter=html"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
## Description

Per [comment 3325][1], PR adds some npm alias scripts that let you generate an html coverage report locally.

`npm run test:cov` will run the unit and client tests, generating an aggregate coverage report that can be viewed in a browser by opening `web3.js/coverage/index.html`.

Have left out `test:e2e:ens` because it installs stuff in the project root - e.g it's designed to run in CI rather than locally. 

You can also combine commands to generate coverage more selectively if you're trying to look at the result of specific tests. e.g This will generate html coverage for `geth:insta` tests only:
```
npm run cov:clean 
npm run test:e2e:geth:insta 
npm run cov:html
```
**Example**:

![Screen Shot 2020-02-05 at 3 05 49 PM](https://user-images.githubusercontent.com/7332026/73891839-02bd2d00-482a-11ea-9993-a7230dbbfeb6.png)


[1]: https://github.com/ethereum/web3.js/pull/3325#issuecomment-580156149

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [ ] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
