### PR TITLE
Add bignumber.js to web3-core (for its types)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,3 +151,4 @@ Released with 1.0.0-beta.37 code base.
 ### Fixed
 
 - Add missing subscription.on('connected') TS type definition (#3319)
+- Add missing bignumber.js dependency for TS types (#3386)

--- a/packages/web3-core/package-lock.json
+++ b/packages/web3-core/package-lock.json
@@ -67,6 +67,11 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"bignumber.js": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -143,11 +148,11 @@
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"dev": true,
 			"requires": {
-				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",
-				"typescript": "^3.8.0-dev.20200201"
+				"typescript": "next"
 			},
 			"dependencies": {
 				"definitelytyped-header-parser": {

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -15,6 +15,7 @@
     "dependencies": {
         "@types/bn.js": "^4.11.4",
         "@types/node": "^12.6.1",
+        "bignumber.js": "^9.0.0",
         "web3-core-helpers": "1.2.6",
         "web3-core-method": "1.2.6",
         "web3-core-requestmanager": "1.2.6",


### PR DESCRIPTION
## Description

In #3213 @types/bignumber.js was removed - that package is [now a stub][4] and the main module implements its types internally. 

However, bignumber.js is not a direct dependency here - it's only used for its types - and TS users currently see the error reported in #3386 about an unresolved import. 

`tsc` tests did not catch this because bignumber.js exists in the development dependency tree.

`bignumber.js` is imported in 
+ [web3-core][1]
+ [web3-eth][2] (which has web3-core [as a dep][3])

This PR should not affect the bundle size.

[1]: https://github.com/ethereum/web3.js/blob/1.x/packages/web3-core/types/index.d.ts#L31
[2]: https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth/types/index.d.ts#L51
[3]: https://github.com/ethereum/web3.js/blob/1.x/packages/web3-eth/package.json#L17
[4]: https://www.npmjs.com/package/@types/bignumber.js

Fixes #3386

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
- [ ] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
