### PR TITLE
Add `npm` and `deps` badges to package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 # web3.js - Ethereum JavaScript API
 
-[![Gitter][gitter-image]][gitter-url] [![StackExchange][stackexchange-image]][stackexchange-url] [![NPM Package][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url] [![Coverage Status][coveralls-image]][coveralls-url]
-[![Lerna][lerna-image]][lerna-url]
+[![Gitter][gitter-image]][gitter-url] [![StackExchange][stackexchange-image]][stackexchange-url] [![NPM Package][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Lerna][lerna-image]][lerna-url]
 
 This is the Ethereum [JavaScript API][docs]
 which connects to the [Generic JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC) spec.
@@ -167,10 +166,8 @@ The contribution guidelines are provided in [CONTRIBUTIONS](./CONTRIBUTIONS.md)
 [npm-url]: https://npmjs.org/package/web3
 [travis-image]: https://travis-ci.org/ethereum/web3.js.svg?branch=1.x
 [travis-url]: https://travis-ci.org/ethereum/web3.js?branch=1.x
-[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg
-[deps-url]: https://david-dm.org/ethereum/web3.js/1.x
 [deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg
-[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x/#info=devDependencies
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev
 [coveralls-image]: https://coveralls.io/repos/ethereum/web3.js/badge.svg?branch=1.x
 [coveralls-url]: https://coveralls.io/r/ethereum/web3.js?branch=1.x
 [waffle-image]: https://badge.waffle.io/ethereum/web3.js.svg?label=ready&title=Ready

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # web3.js - Ethereum JavaScript API
 
-[![Gitter][gitter-image]][gitter-url] [![StackExchange][stackexchange-image]][stackexchange-url] [![NPM Package][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Lerna][lerna-image]][lerna-url]
+[![Gitter][gitter-image]][gitter-url] [![StackExchange][stackexchange-image]][stackexchange-url] [![NPM Package Version][npm-image-version]][npm-url] [![NPM Package Downloads][npm-image-downloads]][npm-url] [![Build Status][travis-image]][travis-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url] [![Coverage Status][coveralls-image]][coveralls-url] [![Lerna][lerna-image]][lerna-url]
 
 This is the Ethereum [JavaScript API][docs]
 which connects to the [Generic JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC) spec.
@@ -162,7 +162,8 @@ The contribution guidelines are provided in [CONTRIBUTIONS](./CONTRIBUTIONS.md)
 
 [repo]: https://github.com/ethereum/web3.js
 [docs]: http://web3js.readthedocs.io/
-[npm-image]: https://img.shields.io/npm/dm/web3.svg
+[npm-image-version]: https://img.shields.io/npm/v/web3.svg
+[npm-image-downloads]: https://img.shields.io/npm/dm/web3.svg
 [npm-url]: https://npmjs.org/package/web3
 [travis-image]: https://travis-ci.org/ethereum/web3.js.svg?branch=1.x
 [travis-url]: https://travis-ci.org/ethereum/web3.js?branch=1.x

--- a/packages/web3-bzz/README.md
+++ b/packages/web3-bzz/README.md
@@ -37,11 +37,11 @@ var bzz = new Web3Bzz('http://swarm-gateways.net');
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-bzz.svg
+[npm-image]: https://img.shields.io/npm/v/web3-bzz.svg
 [npm-url]: https://npmjs.org/package/web3-bzz
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-bzz
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-bzz

--- a/packages/web3-bzz/README.md
+++ b/packages/web3-bzz/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the swarm package.  
+This is the swarm package.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-bzz/README.md
+++ b/packages/web3-bzz/README.md
@@ -1,5 +1,7 @@
 # web3-bzz
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the swarm package.  
@@ -39,3 +41,9 @@ All the typescript typings are placed in the types folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-bzz.svg
+[npm-url]: https://npmjs.org/package/web3-bzz
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-bzz
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-bzz
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-bzz
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-bzz

--- a/packages/web3-core-helpers/README.md
+++ b/packages/web3-core-helpers/README.md
@@ -1,5 +1,7 @@
 # web3-core-helpers
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 Helper functions used in [web3.js][repo] packages.
@@ -26,7 +28,13 @@ helpers.errors;
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-core-helpers.svg
+[npm-url]: https://npmjs.org/package/web3-core-helpers
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-helpers
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-helpers
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core-helpers
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core-helpers

--- a/packages/web3-core-helpers/README.md
+++ b/packages/web3-core-helpers/README.md
@@ -32,7 +32,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-core-helpers.svg
+[npm-image]: https://img.shields.io/npm/v/web3-core-helpers.svg
 [npm-url]: https://npmjs.org/package/web3-core-helpers
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-helpers
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-helpers

--- a/packages/web3-core-method/README.md
+++ b/packages/web3-core-method/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-The Method package used within most [web3.js][repo] packages.
+This method package is used within most [web3.js][repo] packages.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-core-method/README.md
+++ b/packages/web3-core-method/README.md
@@ -1,5 +1,7 @@
 # web3-core-method
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 The Method package used within most [web3.js][repo] packages.
@@ -43,7 +45,13 @@ myCoolLib.sendTransaction({...}, function(){ ... });
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-core-method.svg
+[npm-url]: https://npmjs.org/package/web3-core-method
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-method
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core-method
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core-method

--- a/packages/web3-core-method/README.md
+++ b/packages/web3-core-method/README.md
@@ -52,7 +52,7 @@ All the TypeScript typings are placed in the `types` folder.
 [repo]: https://github.com/ethereum/web3.js
 [npm-image]: https://img.shields.io/npm/v/web3-core-method.svg
 [npm-url]: https://npmjs.org/package/web3-core-method
-[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-method
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-method
 [deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core-method
 [deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core-method

--- a/packages/web3-core-method/README.md
+++ b/packages/web3-core-method/README.md
@@ -49,7 +49,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-core-method.svg
+[npm-image]: https://img.shields.io/npm/v/web3-core-method.svg
 [npm-url]: https://npmjs.org/package/web3-core-method
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-method

--- a/packages/web3-core-promievent/README.md
+++ b/packages/web3-core-promievent/README.md
@@ -54,7 +54,7 @@ myFunc()
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-core-promievent.svg
+[npm-image]: https://img.shields.io/npm/v/web3-core-promievent.svg
 [npm-url]: https://npmjs.org/package/web3-core-promievent
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-promievent
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-promievent

--- a/packages/web3-core-promievent/README.md
+++ b/packages/web3-core-promievent/README.md
@@ -1,5 +1,7 @@
 # web3-core-promievent
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the PromiEvent package is used to return a EventEmitter mixed with a Promise to allow multiple final states as well as chaining.
@@ -52,5 +54,10 @@ myFunc()
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-
+[npm-image]: https://img.shields.io/npm/dm/web3-core-promievent.svg
+[npm-url]: https://npmjs.org/package/web3-core-promievent
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-promievent
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-promievent
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core-promievent
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core-promievent
 

--- a/packages/web3-core-promievent/README.md
+++ b/packages/web3-core-promievent/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the PromiEvent package is used to return a EventEmitter mixed with a Promise to allow multiple final states as well as chaining.
+This is the PromiEvent package used to return a EventEmitter mixed with a Promise to allow multiple final states as well as chaining.
+
 Please read the [documentation][docs] for more.
 
 ## Installation
@@ -51,7 +52,6 @@ myFunc()
 .on('done', console.log);
 ```
 
-
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
 [npm-image]: https://img.shields.io/npm/v/web3-core-promievent.svg
@@ -60,4 +60,3 @@ myFunc()
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-promievent
 [deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core-promievent
 [deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core-promievent
-

--- a/packages/web3-core-requestmanager/README.md
+++ b/packages/web3-core-requestmanager/README.md
@@ -40,7 +40,7 @@ var requestManager = new Web3RequestManager(new Web3WsProvider('ws://localhost:8
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-core-requestmanager.svg
+[npm-image]: https://img.shields.io/npm/v/web3-core-requestmanager.svg
 [npm-url]: https://npmjs.org/package/web3-core-requestmanager
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-requestmanager
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-requestmanager

--- a/packages/web3-core-requestmanager/README.md
+++ b/packages/web3-core-requestmanager/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-The requestmanager package is used by most [web3.js][repo] packages.
+This requestmanager package is used by most [web3.js][repo] packages.
+
 Please read the [documentation][docs] for more.
 
 ## Installation
@@ -36,7 +37,6 @@ var Web3RequestManager = require('web3-core-requestmanager');
 
 var requestManager = new Web3RequestManager(new Web3WsProvider('ws://localhost:8546'));
 ```
-
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js

--- a/packages/web3-core-requestmanager/README.md
+++ b/packages/web3-core-requestmanager/README.md
@@ -1,5 +1,7 @@
 # web3-core-requestmanager
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 The requestmanager package is used by most [web3.js][repo] packages.
@@ -38,5 +40,10 @@ var requestManager = new Web3RequestManager(new Web3WsProvider('ws://localhost:8
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-
+[npm-image]: https://img.shields.io/npm/dm/web3-core-requestmanager.svg
+[npm-url]: https://npmjs.org/package/web3-core-requestmanager
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-requestmanager
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-requestmanager
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core-requestmanager
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core-requestmanager
 

--- a/packages/web3-core-subscriptions/README.md
+++ b/packages/web3-core-subscriptions/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]tus][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo]
 
-The subscriptions package used within some [web3.js][repo] packages.
+This subscriptions package is used within some [web3.js][repo] packages.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-core-subscriptions/README.md
+++ b/packages/web3-core-subscriptions/README.md
@@ -56,7 +56,7 @@ myCoolLib.subscribe('newBlockHeaders', function(){ ... });
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-core-subscriptions.svg
+[npm-image]: https://img.shields.io/npm/v/web3-core-subscriptions.svg
 [npm-url]: https://npmjs.org/package/web3-core-subscriptions
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-subscriptions
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-subscriptions

--- a/packages/web3-core-subscriptions/README.md
+++ b/packages/web3-core-subscriptions/README.md
@@ -1,5 +1,7 @@
 # web3-core-subscriptions
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]tus][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 The subscriptions package used within some [web3.js][repo] packages.
@@ -54,5 +56,10 @@ myCoolLib.subscribe('newBlockHeaders', function(){ ... });
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-
+[npm-image]: https://img.shields.io/npm/dm/web3-core-subscriptions.svg
+[npm-url]: https://npmjs.org/package/web3-core-subscriptions
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core-subscriptions
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core-subscriptions
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core-subscriptions
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core-subscriptions
 

--- a/packages/web3-core/README.md
+++ b/packages/web3-core/README.md
@@ -1,5 +1,7 @@
 # web3-core
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 The core package contains core functions for [web3.js][repo] packages.
@@ -40,7 +42,13 @@ CoolLib.extend();
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-core.svg
+[npm-url]: https://npmjs.org/package/web3-core
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-core
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-core

--- a/packages/web3-core/README.md
+++ b/packages/web3-core/README.md
@@ -46,7 +46,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-core.svg
+[npm-image]: https://img.shields.io/npm/v/web3-core.svg
 [npm-url]: https://npmjs.org/package/web3-core
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-core
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-core

--- a/packages/web3-core/README.md
+++ b/packages/web3-core/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
 The core package contains core functions for [web3.js][repo] packages.
+
 Please read the [documentation][docs] for more.
 
 ## Installation
@@ -36,9 +37,6 @@ CoolLib.BatchRequest();
 CoolLib.extend();
 ...
 ```
-
-[docs]: http://web3js.readthedocs.io/en/1.0/
-[repo]: https://github.com/ethereum/web3.js
 
 ## Types
 

--- a/packages/web3-eth-abi/README.md
+++ b/packages/web3-eth-abi/README.md
@@ -1,5 +1,7 @@
 # web3-eth-abi
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the abi package to be used in the `web3-eth` package.
@@ -36,7 +38,13 @@ Web3EthAbi.encodeFunctionSignature('myMethod(uint256,string)');
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-eth-abi.svg
+[npm-url]: https://npmjs.org/package/web3-eth-abi
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-abi
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-abi
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-eth-abi
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-eth-abi

--- a/packages/web3-eth-abi/README.md
+++ b/packages/web3-eth-abi/README.md
@@ -42,7 +42,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-eth-abi.svg
+[npm-image]: https://img.shields.io/npm/v/web3-eth-abi.svg
 [npm-url]: https://npmjs.org/package/web3-eth-abi
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-abi
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-abi

--- a/packages/web3-eth-abi/README.md
+++ b/packages/web3-eth-abi/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the abi package to be used in the `web3-eth` package.
+This is the abi package used in the `web3-eth` package.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-eth-accounts/README.md
+++ b/packages/web3-eth-accounts/README.md
@@ -49,7 +49,7 @@ All the typescript typings are placed in the types folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-eth-accounts.svg
+[npm-image]: https://img.shields.io/npm/v/web3-eth-accounts.svg
 [npm-url]: https://npmjs.org/package/web3-eth-accounts
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-accounts
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-accounts

--- a/packages/web3-eth-accounts/README.md
+++ b/packages/web3-eth-accounts/README.md
@@ -1,5 +1,7 @@
 # web3-eth-accounts
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the accounts package to be used in the `web3-eth` package.
@@ -47,3 +49,9 @@ All the typescript typings are placed in the types folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-eth-accounts.svg
+[npm-url]: https://npmjs.org/package/web3-eth-accounts
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-accounts
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-accounts
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-eth-accounts
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-eth-accounts

--- a/packages/web3-eth-accounts/README.md
+++ b/packages/web3-eth-accounts/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the accounts package to be used in the `web3-eth` package.
+This is the accounts package used in the `web3-eth` package.
+
 Please read the [documentation][docs] for more.
 
 ## Installation
@@ -45,7 +46,7 @@ account.create();
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js

--- a/packages/web3-eth-contract/README.md
+++ b/packages/web3-eth-contract/README.md
@@ -1,5 +1,7 @@
 # web3-eth-contract
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the contract package to be used in the `web3-eth` package.
@@ -45,7 +47,13 @@ contract.methods.somFunc().send({from: ....})
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-eth-contract.svg
+[npm-url]: https://npmjs.org/package/web3-eth-contract
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-contract
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-contract
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-eth-contract
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-eth-contract

--- a/packages/web3-eth-contract/README.md
+++ b/packages/web3-eth-contract/README.md
@@ -51,7 +51,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-eth-contract.svg
+[npm-image]: https://img.shields.io/npm/v/web3-eth-contract.svg
 [npm-url]: https://npmjs.org/package/web3-eth-contract
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-contract
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-contract

--- a/packages/web3-eth-contract/README.md
+++ b/packages/web3-eth-contract/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the contract package to be used in the `web3-eth` package.
+This is the contract package used in the `web3-eth` package.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-eth-ens/README.md
+++ b/packages/web3-eth-ens/README.md
@@ -1,5 +1,7 @@
 # web3-eth-ens
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the contract package to be used in the `web3-eth` package.
@@ -37,7 +39,13 @@ ens.getAddress('ethereum.eth').then(function(result) {
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-eth-ens.svg
+[npm-url]: https://npmjs.org/package/web3-eth-ens
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-ens
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-ens
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-eth-ens
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-eth-ens

--- a/packages/web3-eth-ens/README.md
+++ b/packages/web3-eth-ens/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
 This is the contract package to be used in the `web3-eth` package.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-eth-ens/README.md
+++ b/packages/web3-eth-ens/README.md
@@ -43,7 +43,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-eth-ens.svg
+[npm-image]: https://img.shields.io/npm/v/web3-eth-ens.svg
 [npm-url]: https://npmjs.org/package/web3-eth-ens
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-ens
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-ens

--- a/packages/web3-eth-iban/README.md
+++ b/packages/web3-eth-iban/README.md
@@ -1,5 +1,7 @@
 # web3-eth-iban
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the IBAN package to be used in the `web3-eth` package.
@@ -39,7 +41,13 @@ iban.toAddress() > '0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B';
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-eth-iban.svg
+[npm-url]: https://npmjs.org/package/web3-eth-iban
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-iban
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-iban
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-eth-iban
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=web3-eth-iban

--- a/packages/web3-eth-iban/README.md
+++ b/packages/web3-eth-iban/README.md
@@ -45,7 +45,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-eth-iban.svg
+[npm-image]: https://img.shields.io/npm/v/web3-eth-iban.svg
 [npm-url]: https://npmjs.org/package/web3-eth-iban
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-iban
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-iban

--- a/packages/web3-eth-personal/README.md
+++ b/packages/web3-eth-personal/README.md
@@ -1,5 +1,7 @@
 # web3-eth-personal
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the personal package to be used in the `web3-eth` package.
@@ -35,7 +37,13 @@ var personal = new Web3EthPersonal('ws://localhost:8546');
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-eth-personal.svg
+[npm-url]: https://npmjs.org/package/web3-eth-personal
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-personal
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-personal
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-eth-personal
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-eth-personal

--- a/packages/web3-eth-personal/README.md
+++ b/packages/web3-eth-personal/README.md
@@ -41,7 +41,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-eth-personal.svg
+[npm-image]: https://img.shields.io/npm/v/web3-eth-personal.svg
 [npm-url]: https://npmjs.org/package/web3-eth-personal
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth-personal
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth-personal

--- a/packages/web3-eth-personal/README.md
+++ b/packages/web3-eth-personal/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the personal package to be used in the `web3-eth` package.
+This is the personal package used in the `web3-eth` package.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-eth/README.md
+++ b/packages/web3-eth/README.md
@@ -1,5 +1,7 @@
 # web3-eth
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the Eth package to be used [web3.js][repo].
@@ -35,7 +37,13 @@ var eth = new Web3Eth('ws://localhost:8546');
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
-[repo]: https://github.com/ethereum/web3.js
+[repo]: https://github.com/ethereum/web3-eth.js
+[npm-image]: https://img.shields.io/npm/dm/web3-eth.svg
+[npm-url]: https://npmjs.org/package/web3-eth
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-eth
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-eth

--- a/packages/web3-eth/README.md
+++ b/packages/web3-eth/README.md
@@ -41,7 +41,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3-eth.js
-[npm-image]: https://img.shields.io/npm/dm/web3-eth.svg
+[npm-image]: https://img.shields.io/npm/v/web3-eth.svg
 [npm-url]: https://npmjs.org/package/web3-eth
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-eth
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-eth

--- a/packages/web3-eth/README.md
+++ b/packages/web3-eth/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the Eth package to be used [web3.js][repo].
+This Eth package is used within some [web3.js][repo] package.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-net/README.md
+++ b/packages/web3-net/README.md
@@ -1,5 +1,7 @@
 # web3-net
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the net package to be used in other web3.js packages.
@@ -35,7 +37,13 @@ var net = new Web3Net('ws://localhost:8546');
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-net.svg
+[npm-url]: https://npmjs.org/package/web3-net
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-net
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-net
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-net
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-net

--- a/packages/web3-net/README.md
+++ b/packages/web3-net/README.md
@@ -41,7 +41,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-net.svg
+[npm-image]: https://img.shields.io/npm/v/web3-net.svg
 [npm-url]: https://npmjs.org/package/web3-net
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-net
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-net

--- a/packages/web3-net/README.md
+++ b/packages/web3-net/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is the net package to be used in other web3.js packages.
+This is the net package used in other [web3.js][repo] packages.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-providers-http/README.md
+++ b/packages/web3-providers-http/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-_This is a sub package of [web3.js][repo]_
+This is a sub-package of [web3.js][repo].
 
-This is a HTTP provider for [web3.js][repo].  
+This is a HTTP provider for [web3.js][repo].
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-providers-http/README.md
+++ b/packages/web3-providers-http/README.md
@@ -1,5 +1,7 @@
 # web3-providers-http
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 _This is a sub package of [web3.js][repo]_
 
 This is a HTTP provider for [web3.js][repo].  
@@ -44,7 +46,13 @@ var provider = new Web3HttpProvider('http://localhost:8545', options);
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-providers-http.svg
+[npm-url]: https://npmjs.org/package/web3-providers-http
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-providers-http
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-providers-http
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-providers-http
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-providers-http

--- a/packages/web3-providers-ipc/README.md
+++ b/packages/web3-providers-ipc/README.md
@@ -42,7 +42,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-providers-ipc.svg
+[npm-image]: https://img.shields.io/npm/v/web3-providers-ipc.svg
 [npm-url]: https://npmjs.org/package/web3-providers-ipc
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-providers-ipc
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-providers-ipc

--- a/packages/web3-providers-ipc/README.md
+++ b/packages/web3-providers-ipc/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This is a IPC provider for [web3.js][repo].  
+This is a IPC provider for [web3.js][repo].
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-providers-ipc/README.md
+++ b/packages/web3-providers-ipc/README.md
@@ -1,5 +1,7 @@
 # web3-providers-ipc
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is a IPC provider for [web3.js][repo].  
@@ -36,7 +38,13 @@ var ipc = new Web3IpcProvider('/Users/me/Library/Ethereum/geth.ipc', net);
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-providers-ipc.svg
+[npm-url]: https://npmjs.org/package/web3-providers-ipc
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-providers-ipc
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-providers-ipc
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-providers-ipc
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-providers-ipc

--- a/packages/web3-providers-ws/README.md
+++ b/packages/web3-providers-ws/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
 This is a websocket provider for [web3.js][repo].  
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-providers-ws/README.md
+++ b/packages/web3-providers-ws/README.md
@@ -1,5 +1,7 @@
 # web3-providers-ws
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is a websocket provider for [web3.js][repo].  
@@ -39,7 +41,13 @@ var ws = new Web3WsProvider('ws://localhost:8546', options);
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-providers-ws.svg
+[npm-url]: https://npmjs.org/package/web3-providers-ws
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-providers-ws
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-providers-ws
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-providers-ws
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-providers-ws

--- a/packages/web3-providers-ws/README.md
+++ b/packages/web3-providers-ws/README.md
@@ -45,7 +45,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-providers-ws.svg
+[npm-image]: https://img.shields.io/npm/v/web3-providers-ws.svg
 [npm-url]: https://npmjs.org/package/web3-providers-ws
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-providers-ws
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-providers-ws

--- a/packages/web3-shh/README.md
+++ b/packages/web3-shh/README.md
@@ -1,5 +1,7 @@
 # web3-shh
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This is the whisper v5 package.  
@@ -35,7 +37,13 @@ var shh = new Web3Personal('ws://localhost:8546');
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-shh.svg
+[npm-url]: https://npmjs.org/package/web3-shh
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-shh
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-shh
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-shh
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-shh

--- a/packages/web3-shh/README.md
+++ b/packages/web3-shh/README.md
@@ -41,7 +41,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-shh.svg
+[npm-image]: https://img.shields.io/npm/v/web3-shh.svg
 [npm-url]: https://npmjs.org/package/web3-shh
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-shh
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-shh

--- a/packages/web3-utils/README.md
+++ b/packages/web3-utils/README.md
@@ -46,7 +46,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3-utils.svg
+[npm-image]: https://img.shields.io/npm/v/web3-utils.svg
 [npm-url]: https://npmjs.org/package/web3-utils
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-utils
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-utils

--- a/packages/web3-utils/README.md
+++ b/packages/web3-utils/README.md
@@ -2,9 +2,10 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a sub package of [web3.js][repo]
+This is a sub-package of [web3.js][repo].
 
-This contains useful utility functions for Dapp developers.  
+This contains useful utility functions for Dapp developers.
+
 Please read the [documentation][docs] for more.
 
 ## Installation

--- a/packages/web3-utils/README.md
+++ b/packages/web3-utils/README.md
@@ -1,5 +1,7 @@
 # web3-utils
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a sub package of [web3.js][repo]
 
 This contains useful utility functions for Dapp developers.  
@@ -40,7 +42,13 @@ console.log(Web3Utils);
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3-utils.svg
+[npm-url]: https://npmjs.org/package/web3-utils
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3-utils
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3-utils
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3-utils
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3-utils

--- a/packages/web3/README.md
+++ b/packages/web3/README.md
@@ -16,11 +16,11 @@ npm install web3
 
 ## Types
 
-All the typescript typings are placed in the types folder.
+All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
-[npm-image]: https://img.shields.io/npm/dm/web3.svg
+[npm-image]: https://img.shields.io/npm/v/web3.svg
 [npm-url]: https://npmjs.org/package/web3
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3
 [deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3

--- a/packages/web3/README.md
+++ b/packages/web3/README.md
@@ -1,5 +1,7 @@
 # web3
 
+[![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
+
 This is a main package of [web3.js](https://github.com/ethereum/web3.js)
 
 Please read the main [readme](https://github.com/ethereum/web3.js) and [documentation](https://web3js.readthedocs.io) for more.
@@ -18,3 +20,9 @@ All the typescript typings are placed in the types folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[npm-image]: https://img.shields.io/npm/dm/web3.svg
+[npm-url]: https://npmjs.org/package/web3
+[deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3
+[deps-url]: https://david-dm.org/ethereum/web3.js/1.x?path=packages/web3
+[deps-dev-image]: https://david-dm.org/ethereum/web3.js/1.x/dev-status.svg?path=packages/web3
+[deps-dev-url]: https://david-dm.org/ethereum/web3.js/1.x?type=dev&path=packages/web3

--- a/packages/web3/README.md
+++ b/packages/web3/README.md
@@ -2,9 +2,9 @@
 
 [![NPM Package][npm-image]][npm-url] [![Dependency Status][deps-image]][deps-url] [![Dev Dependency Status][deps-dev-image]][deps-dev-url]
 
-This is a main package of [web3.js](https://github.com/ethereum/web3.js)
+This is the main package of [web3.js][repo].
 
-Please read the main [readme](https://github.com/ethereum/web3.js) and [documentation](https://web3js.readthedocs.io) for more.
+Please read the main [README][repo-readme] and [documentation][docs] for more.
 
 ## Installation
 
@@ -20,6 +20,7 @@ All the TypeScript typings are placed in the `types` folder.
 
 [docs]: http://web3js.readthedocs.io/en/1.0/
 [repo]: https://github.com/ethereum/web3.js
+[repo-readme]: https://github.com/ethereum/web3.js/blob/1.x/README.md
 [npm-image]: https://img.shields.io/npm/v/web3.svg
 [npm-url]: https://npmjs.org/package/web3
 [deps-image]: https://david-dm.org/ethereum/web3.js/1.x/status.svg?path=packages/web3


### PR DESCRIPTION
## Description

I noticed using [`david-dm.org`](https://david-dm.org/ethereum/web3.js/1.x) for the root repository is not so useful since the lerna structure has no deps in root (only devDeps), so this PR adds `npm` and `deps` badges to individual package READMEs.

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [ ] I ran ```npm run test:unit``` with success.
- [ ] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
