### PR TITLE
Fix historical event subscriptions when made as first provider request 

### DIFF
--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -232,9 +232,13 @@ Subscription.prototype.subscribe = function() {
     // get past logs, if fromBlock is available
     if(payload.params[0] === 'logs' && _.isObject(payload.params[1]) && payload.params[1].hasOwnProperty('fromBlock') && isFinite(payload.params[1].fromBlock)) {
         // send the subscription request
+
+        // copy the params to avoid race-condition with deletion below this block
+        var blockParams = Object.assign({}, payload.params[1]);
+
         this.options.requestManager.send({
             method: 'eth_getLogs',
-            params: [payload.params[1]]
+            params: [blockParams]
         }, function (err, logs) {
             if(!err) {
                 logs.forEach(function(log){

--- a/test/e2e.contract.events.js
+++ b/test/e2e.contract.events.js
@@ -13,6 +13,7 @@ describe('contract.events [ @E2E ]', function() {
     var accounts;
     var basic;
     var instance;
+    var port;
 
     var basicOptions = {
         data: Basic.bytecode,
@@ -21,7 +22,7 @@ describe('contract.events [ @E2E ]', function() {
     };
 
     beforeEach(async function(){
-        var port = utils.getWebsocketPort();
+        port = utils.getWebsocketPort();
 
         web3 = new Web3('ws://localhost:' + port);
         accounts = await web3.eth.getAccounts();
@@ -70,6 +71,53 @@ describe('contract.events [ @E2E ]', function() {
                 .methods
                 .firesEvent(accounts[0], 1)
                 .send({from: accounts[0]});
+        });
+    });
+
+    // Regression test for a race-condition where a fresh web3 instance
+    // subscribing to past events would have its call parameters deleted while it
+    // made initial Websocket handshake and return an incorrect response.
+    it('can immediately listen for events in the past', async function(){
+        this.timeout(15000);
+
+        const first = await instance
+            .methods
+            .firesEvent(accounts[0], 1)
+            .send({from: accounts[0]});
+
+        const second = await instance
+            .methods
+            .firesEvent(accounts[0], 1)
+            .send({from: accounts[0]});
+
+        // Go forward one block...
+        await utils.mine(web3, accounts[0]);
+        const latestBlock = await web3.eth.getBlockNumber();
+
+        assert(first.blockNumber < latestBlock);
+        assert(second.blockNumber < latestBlock);
+
+        // Re-instantiate web3 & instance to simulate
+        // subscribing to past events as first request
+        web3 = new Web3('ws://localhost:' + port);
+        const newInstance = new web3.eth.Contract(Basic.abi, instance.options.address);
+
+        let counter = 0;
+        await new Promise(async resolve => {
+            newInstance
+                .events
+                .BasicEvent({
+                    fromBlock: 0
+                })
+                .on('data', function(event) {
+                    counter++;
+                    assert(event.blockNumber < latestBlock);
+
+                    if (counter === 2){
+                        this.removeAllListeners();
+                        resolve();
+                    }
+                });
         });
     });
 


### PR DESCRIPTION
## Description

**PR targets #3190** (because it fixes a Websocket bug)

Resolves a race condition that arises when the first request made by a Websocket provider is a subscription to an event which includes a request for historical logs. 

Web3 was deleting the `fromBlock` parameter made for the historical logs request while the Websocket connection established itself, resulting in the "missing logs" bug reported in #3389.

Commit 64c1302671c90c3d6497ea473599c8006a62f5af is a test that can be seen failing in [Travis here][1]
Commit  7f3f42b121c366a65da2dbf26509da8237ec0ee6 fixes it by copying the params. 

The copied params object looks like....
```js
{
 "fromBlock": "0x0",
 "topics": [
  "0x929af6b98ce8455e51b1e90cceeeec03ce38d7c7396f1f0b0233d043c898a29c",
  null
 ],
 "address": "0xc30a9b6f84a3d660585437a00ddd0090773ea9dc"
}
```

[1]: https://travis-ci.org/ethereum/web3.js/jobs/657937790#L664

Fixes #3389

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
- [ ] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
