### PR TITLE
Document WS clientConfig options in README and RTD

### DIFF
--- a/docs/include_package-core.rst
+++ b/docs/include_package-core.rst
@@ -99,6 +99,75 @@ Example
     // on windows the path is: "\\\\.\\pipe\\geth.ipc"
     // on linux the path is: "/users/myuser/.ethereum/geth.ipc"
 
+-------------
+Configuration
+-------------
+
+.. code-block:: javascript
+
+    // ====
+    // Http
+    // ====
+
+    var Web3HttpProvider = require('web3-providers-http');
+
+    var options = {
+        keepAlive: true,
+        withCredentials: false,
+        timeout: 20000, // ms
+        headers: [
+            {
+                name: 'Access-Control-Allow-Origin',
+                value: '*'
+            },
+            {
+                ...
+            }
+        ],
+        agent: {
+            http: http.Agent(...),
+            baseUrl: ''
+        }
+    };
+
+    var provider = new Web3HttpProvider('http://localhost:8545', options);
+
+    // ==========
+    // Websockets
+    // ==========
+
+    var Web3WsProvider = require('web3-providers-ws');
+
+    var options = {
+        timeout: 30000, // ms
+
+        // Useful for credentialed urls, e.g: ws://username:password@localhost:8546
+        headers: {
+          authorization: 'Basic username:password'
+        },
+
+        // Useful if requests result are large
+        clientConfig: {
+          maxReceivedFrameSize: 100000000,   // bytes - default: 1MiB
+          maxReceivedMessageSize: 100000000, // bytes - default: 8MiB
+        },
+
+        // Enable auto reconnection
+        reconnect: {
+            auto: true,
+            delay: 5000, // ms
+            maxAttempts: 5,
+            onTimeout: false
+        }
+    };
+
+    var ws = new Web3WsProvider('ws://localhost:8546', options);
+
+
+More information for the Http and Websocket provider modules can be found here:
+
+    - `HttpProvider <https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-http#usage>`_
+    - `WebsocketProvider <https://github.com/ethereum/web3.js/tree/1.x/packages/web3-providers-ws#usage>`_
 
 ------------------------------------------------------------------------------
 

--- a/packages/web3-providers-ws/README.md
+++ b/packages/web3-providers-ws/README.md
@@ -2,7 +2,7 @@
 
 This is a sub package of [web3.js][repo]
 
-This is a websocket provider for [web3.js][repo].  
+This is a websocket provider for [web3.js][repo].
 Please read the [documentation][docs] for more.
 
 ## Installation
@@ -31,16 +31,33 @@ This will expose the `Web3WsProvider` object on the window object.
 var Web3WsProvider = require('web3-providers-ws');
 
 var options = {
-    timeout: 30000,
-    headers: { authorization: 'Basic username:password' },
+    timeout: 30000, // ms
+
+    // Useful for credentialed urls, e.g: ws://username:password@localhost:8546
+    headers: {
+      authorization: 'Basic username:password'
+    },
+
+    // Useful if requests are large
+    clientConfig: {
+      maxReceivedFrameSize: 100000000,   // bytes - default: 1MiB
+      maxReceivedMessageSize: 100000000, // bytes - default: 8MiB
+    },
+
+    // Enable auto reconnection
     reconnect: {
-        auto: false,
-        delay: 5000,
-        maxAttempts: false,
+        auto: true,
+        delay: 5000, // ms
+        maxAttempts: 5,
         onTimeout: false
     }
-}; // set a custom timeout at 30 seconds, credentials (you can also add the credentials to the URL: ws://username:password@localhost:8546), and enable WebSocket auto-reconnection
+};
+
 var ws = new Web3WsProvider('ws://localhost:8546', options);
+
+(Additional client config options can be found [here][1])
+
+[1]: https://github.com/web3-js/WebSocket-Node/blob/polyfill/globalThis/docs/WebSocketClient.md
 ```
 
 ## Types


### PR DESCRIPTION
## Description

**PR targets #3190** (because it's a Websockets improvement)

Adds documentation about how to configure the Websocket provider's data size limits. This issue was raised recently in #3388 where someone was trying to read a large block from Ropsten. 

PR updates WS module README and creates a sub-section about configuring providers in the ReadTheDocs documentation.  

## Type of change

- [x] Documentation

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [ ] I ran ```npm run test:unit``` with success.
- [ ] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
