### PR TITLE
Clarify that 0x prefix is needed for imported private keys

### DIFF
--- a/docs/web3-eth-accounts.rst
+++ b/docs/web3-eth-accounts.rst
@@ -98,12 +98,18 @@ privateKeyToAccount
 
 Creates an account object from a private key.
 
+For more advanced hierarchial address derivation, see 
+[truffle-hd-awallet-provider](https://github.com/trufflesuite/truffle/tree/develop/packages/hdwallet-provider)
+package.
+
 ----------
 Parameters
 ----------
 
-1. ``privateKey`` - ``String``: The private key to convert.
-1. ``ignoreLength`` - ``Boolean``: If set to true does the ``privateKey`` length not get validated.
+1. ``privateKey`` - ``String``: The private key to import. This is 32 bytes of random data.
+If you are supplying a hexadecimal number, it must have `0x` prefix in order to be in line 
+with other Ethereum libraries.
+2. ``ignoreLength`` - ``Boolean``: If set to true does the ``privateKey`` length not get validated.
 
 -------
 Returns


### PR DESCRIPTION
## Description

Purely documentation update.

I run an issue that `web3.eth.accounts.privateKeyToAccount` private key format was behaving differently from other Ethereum packages

* truffle-hd-wallet

* ethereumjs-wallet

This may lead to a problem that users are freaking out and think they lost their account when dealing with raw private keys.

web3.js generated different accounts from the other packages because private key was handled differently. This was because of the disagreement if hexadecimal private keys should be prefixed with `0x` or not.

I clarified this in the documentation and also added a pointer about creating a HD wallet.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have selected the correct base branch. (Hopefully docs are still being updated for 1.x)
- [X] I have made corresponding changes to the documentation.
