### PR TITLE
Move @types/node to dev dependencies

### DIFF
--- a/packages/web3/package-lock.json
+++ b/packages/web3/package-lock.json
@@ -25,9 +25,10 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.12.26",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
-			"integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA=="
+			"version": "12.12.34",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
+			"integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g==",
+			"dev": true
 		},
 		"@types/parsimmon": {
 			"version": "1.10.1",
@@ -135,7 +136,7 @@
 			"integrity": "sha512-ph4GXLw3HYzlQMJOFcpCqWHuL3MxJ/344OR7wn0wlQGchQGTIVNsSUl8iKEMatpy2geNMysgA9fQa6xVhHOkTQ==",
 			"dev": true,
 			"requires": {
-				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#production",
+				"definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#d957ad0bb2f4ecb60ac04f734e0b38fbc8e70b8a",
 				"fs-extra": "^6.0.1",
 				"strip-json-comments": "^2.0.1",
 				"tslint": "^5.12.0",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -49,7 +49,6 @@
         }
     ],
     "dependencies": {
-        "@types/node": "^12.6.1",
         "web3-bzz": "1.2.6",
         "web3-core": "1.2.6",
         "web3-eth": "1.2.6",
@@ -59,6 +58,7 @@
         "web3-utils": "1.2.6"
     },
     "devDependencies": {
+        "@types/node": "^12.12.34",
         "definitelytyped-header-parser": "^1.0.1",
         "dtslint": "0.4.2"
     }


### PR DESCRIPTION
## Description

**#3412 redux** (This is being re-opened on a local branch because the original PR was made directly from the 1.x branch of a fork and needed some maintainer edits -cg )

moving @types/node to a devDependency. It isn't needed at runtime, and if a library user is is targeting browser this dependency will give them incorrect type hints.

Fixes #2965 

and  re confirmation request of #3337 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
- [x] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [x] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [] I have updated the ``CHANGELOG.md`` file in the root folder.
- [] I have tested my code on the live network.
