### PR TITLE
Remove any-promise dependency

### DIFF
--- a/packages/web3-core-promievent/package-lock.json
+++ b/packages/web3-core-promievent/package-lock.json
@@ -4,11 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"any-promise": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-		},
 		"eventemitter3": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",

--- a/packages/web3-core-promievent/package.json
+++ b/packages/web3-core-promievent/package.json
@@ -9,7 +9,6 @@
     },
     "main": "src/index.js",
     "dependencies": {
-        "any-promise": "1.3.0",
         "eventemitter3": "3.1.2"
     }
 }

--- a/packages/web3-core-promievent/src/index.js
+++ b/packages/web3-core-promievent/src/index.js
@@ -23,7 +23,6 @@
 "use strict";
 
 var EventEmitter = require('eventemitter3');
-var Promise = require("any-promise");
 
 /**
  * This function generates a defer promise and adds eventEmitter functionality to it

--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -52,6 +52,18 @@
 				"semver": "^6.3.0"
 			}
 		},
+		"@web3-js/websocket": {
+			"version": "1.0.30",
+			"resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
+			"integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
+			"requires": {
+				"debug": "^2.2.0",
+				"es5-ext": "^0.10.50",
+				"nan": "^2.14.0",
+				"typedarray-to-buffer": "^3.1.5",
+				"yaeti": "^0.0.6"
+			}
+		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -247,6 +259,11 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
+		"cookiejar": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+		},
 		"create-ecdh": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -297,6 +314,23 @@
 				"public-encrypt": "^4.0.0",
 				"randombytes": "^2.0.0",
 				"randomfill": "^1.0.3"
+			}
+		},
+		"d": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+			"requires": {
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
 			}
 		},
 		"decode-uri-component": {
@@ -368,11 +402,11 @@
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"dev": true,
 			"requires": {
-				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200201"
+				"typescript": "next"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {
@@ -398,6 +432,35 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
+		"es5-ext": {
+			"version": "0.10.53",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+			"requires": {
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.3",
+				"next-tick": "~1.0.0"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+			"requires": {
+				"d": "^1.0.1",
+				"ext": "^1.1.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -428,6 +491,14 @@
 				"xhr-request-promise": "^0.1.2"
 			}
 		},
+		"ethereum-bloom-filters": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
+			"integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
+			"requires": {
+				"js-sha3": "^0.8.0"
+			}
+		},
 		"ethereumjs-common": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
@@ -456,6 +527,22 @@
 				"secp256k1": "^3.0.1"
 			}
 		},
+		"ethjs-unit": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+			"integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+			"requires": {
+				"bn.js": "4.11.6",
+				"number-to-bn": "1.7.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
+			}
+		},
 		"ethjs-util": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
@@ -465,6 +552,11 @@
 				"strip-hex-prefix": "1.0.0"
 			}
 		},
+		"eventemitter3": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+		},
 		"evp_bytestokey": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -472,6 +564,21 @@
 			"requires": {
 				"md5.js": "^1.3.4",
 				"safe-buffer": "^5.1.1"
+			}
+		},
+		"ext": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+			"integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+			"requires": {
+				"type": "^2.0.0"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+				}
 			}
 		},
 		"file-uri-to-path": {
@@ -559,6 +666,11 @@
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
+		"http-https": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
+			"integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -583,6 +695,16 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
 			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+		},
+		"js-sha3": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -686,15 +808,49 @@
 				"minimist": "0.0.8"
 			}
 		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
 		"nan": {
 			"version": "2.14.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
 			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+		},
+		"number-to-bn": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+			"integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+			"requires": {
+				"bn.js": "4.11.6",
+				"strip-hex-prefix": "1.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
+			}
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
+		"oboe": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
+			"integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+			"requires": {
+				"http-https": "^1.0.0"
+			}
 		},
 		"once": {
 			"version": "1.4.0",
@@ -960,6 +1116,19 @@
 				"tslib": "^1.8.1"
 			}
 		},
+		"type": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+			"integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+		},
+		"typedarray-to-buffer": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+			"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+			"requires": {
+				"is-typedarray": "^1.0.0"
+			}
+		},
 		"typescript": {
 			"version": "3.8.0-dev.20200201",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200201.tgz",
@@ -982,10 +1151,153 @@
 			"resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
 			"integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
 		},
+		"utf8": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+		},
+		"web3-core": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.6.tgz",
+			"integrity": "sha512-y/QNBFtr5cIR8vxebnotbjWJpOnO8LDYEAzZjeRRUJh2ijmhjoYk7dSNx9ExgC0UCfNFRoNCa9dGRu/GAxwRlw==",
+			"requires": {
+				"@types/bn.js": "^4.11.4",
+				"@types/node": "^12.6.1",
+				"web3-core-helpers": "1.2.6",
+				"web3-core-method": "1.2.6",
+				"web3-core-requestmanager": "1.2.6",
+				"web3-utils": "1.2.6"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "12.12.28",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.28.tgz",
+					"integrity": "sha512-g73GJYJDXgf0jqg+P9S8h2acWbDXNkoCX8DLtJVu7Fkn788pzQ/oJsrdJz/2JejRf/SjfZaAhsw+3nd1D5EWGg=="
+				}
+			}
+		},
+		"web3-core-helpers": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.6.tgz",
+			"integrity": "sha512-gYKWmC2HmO7RcDzpo4L1K8EIoy5L8iubNDuTC6q69UxczwqKF/Io0kbK/1Z10Av++NlzOSiuyGp2gc4t4UOsDw==",
+			"requires": {
+				"underscore": "1.9.1",
+				"web3-eth-iban": "1.2.6",
+				"web3-utils": "1.2.6"
+			}
+		},
+		"web3-core-method": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.6.tgz",
+			"integrity": "sha512-r2dzyPEonqkBg7Mugq5dknhV5PGaZTHBZlS/C+aMxNyQs3T3eaAsCTqlQDitwNUh/sUcYPEGF0Vo7ahYK4k91g==",
+			"requires": {
+				"underscore": "1.9.1",
+				"web3-core-helpers": "1.2.6",
+				"web3-core-promievent": "1.2.6",
+				"web3-core-subscriptions": "1.2.6",
+				"web3-utils": "1.2.6"
+			}
+		},
+		"web3-core-promievent": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.6.tgz",
+			"integrity": "sha512-km72kJef/qtQNiSjDJJVHIZvoVOm6ytW3FCYnOcCs7RIkviAb5JYlPiye0o4pJOLzCXYID7DK7Q9bhY8qWb1lw==",
+			"requires": {
+				"any-promise": "1.3.0",
+				"eventemitter3": "3.1.2"
+			}
+		},
+		"web3-core-requestmanager": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.6.tgz",
+			"integrity": "sha512-QU2cbsj9Dm0r6om40oSwk8Oqbp3wTa08tXuMpSmeOTkGZ3EMHJ1/4LiJ8shwg1AvPMrKVU0Nri6+uBNCdReZ+g==",
+			"requires": {
+				"underscore": "1.9.1",
+				"web3-core-helpers": "1.2.6",
+				"web3-providers-http": "1.2.6",
+				"web3-providers-ipc": "1.2.6",
+				"web3-providers-ws": "1.2.6"
+			}
+		},
+		"web3-core-subscriptions": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.6.tgz",
+			"integrity": "sha512-M0PzRrP2Ct13x3wPulFtc5kENH4UtnPxO9YxkfQlX2WRKENWjt4Rfq+BCVGYEk3rTutDfWrjfzjmqMRvXqEY5Q==",
+			"requires": {
+				"eventemitter3": "3.1.2",
+				"underscore": "1.9.1",
+				"web3-core-helpers": "1.2.6"
+			}
+		},
+		"web3-eth-iban": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.6.tgz",
+			"integrity": "sha512-TPMc3BW9Iso7H+9w+ytbqHK9wgOmtocyCD3PaAe5Eie50KQ/j7ThA60dGJnxItVo6yyRv5pZAYxPVob9x/fJlg==",
+			"requires": {
+				"bn.js": "4.11.8",
+				"web3-utils": "1.2.6"
+			}
+		},
+		"web3-providers-http": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.6.tgz",
+			"integrity": "sha512-2+SaFCspb5f82QKuHB3nEPQOF9iSWxRf7c18fHtmnLNVkfG9SwLN1zh67bYn3tZGUdOI3gj8aX4Uhfpwx9Ezpw==",
+			"requires": {
+				"web3-core-helpers": "1.2.6",
+				"xhr2-cookies": "1.1.0"
+			}
+		},
+		"web3-providers-ipc": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.6.tgz",
+			"integrity": "sha512-b0Es+/GTZyk5FG3SgUDW+2/mBwJAXWt5LuppODptiOas8bB2khLjG6+Gm1K4uwOb+1NJGPt5mZZ8Wi7vibtQ+A==",
+			"requires": {
+				"oboe": "2.1.4",
+				"underscore": "1.9.1",
+				"web3-core-helpers": "1.2.6"
+			}
+		},
+		"web3-providers-ws": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.6.tgz",
+			"integrity": "sha512-20waSYX+gb5M5yKhug5FIwxBBvkKzlJH7sK6XEgdOx6BZ9YYamLmvg9wcRVtnSZO8hV/3cWenO/tRtTrHVvIgQ==",
+			"requires": {
+				"@web3-js/websocket": "^1.0.29",
+				"underscore": "1.9.1",
+				"web3-core-helpers": "1.2.6"
+			}
+		},
+		"web3-utils": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+			"integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+			"requires": {
+				"bn.js": "4.11.8",
+				"eth-lib": "0.2.7",
+				"ethereum-bloom-filters": "^1.0.6",
+				"ethjs-unit": "0.1.6",
+				"number-to-bn": "1.7.0",
+				"randombytes": "^2.1.0",
+				"underscore": "1.9.1",
+				"utf8": "3.0.0"
+			},
+			"dependencies": {
+				"eth-lib": {
+					"version": "0.2.7",
+					"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+					"integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+					"requires": {
+						"bn.js": "^4.11.6",
+						"elliptic": "^6.4.0",
+						"xhr-request-promise": "^0.1.2"
+					}
+				}
+			}
 		},
 		"wrappy": {
 			"version": "1.0.2",
@@ -1025,10 +1337,23 @@
 				"xhr-request": "^1.0.1"
 			}
 		},
+		"xhr2-cookies": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+			"integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+			"requires": {
+				"cookiejar": "^2.1.1"
+			}
+		},
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
 			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+		},
+		"yaeti": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+			"integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
 		}
 	}
 }

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -14,7 +14,6 @@
     "main": "src/index.js",
     "dependencies": {
         "@web3-js/scrypt-shim": "^0.1.0",
-        "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
         "eth-lib": "^0.2.8",
         "ethereumjs-common": "^1.3.2",

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -25,7 +25,6 @@
 var _ = require('underscore');
 var core = require('web3-core');
 var Method = require('web3-core-method');
-var Promise = require('any-promise');
 var Account = require('eth-lib/lib/account');
 var Hash = require('eth-lib/lib/hash');
 var RLP = require('eth-lib/lib/rlp');// jshint ignore:line


### PR DESCRIPTION
## Description

The [any-promise][5] package has an [unsafe dereferencing][1] of the `window` object in its code that throws in the Web Worker environment. This PR removes it and falls back on native promises.

**What does any-promise do?** (from their README)
> NOTE: You probably want native promises now

> Let your library support any ES 2015 (ES6) compatible Promise and leave the choice to application authors. The application can optionally register its preferred Promise implementation and it will be exported when requiring any-promise from library code.

> If no preference is registered, defaults to the global Promise for newer Node.js versions. The browser version defaults to the window Promise, so polyfill or register as necessary.

Essentially, consumers of Web3 can decide which promise to use and Web3 will respect that, since it (usually) requires Promise from `any-promise`.

Hard to know if anyone is relying on this...

**Resources**
+ [Most browsers support native Promises][2] - exceptions are IE11 and Opera mini. 
+ IE 11 [lifecycle FAQ][3] advises users to switch to IE Edge
+ PR #1415 (March 2018) standardized use of `any-promise` at Web3
 
[1]: https://github.com/harttle/liquidjs/issues/73
[2]: https://caniuse.com/#feat=promises
[3]: https://support.microsoft.com/en-us/help/17454/lifecycle-faq-internet-explorer
[5]: https://github.com/kevinbeaty/any-promise

Fixes #3377 #2211 #1774

## Type of change

- [x] Bug fix (probably non-breaking?)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
- [x] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
