### PR TITLE
add prefix to a private key on the web3-eth-accounts

### DIFF
--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -486,7 +486,9 @@ Wallet.prototype.create = function(numberOfAccounts, entropy) {
 };
 
 Wallet.prototype.add = function(account) {
-
+    if (!account.startsWith('0x')) {
+        account = '0x' + account;
+    }
     if (_.isString(account)) {
         account = this._accounts.privateKeyToAccount(account);
     }


### PR DESCRIPTION
Relates to https://github.com/ethereum/web3.js/issues/3458

Added `0x` prefix before executing functions if it not included.
