### PR TITLE
Adds the ENS registry for goerli testnet

### DIFF
--- a/packages/web3-eth-ens/src/contracts/Registry.js
+++ b/packages/web3-eth-ens/src/contracts/Registry.js
@@ -361,7 +361,8 @@ export default class Registry extends AbstractContract {
         const ensAddresses = {
             main: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
             ropsten: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-            rinkeby: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
+            rinkeby: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+            goerli: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
         };
 
         const block = await this.net.getBlockByNumber('latest', false);


### PR DESCRIPTION
## Description

The ENS registry for goerli testnet has been added to version 1.x but is still missing in 2.x. This PR adds it in branch 2.x.

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [ ] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
