### PR TITLE
Add E2E events tests for subscribe("logs")

### DIFF
--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -73,6 +73,54 @@ describe('contract.events [ @E2E ]', function() {
         });
     });
 
+    it('hears events when subscribed to "logs" (emitter)', function(){
+        return new Promise(async function(resolve, reject){
+
+            assert(typeof instance.options.address === 'string');
+            assert(instance.options.address.length > 0);
+
+            const subscription = web3.eth.subscribe(
+                "logs",
+                {
+                    address: instance.options.address
+                })
+                .once("data", function(log) {
+                    assert.equal(log.address, instance.options.address);
+                    subscription.unsubscribe();
+                    resolve();
+                });
+
+            await instance
+                    .methods
+                    .firesEvent(accounts[0], 1)
+                    .send({from: accounts[0]});
+        });
+    });
+
+    it('hears events when subscribed to "logs" (callback)', function(){
+        return new Promise(async function(resolve, reject){
+
+            assert(typeof instance.options.address === 'string');
+            assert(instance.options.address.length > 0);
+
+            const subscription = web3.eth.subscribe(
+                "logs",
+                {
+                    address: instance.options.address
+                },
+                function(error, log) {
+                   assert.equal(log.address, instance.options.address);
+                   subscription.unsubscribe();
+                   resolve();
+                });
+
+            await instance
+                    .methods
+                    .firesEvent(accounts[0], 1)
+                    .send({from: accounts[0]});
+        });
+    });
+
     // Test models event signature shadowing when one contract calls another.
     // Child and parent contracts have an event named `similar` which has the same
     // function signature but indexes arguments differently.


### PR DESCRIPTION
## Description

Adds regression / example E2E tests for #1752 where there are recurrent reports that subscribing to logs and filtering by contract address never yields a result. 

Tests pass using ganache and a geth --dev client mining at 2 second intervals.

## Type of change

- [x] Test

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success and extended the tests if necessary.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
