### PR TITLE
Use TextEncoder to encode UTF-8

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,14 +10,17 @@ function getTestFiles(){
     switch (process.env.BROWSER_BUNDLE_TEST){
         case 'publishedDist': return ["packages/web3/dist/web3.min.js", "test/e2e.minified.js"]
         case 'gitRepoDist':   return ["dist/web3.min.js", "test/e2e.minified.js"]
-        default:              return ["test/**/e2e*.js"]
+        default:              return ["test/**/e2e*.js", "test/**/*tf8*.js"]
     }
 }
 
 // Only loads browserified preprocessor for the logic unit tests so we can `require` stuff.
 function getPreprocessors(){
     if (!process.env.BROWSER_BUNDLE_TEST){
-        return { 'test/**/e2e*.js': [ 'browserify' ] }
+        return {
+            'test/**/e2e*.js': [ 'browserify' ],
+            'test/**/*tf8*.js': [ 'browserify' ]
+        }
     }
 }
 

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -19,8 +19,7 @@
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
-        "underscore": "1.9.1",
-        "utf8": "3.0.0"
+        "underscore": "1.9.1"
     },
     "devDependencies": {
         "definitelytyped-header-parser": "^1.0.1",

--- a/test/utils.toUtf8.js
+++ b/test/utils.toUtf8.js
@@ -8,7 +8,8 @@ var tests = [
     { value: '0x6d79537472696e67', expected: 'myString'},
     { value: '0x6d79537472696e6700', expected: 'myString'},
     { value: '0x65787065637465642076616c7565000000000000000000000000000000000000', expected: 'expected value'},
-    { value: '0x000000000000000000000000000000000000657870656374000065642076616c7565', expected: 'expect\u0000\u0000ed value'}
+    { value: '0x000000000000000000000000000000000000657870656374000065642076616c7565', expected: 'expect\u0000\u0000ed value'},
+    { value: '0x9f90e274657374', expected: '���test' }
 ];
 
 describe('lib/utils/utils', function () {


### PR DESCRIPTION
## Description

Use [TextEncoder](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder) to encode UTF-8 sequences.

Related: #1610 (Edit: Thought this would fix until @cgewecke noted that getPastEvents uses a different UTF-8 codec)
Related: #3441

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [ ] I ran ```npm run test:unit``` with success.
- [ ] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
- [ ] I ran ```npm run build-all``` and tested the resulting file/'s from  ```dist``` folder in a browser.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
