### PR TITLE
Replace invalid UTF-8 chars when decoding

### DIFF
--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -20,7 +20,7 @@
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
         "underscore": "1.9.1",
-        "utf8": "3.0.0"
+        "uwutf8": "3.0.2"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -23,7 +23,7 @@
 var _ = require('underscore');
 var BN = require('bn.js');
 var numberToBN = require('number-to-bn');
-var utf8 = require('utf8');
+var uwutf8 = require('uwutf8');
 var Hash = require("eth-lib/lib/hash");
 var ethereumBloomFilters = require('ethereum-bloom-filters');
 
@@ -166,7 +166,7 @@ var rightPad = function (string, chars, sign) {
  * @returns {String} hex representation of input string
  */
 var utf8ToHex = function(str) {
-    str = utf8.encode(str);
+    str = uwutf8.encode(str);
     var hex = "";
 
     // remove \u0000 padding from either side
@@ -216,7 +216,7 @@ var hexToUtf8 = function(hex) {
         // }
     }
 
-    return utf8.decode(str);
+    return uwutf8.decode(str, { strict: false });
 };
 
 

--- a/test/utils.toUtf8.js
+++ b/test/utils.toUtf8.js
@@ -8,7 +8,8 @@ var tests = [
     { value: '0x6d79537472696e67', expected: 'myString'},
     { value: '0x6d79537472696e6700', expected: 'myString'},
     { value: '0x65787065637465642076616c7565000000000000000000000000000000000000', expected: 'expected value'},
-    { value: '0x000000000000000000000000000000000000657870656374000065642076616c7565', expected: 'expect\u0000\u0000ed value'}
+    { value: '0x000000000000000000000000000000000000657870656374000065642076616c7565', expected: 'expect\u0000\u0000ed value'},
+    { value: '0x9f90e274657374', expected: '���test' }
 ];
 
 describe('lib/utils/utils', function () {


### PR DESCRIPTION
## Description

Currently bad UTF-8 sequences cause getPastEvents to crash unrecoverably. Fixing the utility will allow programs to not die while listening to events that have bad logs.

Fixes #1610 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
- [x] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [x] I have tested my code on the live network.
