### PR TITLE
Update deps and tests for Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
                         "unit_and_e2e_clients",
                         "e2e_ganache",
                         "e2e_mosaic",
-                        "e2e_ens",
                         "e2e_browsers",
                     ]
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3116,12 +3116,6 @@
                 "normalize-path": "^2.1.1"
             }
         },
-        "app-module-path": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
-            "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
-            "dev": true
-        },
         "append-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
@@ -4928,6 +4922,14 @@
                         "parse-json": "^4.0.0",
                         "pify": "^3.0.0",
                         "strip-bom": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
                     }
                 },
                 "parse-json": {
@@ -4947,6 +4949,14 @@
                     "dev": true,
                     "requires": {
                         "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
                     }
                 },
                 "read-pkg": {
@@ -5221,20 +5231,6 @@
                         "json-parse-better-errors": "^1.0.1"
                     }
                 }
-            }
-        },
-        "coveralls": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.7.tgz",
-            "integrity": "sha512-mUuH2MFOYB2oBaA4D4Ykqi9LaEYpMMlsiOMJOrv358yAjP6enPIk55fod2fNJ8AvwoYXStWQls37rA+s5e7boA==",
-            "dev": true,
-            "requires": {
-                "growl": "~> 1.10.0",
-                "js-yaml": "^3.13.1",
-                "lcov-parse": "^0.0.10",
-                "log-driver": "^1.2.7",
-                "minimist": "^1.2.0",
-                "request": "^2.86.0"
             }
         },
         "cp-file": {
@@ -7502,8 +7498,7 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -7527,15 +7522,13 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                     "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                     "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -7552,22 +7545,19 @@
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                     "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                     "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -7698,8 +7688,7 @@
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -7713,7 +7702,6 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -7730,7 +7718,6 @@
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -7739,15 +7726,13 @@
                     "version": "0.0.8",
                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
                     "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -7768,7 +7753,6 @@
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -7857,8 +7841,7 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                     "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -7872,7 +7855,6 @@
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -7968,8 +7950,7 @@
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -8011,7 +7992,6 @@
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -8033,7 +8013,6 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -8082,15 +8061,13 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
                     "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 }
             }
         },
@@ -9650,6 +9627,14 @@
             "requires": {
                 "duplexer": "^0.1.1",
                 "pify": "^3.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
             }
         },
         "handlebars": {
@@ -9718,12 +9703,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
             "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-            "dev": true
-        },
-        "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
         "has-gulplog": {
@@ -11232,12 +11211,6 @@
                 "invert-kv": "^1.0.0"
             }
         },
-        "lcov-parse": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-            "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-            "dev": true
-        },
         "lead": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
@@ -11458,12 +11431,6 @@
             "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
             "dev": true
         },
-        "log-driver": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-            "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-            "dev": true
-        },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -11557,6 +11524,14 @@
             "dev": true,
             "requires": {
                 "pify": "^3.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
             }
         },
         "make-error": {
@@ -11768,6 +11743,14 @@
                         "parse-json": "^4.0.0",
                         "pify": "^3.0.0",
                         "strip-bom": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
                     }
                 },
                 "parse-json": {
@@ -11787,6 +11770,14 @@
                     "dev": true,
                     "requires": {
                         "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
                     }
                 },
                 "read-pkg": {
@@ -13421,12 +13412,6 @@
                 "readable-stream": "^2.0.1"
             }
         },
-        "original-require": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
-            "integrity": "sha1-DxMEcVhM0zURxew4yNWSE/msXiA=",
-            "dev": true
-        },
         "os-browserify": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -13859,9 +13844,9 @@
             "dev": true
         },
         "pify": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
             "dev": true
         },
         "pinkie": {
@@ -16365,6 +16350,14 @@
                 "pify": "^3.0.0",
                 "temp-dir": "^1.0.0",
                 "uuid": "^3.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
             }
         },
         "test-exclude": {
@@ -16398,6 +16391,14 @@
                         "parse-json": "^4.0.0",
                         "pify": "^3.0.0",
                         "strip-bom": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
                     }
                 },
                 "locate-path": {
@@ -16457,6 +16458,14 @@
                     "dev": true,
                     "requires": {
                         "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
                     }
                 },
                 "read-pkg": {
@@ -16722,82 +16731,6 @@
             "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
             "dev": true
         },
-        "truffle": {
-            "version": "5.1.8",
-            "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.8.tgz",
-            "integrity": "sha512-/r2ul1mtoNO2obGZmfQX3kjTPQdWRfIjW4sm5x35VJVxsdPif5WZXsDluPAlcbqJcqP6vwLZNmWoZHMLUE5Y8w==",
-            "dev": true,
-            "requires": {
-                "app-module-path": "^2.2.0",
-                "mocha": "5.2.0",
-                "original-require": "1.0.1"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.15.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-                    "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-                    "dev": true
-                },
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "he": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-                    "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-                    "dev": true
-                },
-                "mocha": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-                    "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-                    "dev": true,
-                    "requires": {
-                        "browser-stdout": "1.3.1",
-                        "commander": "2.15.1",
-                        "debug": "3.1.0",
-                        "diff": "3.5.0",
-                        "escape-string-regexp": "1.0.5",
-                        "glob": "7.1.2",
-                        "growl": "1.10.5",
-                        "he": "1.1.1",
-                        "minimatch": "3.0.4",
-                        "mkdirp": "0.5.1",
-                        "supports-color": "5.4.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-                    "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "tslib": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -16869,9 +16802,9 @@
             }
         },
         "typescript": {
-            "version": "3.9.0-dev.20200330",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.0-dev.20200330.tgz",
-            "integrity": "sha512-RI1hwkdnHUbQ78PT/VbLgrMjyb47/8+G2CIfuWW6lBAQIwgqjEyYlKW9PbDRG3WlHXieTMkE3Rjwn9hF08dU3Q==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
             "dev": true
         },
         "uglify-js": {
@@ -17788,7 +17721,7 @@
                 "eth-lib": "0.2.7",
                 "ethereumjs-common": "^1.3.2",
                 "ethereumjs-tx": "^2.1.1",
-                "scrypt-shim": "github:web3-js/scrypt-shim",
+                "scrypt-shim": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
                 "underscore": "1.9.1",
                 "uuid": "3.3.2",
                 "web3-core": "1.2.2",
@@ -17922,7 +17855,7 @@
             "requires": {
                 "underscore": "1.9.1",
                 "web3-core-helpers": "1.2.2",
-                "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+                "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
             },
             "dependencies": {
                 "websocket": {
@@ -18459,6 +18392,14 @@
                         "pify": "^3.0.0",
                         "sort-keys": "^2.0.0",
                         "write-file-atomic": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
                     }
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2882,6 +2882,37 @@
             "integrity": "sha512-vfzZGgZKRFy7KEWcBGfIFk+h6B+thDCLfkD1exMBMRlUsx2icA+J6y4kAbZs/TjSTeY1duw89QUU133TSzr60Q==",
             "dev": true
         },
+        "@web3-js/scrypt-shim": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
+            "integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
+            "dev": true,
+            "requires": {
+                "scryptsy": "^2.1.0",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "@web3-js/websocket": {
+            "version": "1.0.30",
+            "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
+            "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0",
+                "es5-ext": "^0.10.50",
+                "nan": "^2.14.0",
+                "typedarray-to-buffer": "^3.1.5",
+                "yaeti": "^0.0.6"
+            }
+        },
         "@zkochan/cmd-shim": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
@@ -3674,16 +3705,6 @@
                 "safe-buffer": "^5.0.1"
             }
         },
-        "bl": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-            "dev": true,
-            "requires": {
-                "readable-stream": "^2.3.5",
-                "safe-buffer": "^5.1.1"
-            }
-        },
         "blob": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -3946,24 +3967,6 @@
                 "randombytes": "^2.0.1"
             }
         },
-        "browserify-sha3": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.4.tgz",
-            "integrity": "sha1-CGxHuMgjFsnUcCLCYYWVRXbdjiY=",
-            "dev": true,
-            "requires": {
-                "js-sha3": "^0.6.1",
-                "safe-buffer": "^5.1.1"
-            },
-            "dependencies": {
-                "js-sha3": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.6.1.tgz",
-                    "integrity": "sha1-W4n3enR3Z5h39YxKB1JAk0sflcA=",
-                    "dev": true
-                }
-            }
-        },
         "browserify-sign": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
@@ -4029,12 +4032,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
             "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "dev": true
-        },
-        "buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
             "dev": true
         },
         "buffer-equal": {
@@ -5463,30 +5460,6 @@
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
         },
-        "decompress": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-            "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
-            "dev": true,
-            "requires": {
-                "decompress-tar": "^4.0.0",
-                "decompress-tarbz2": "^4.0.0",
-                "decompress-targz": "^4.0.0",
-                "decompress-unzip": "^4.0.1",
-                "graceful-fs": "^4.1.10",
-                "make-dir": "^1.0.0",
-                "pify": "^2.3.0",
-                "strip-dirs": "^2.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
-            }
-        },
         "decompress-response": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
@@ -5494,85 +5467,6 @@
             "dev": true,
             "requires": {
                 "mimic-response": "^1.0.0"
-            }
-        },
-        "decompress-tar": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
-            "dev": true,
-            "requires": {
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0",
-                "tar-stream": "^1.5.2"
-            }
-        },
-        "decompress-tarbz2": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
-            "dev": true,
-            "requires": {
-                "decompress-tar": "^4.1.0",
-                "file-type": "^6.1.0",
-                "is-stream": "^1.1.0",
-                "seek-bzip": "^1.0.5",
-                "unbzip2-stream": "^1.0.9"
-            },
-            "dependencies": {
-                "file-type": {
-                    "version": "6.2.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-                    "dev": true
-                }
-            }
-        },
-        "decompress-targz": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
-            "dev": true,
-            "requires": {
-                "decompress-tar": "^4.1.1",
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0"
-            }
-        },
-        "decompress-unzip": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
-            "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
-            "dev": true,
-            "requires": {
-                "file-type": "^3.8.0",
-                "get-stream": "^2.2.0",
-                "pify": "^2.3.0",
-                "yauzl": "^2.4.2"
-            },
-            "dependencies": {
-                "file-type": {
-                    "version": "3.9.0",
-                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-                    "dev": true
-                },
-                "get-stream": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-                    "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
-                    "dev": true,
-                    "requires": {
-                        "object-assign": "^4.0.1",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                }
             }
         },
         "dedent": {
@@ -5651,9 +5545,9 @@
             }
         },
         "defer-to-connect": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-            "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
             "dev": true
         },
         "define-properties": {
@@ -6538,14 +6432,13 @@
             }
         },
         "eth-lib": {
-            "version": "0.1.27",
-            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
-            "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+            "version": "0.1.29",
+            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+            "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
-                "keccakjs": "^0.2.1",
                 "nano-json-stream-parser": "^0.1.2",
                 "servify": "^0.1.12",
                 "ws": "^3.0.0",
@@ -7125,15 +7018,6 @@
                 "reusify": "^1.0.0"
             }
         },
-        "fd-slicer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
-            "dev": true,
-            "requires": {
-                "pend": "~1.2.0"
-            }
-        },
         "figgy-pudding": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -7148,12 +7032,6 @@
             "requires": {
                 "escape-string-regexp": "^1.0.5"
             }
-        },
-        "file-type": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
-            "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-            "dev": true
         },
         "file-uri-to-path": {
             "version": "1.0.0",
@@ -9003,16 +8881,14 @@
             "dev": true
         },
         "geth-dev-assistant": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/geth-dev-assistant/-/geth-dev-assistant-0.1.3.tgz",
-            "integrity": "sha512-HTWrfOEfq32mLaq5BQeGSNTlz9OShgpvospQnEB0PEupqgjhKubZX3VdTThXgnrwKEJwaxM2bAGjz3Ln+nvjwg==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/geth-dev-assistant/-/geth-dev-assistant-0.1.4.tgz",
+            "integrity": "sha512-9OATUppz1O9qmhiJLHe/SBHCdwmApMEBjDesfLpxR7hfVxeEFuur3eMuCd5TuQJttRzlqnVnJ9ZrB/Lo895hoA==",
             "dev": true,
             "requires": {
                 "colors": "^1.3.3",
                 "node-emoji": "^1.10.0",
-                "scrypt-shim": "git+https://github.com/web3-js/scrypt-shim.git#be5e616323a8b5e568788bf94d03c1b8410eac54",
-                "web3": "^1.2.1",
-                "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+                "web3": "^1.2.7-rc.0",
                 "yargs": "^13.2.2"
             },
             "dependencies": {
@@ -9071,9 +8947,9 @@
                     }
                 },
                 "p-limit": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-                    "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
                     "dev": true,
                     "requires": {
                         "p-try": "^2.0.0"
@@ -9150,9 +9026,9 @@
                     "dev": true
                 },
                 "yargs": {
-                    "version": "13.3.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-                    "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
                     "dev": true,
                     "requires": {
                         "cliui": "^5.0.0",
@@ -9164,13 +9040,13 @@
                         "string-width": "^3.0.0",
                         "which-module": "^2.0.0",
                         "y18n": "^4.0.0",
-                        "yargs-parser": "^13.1.1"
+                        "yargs-parser": "^13.1.2"
                     }
                 },
                 "yargs-parser": {
-                    "version": "13.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-                    "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
                     "dev": true,
                     "requires": {
                         "camelcase": "^5.0.0",
@@ -9431,16 +9307,50 @@
                 "sparkles": "^1.0.0"
             }
         },
+        "got": {
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+            "dev": true,
+            "requires": {
+                "@sindresorhus/is": "^0.14.0",
+                "@szmarczak/http-timer": "^1.1.2",
+                "cacheable-request": "^6.0.0",
+                "decompress-response": "^3.3.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^4.1.0",
+                "lowercase-keys": "^1.0.1",
+                "mimic-response": "^1.0.1",
+                "p-cancelable": "^1.0.0",
+                "to-readable-stream": "^1.0.0",
+                "url-parse-lax": "^3.0.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
+            }
+        },
         "graceful-fs": {
             "version": "4.1.15",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
             "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-            "dev": true
-        },
-        "graceful-readlink": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
             "dev": true
         },
         "growl": {
@@ -9886,9 +9796,9 @@
             }
         },
         "http-cache-semantics": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-            "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
             "dev": true
         },
         "http-errors": {
@@ -10324,9 +10234,9 @@
             "dev": true
         },
         "ipaddr.js": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-            "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "dev": true
         },
         "is-absolute": {
@@ -10518,12 +10428,6 @@
             "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
             "dev": true
         },
-        "is-natural-number": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
-            "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-            "dev": true
-        },
         "is-negated-glob": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -10626,9 +10530,9 @@
             }
         },
         "is-retry-allowed": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+            "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
             "dev": true
         },
         "is-ssh": {
@@ -11131,16 +11035,6 @@
                 "inherits": "^2.0.3",
                 "nan": "^2.2.1",
                 "safe-buffer": "^5.1.0"
-            }
-        },
-        "keccakjs": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
-            "integrity": "sha512-BjLkNDcfaZ6l8HBG9tH0tpmDv3sS2mA7FNQxFHpCdzP3Gb2MVruXBSuoM66SnVxKJpAr5dKGdkHD+bDokt8fTg==",
-            "dev": true,
-            "requires": {
-                "browserify-sha3": "^0.0.4",
-                "sha3": "^1.2.2"
             }
         },
         "keyv": {
@@ -12295,9 +12189,9 @@
             }
         },
         "mock-fs": {
-            "version": "4.10.2",
-            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.2.tgz",
-            "integrity": "sha512-ewPQ83O4U8/Gd8I15WoB6vgTTmq5khxBskUWCRvswUqjCfOOTREmxllztQOm+PXMWUxATry+VBWXQJloAyxtbQ==",
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.11.0.tgz",
+            "integrity": "sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw==",
             "dev": true
         },
         "modify-values": {
@@ -14068,9 +13962,9 @@
             }
         },
         "prepend-http": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
             "dev": true
         },
         "pretty-hrtime": {
@@ -14200,13 +14094,13 @@
             }
         },
         "proxy-addr": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-            "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+            "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
             "dev": true,
             "requires": {
                 "forwarded": "~0.1.2",
-                "ipaddr.js": "1.9.0"
+                "ipaddr.js": "1.9.1"
             }
         },
         "proxy-from-env": {
@@ -15038,23 +14932,6 @@
             "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
             "dev": true
         },
-        "scrypt-shim": {
-            "version": "git+https://github.com/web3-js/scrypt-shim.git#be5e616323a8b5e568788bf94d03c1b8410eac54",
-            "from": "git+https://github.com/web3-js/scrypt-shim.git#be5e616323a8b5e568788bf94d03c1b8410eac54",
-            "dev": true,
-            "requires": {
-                "scryptsy": "^2.1.0",
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
         "scryptsy": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
@@ -15075,26 +14952,6 @@
                 "elliptic": "^6.4.1",
                 "nan": "^2.14.0",
                 "safe-buffer": "^5.1.2"
-            }
-        },
-        "seek-bzip": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-            "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
-            "dev": true,
-            "requires": {
-                "commander": "~2.8.1"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.8.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-readlink": ">= 1.0.0"
-                    }
-                }
             }
         },
         "semver": {
@@ -15215,23 +15072,6 @@
             "requires": {
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.0.1"
-            }
-        },
-        "sha3": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-            "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
-            "dev": true,
-            "requires": {
-                "nan": "2.13.2"
-            },
-            "dependencies": {
-                "nan": {
-                    "version": "2.13.2",
-                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-                    "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
-                    "dev": true
-                }
             }
         },
         "shasum": {
@@ -15994,15 +15834,6 @@
                 "is-utf8": "^0.2.0"
             }
         },
-        "strip-dirs": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
-            "dev": true,
-            "requires": {
-                "is-natural-number": "^4.0.1"
-            }
-        },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -16150,14 +15981,13 @@
             }
         },
         "swarm-js": {
-            "version": "0.1.39",
-            "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
-            "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+            "version": "0.1.40",
+            "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.40.tgz",
+            "integrity": "sha512-yqiOCEoA4/IShXkY3WKwP5PvZhmoOOD8clsKA7EEcRILMkTEYHCQ21HDCAcVpmIxZq4LyZvWeRJ6quIyHk1caA==",
             "dev": true,
             "requires": {
                 "bluebird": "^3.5.0",
                 "buffer": "^5.0.5",
-                "decompress": "^4.0.0",
                 "eth-lib": "^0.1.26",
                 "fs-extra": "^4.0.2",
                 "got": "^7.1.0",
@@ -16166,13 +15996,13 @@
                 "mock-fs": "^4.1.0",
                 "setimmediate": "^1.0.5",
                 "tar": "^4.0.2",
-                "xhr-request-promise": "^0.1.2"
+                "xhr-request": "^1.0.1"
             },
             "dependencies": {
                 "bluebird": {
-                    "version": "3.7.1",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-                    "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+                    "version": "3.7.2",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+                    "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
                     "dev": true
                 },
                 "got": {
@@ -16203,11 +16033,26 @@
                     "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
                     "dev": true
                 },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+                    "dev": true
+                },
                 "setimmediate": {
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
                     "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
                     "dev": true
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "^1.0.1"
+                    }
                 }
             }
         },
@@ -16304,21 +16149,6 @@
                         "readable-stream": "^3.1.1"
                     }
                 }
-            }
-        },
-        "tar-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-            "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-            "dev": true,
-            "requires": {
-                "bl": "^1.0.0",
-                "buffer-alloc": "^1.2.0",
-                "end-of-stream": "^1.0.0",
-                "fs-constants": "^1.0.0",
-                "readable-stream": "^2.3.0",
-                "to-buffer": "^1.1.1",
-                "xtend": "^4.0.0"
             }
         },
         "tarr": {
@@ -16617,12 +16447,6 @@
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
         },
-        "to-buffer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-            "dev": true
-        },
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -16909,16 +16733,6 @@
             "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
             "dev": true
         },
-        "unbzip2-stream": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-            "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
-            "dev": true,
-            "requires": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
-        },
         "unc-path-regex": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -17150,12 +16964,12 @@
             "dev": true
         },
         "url-parse-lax": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
             "dev": true,
             "requires": {
-                "prepend-http": "^1.0.1"
+                "prepend-http": "^2.0.0"
             }
         },
         "url-set-query": {
@@ -17452,202 +17266,389 @@
             }
         },
         "web3": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
-            "integrity": "sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.7-rc.0.tgz",
+            "integrity": "sha512-Hvlwk5x7ZiUpK2O1APv9MVcZlBTUCvHNsdamO6s8ymv6ABrO0qqgoQqt6QGOSF0OhKUouoGVeUqEbuC8ZZpnmw==",
             "dev": true,
             "requires": {
-                "@types/node": "^12.6.1",
-                "web3-bzz": "1.2.2",
-                "web3-core": "1.2.2",
-                "web3-eth": "1.2.2",
-                "web3-eth-personal": "1.2.2",
-                "web3-net": "1.2.2",
-                "web3-shh": "1.2.2",
-                "web3-utils": "1.2.2"
-            }
-        },
-        "web3-bzz": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
-            "integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
-            "dev": true,
-            "requires": {
-                "@types/node": "^10.12.18",
-                "got": "9.6.0",
-                "swarm-js": "0.1.39",
-                "underscore": "1.9.1"
+                "web3-bzz": "1.2.7-rc.0",
+                "web3-core": "1.2.7-rc.0",
+                "web3-eth": "1.2.7-rc.0",
+                "web3-eth-personal": "1.2.7-rc.0",
+                "web3-net": "1.2.7-rc.0",
+                "web3-shh": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
             },
             "dependencies": {
-                "@types/node": {
-                    "version": "10.17.0",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.0.tgz",
-                    "integrity": "sha512-wuJwN2KV4tIRz1bu9vq5kSPasJ8IsEjZaP1ZR7KlmdUZvGF/rXy8DmXOVwUD0kAtvtJ7aqMKPqUXC0NUTDbrDg==",
-                    "dev": true
-                },
-                "get-stream": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
                     "dev": true,
                     "requires": {
-                        "pump": "^3.0.0"
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
                     }
                 },
-                "got": {
-                    "version": "9.6.0",
-                    "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-                    "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
                     "dev": true,
                     "requires": {
-                        "@sindresorhus/is": "^0.14.0",
-                        "@szmarczak/http-timer": "^1.1.2",
-                        "cacheable-request": "^6.0.0",
-                        "decompress-response": "^3.3.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^4.1.0",
-                        "lowercase-keys": "^1.0.1",
-                        "mimic-response": "^1.0.1",
-                        "p-cancelable": "^1.0.0",
-                        "to-readable-stream": "^1.0.0",
-                        "url-parse-lax": "^3.0.0"
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
                     }
                 },
-                "prepend-http": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-                    "dev": true
-                },
-                "pump": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
                     "dev": true,
                     "requires": {
-                        "end-of-stream": "^1.1.0",
-                        "once": "^1.3.1"
-                    }
-                },
-                "url-parse-lax": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-                    "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-                    "dev": true,
-                    "requires": {
-                        "prepend-http": "^2.0.0"
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
                     }
                 }
             }
         },
+        "web3-bzz": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.7-rc.0.tgz",
+            "integrity": "sha512-Z8RAP6qpS2dvYNgCCjDbc6rzGRay9ZI5bJzMOn5BwSJF6ySDhSkSh8aIPGrsL0NV61QLpT6Aqyrbkvoa5lJglg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "^10.12.18",
+                "got": "9.6.0",
+                "swarm-js": "^0.1.40",
+                "underscore": "1.9.1"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "10.17.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
+                    "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ==",
+                    "dev": true
+                }
+            }
+        },
         "web3-core": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
-            "integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.7-rc.0.tgz",
+            "integrity": "sha512-F1jw+zCUgu0KD1Pfru7shLATkE37VeTNpCIKFSLyX2ei9fCZSBdgS+gM3AknZIE0vcUFVNkMGZiTtiXkIpZP2w==",
             "dev": true,
             "requires": {
                 "@types/bn.js": "^4.11.4",
                 "@types/node": "^12.6.1",
-                "web3-core-helpers": "1.2.2",
-                "web3-core-method": "1.2.2",
-                "web3-core-requestmanager": "1.2.2",
-                "web3-utils": "1.2.2"
+                "bignumber.js": "^9.0.0",
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-core-method": "1.2.7-rc.0",
+                "web3-core-requestmanager": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "bignumber.js": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+                    "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+                    "dev": true
+                },
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
             }
         },
         "web3-core-helpers": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
-            "integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.7-rc.0.tgz",
+            "integrity": "sha512-9L9x0hbp/mKRFhn9RWm0f2PgExgfzlACbO+HwnSDyz720whzUJ3plrT0kwxNtE7GX5sP9u4+ALXJjfnhm/6dWA==",
             "dev": true,
             "requires": {
                 "underscore": "1.9.1",
-                "web3-eth-iban": "1.2.2",
-                "web3-utils": "1.2.2"
+                "web3-eth-iban": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
             }
         },
         "web3-core-method": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
-            "integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.7-rc.0.tgz",
+            "integrity": "sha512-kWOUzFQYRxfoHpet57g+L/DFwrWm2VrgU5qYxtJMgxHlGjgRV9tLcjWKyd7P/2z4r5O07vDplkenmVty84+HPQ==",
             "dev": true,
             "requires": {
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.2",
-                "web3-core-promievent": "1.2.2",
-                "web3-core-subscriptions": "1.2.2",
-                "web3-utils": "1.2.2"
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-core-promievent": "1.2.7-rc.0",
+                "web3-core-subscriptions": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
             }
         },
         "web3-core-promievent": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
-            "integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.7-rc.0.tgz",
+            "integrity": "sha512-xSmacnuhwzvoTGtvAiZ/YCbOMfyAWAdrThtTdY7Y/pXC1B1q1JbLtSxDG+9vnZ4eOjrivwEFL47RLnBzUPJdBg==",
             "dev": true,
             "requires": {
-                "any-promise": "1.3.0",
                 "eventemitter3": "3.1.2"
             }
         },
         "web3-core-requestmanager": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
-            "integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.7-rc.0.tgz",
+            "integrity": "sha512-ACuFWu/tWbKIEyY+mX9MkCxeKETS8FGNPFHzcPohSq0nhtXfoM+BTdMMN/BMN8N73QC5xmIv1oMVviEuk48P4w==",
             "dev": true,
             "requires": {
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.2",
-                "web3-providers-http": "1.2.2",
-                "web3-providers-ipc": "1.2.2",
-                "web3-providers-ws": "1.2.2"
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-providers-http": "1.2.7-rc.0",
+                "web3-providers-ipc": "1.2.7-rc.0",
+                "web3-providers-ws": "1.2.7-rc.0"
             }
         },
         "web3-core-subscriptions": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.2.tgz",
-            "integrity": "sha512-QbTgigNuT4eicAWWr7ahVpJyM8GbICsR1Ys9mJqzBEwpqS+RXTRVSkwZ2IsxO+iqv6liMNwGregbJLq4urMFcQ==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.7-rc.0.tgz",
+            "integrity": "sha512-kW89ucb+IsFrCxfH1MA6VqOFqkliBHpWYdTXsNCnhsNu6hZEzQ1OL8HaTJSRZGq7hgUGUS1/Dqnh6FFFOnfR/w==",
             "dev": true,
             "requires": {
                 "eventemitter3": "3.1.2",
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.2"
+                "web3-core-helpers": "1.2.7-rc.0"
             }
         },
         "web3-eth": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.2.tgz",
-            "integrity": "sha512-UXpC74mBQvZzd4b+baD4Ocp7g+BlwxhBHumy9seyE/LMIcMlePXwCKzxve9yReNpjaU16Mmyya6ZYlyiKKV8UA==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.7-rc.0.tgz",
+            "integrity": "sha512-IDF3SH2PTw0D2Lf78MzSIbgvavLoYmA4CO4kb5r68QgzGS/bcQ5VBadjrXkp9NieTGtLUr/BuuepYqWLXyGOrw==",
             "dev": true,
             "requires": {
                 "underscore": "1.9.1",
-                "web3-core": "1.2.2",
-                "web3-core-helpers": "1.2.2",
-                "web3-core-method": "1.2.2",
-                "web3-core-subscriptions": "1.2.2",
-                "web3-eth-abi": "1.2.2",
-                "web3-eth-accounts": "1.2.2",
-                "web3-eth-contract": "1.2.2",
-                "web3-eth-ens": "1.2.2",
-                "web3-eth-iban": "1.2.2",
-                "web3-eth-personal": "1.2.2",
-                "web3-net": "1.2.2",
-                "web3-utils": "1.2.2"
+                "web3-core": "1.2.7-rc.0",
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-core-method": "1.2.7-rc.0",
+                "web3-core-subscriptions": "1.2.7-rc.0",
+                "web3-eth-abi": "1.2.7-rc.0",
+                "web3-eth-accounts": "1.2.7-rc.0",
+                "web3-eth-contract": "1.2.7-rc.0",
+                "web3-eth-ens": "1.2.7-rc.0",
+                "web3-eth-iban": "1.2.7-rc.0",
+                "web3-eth-personal": "1.2.7-rc.0",
+                "web3-net": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
             }
         },
         "web3-eth-abi": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.2.tgz",
-            "integrity": "sha512-Yn/ZMgoOLxhTVxIYtPJ0eS6pnAnkTAaJgUJh1JhZS4ekzgswMfEYXOwpMaD5eiqPJLpuxmZFnXnBZlnQ1JMXsw==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.7-rc.0.tgz",
+            "integrity": "sha512-kzYGAVTlnuQd1Z99epC0qOpx5YDJ4Od6rQ+2qlLwg8RwOUKum+ATYscyviM3t9NrgO+sPxHw4rsLxZGGWUZBZw==",
             "dev": true,
             "requires": {
                 "ethers": "4.0.0-beta.3",
                 "underscore": "1.9.1",
-                "web3-utils": "1.2.2"
+                "web3-utils": "1.2.7-rc.0"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.0",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.0.tgz",
-                    "integrity": "sha512-wuJwN2KV4tIRz1bu9vq5kSPasJ8IsEjZaP1ZR7KlmdUZvGF/rXy8DmXOVwUD0kAtvtJ7aqMKPqUXC0NUTDbrDg==",
+                    "version": "10.17.19",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
+                    "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ==",
                     "dev": true
                 },
                 "elliptic": {
@@ -17660,6 +17661,34 @@
                         "brorand": "^1.0.1",
                         "hash.js": "^1.0.0",
                         "inherits": "^2.0.1"
+                    }
+                },
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    },
+                    "dependencies": {
+                        "elliptic": {
+                            "version": "6.5.2",
+                            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+                            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+                            "dev": true,
+                            "requires": {
+                                "bn.js": "^4.4.0",
+                                "brorand": "^1.0.1",
+                                "hash.js": "^1.0.0",
+                                "hmac-drbg": "^1.0.0",
+                                "inherits": "^2.0.1",
+                                "minimalistic-assert": "^1.0.0",
+                                "minimalistic-crypto-utils": "^1.0.0"
+                            }
+                        }
                     }
                 },
                 "ethers": {
@@ -17696,6 +17725,24 @@
                     "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
                     "dev": true
                 },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
                 "scrypt-js": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
@@ -17707,27 +17754,119 @@
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
                     "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
                     "dev": true
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
                 }
             }
         },
         "web3-eth-accounts": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.2.tgz",
-            "integrity": "sha512-KzHOEyXOEZ13ZOkWN3skZKqSo5f4Z1ogPFNn9uZbKCz+kSp+gCAEKxyfbOsB/JMAp5h7o7pb6eYsPCUBJmFFiA==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.7-rc.0.tgz",
+            "integrity": "sha512-hnsuEAKLb9OwcQrRBBZ/ZkWnlixEJuULxtawCds67Jvoa4OaBxNsaCKY8eZ79d9U2+bayoYjdj0WOSNdLvF/Qw==",
             "dev": true,
             "requires": {
-                "any-promise": "1.3.0",
+                "@web3-js/scrypt-shim": "^0.1.0",
                 "crypto-browserify": "3.12.0",
-                "eth-lib": "0.2.7",
+                "eth-lib": "^0.2.8",
                 "ethereumjs-common": "^1.3.2",
                 "ethereumjs-tx": "^2.1.1",
-                "scrypt-shim": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
                 "underscore": "1.9.1",
                 "uuid": "3.3.2",
-                "web3-core": "1.2.2",
-                "web3-core-helpers": "1.2.2",
-                "web3-core-method": "1.2.2",
-                "web3-utils": "1.2.2"
+                "web3-core": "1.2.7-rc.0",
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-core-method": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    },
+                    "dependencies": {
+                        "eth-lib": {
+                            "version": "0.2.7",
+                            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                            "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                            "dev": true,
+                            "requires": {
+                                "bn.js": "^4.11.6",
+                                "elliptic": "^6.4.0",
+                                "xhr-request-promise": "^0.1.2"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "web3-eth-contract": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.7-rc.0.tgz",
+            "integrity": "sha512-Gvw5/Ko+ArEfyt+iZO9yxjel476CpHH9v5CqBB5No8x0MUNUA7pEHlZcByHNbna8QtE/7lGRM/zQs8KCZlYuzw==",
+            "dev": true,
+            "requires": {
+                "@types/bn.js": "^4.11.4",
+                "underscore": "1.9.1",
+                "web3-core": "1.2.7-rc.0",
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-core-method": "1.2.7-rc.0",
+                "web3-core-promievent": "1.2.7-rc.0",
+                "web3-core-subscriptions": "1.2.7-rc.0",
+                "web3-eth-abi": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
             },
             "dependencies": {
                 "eth-lib": {
@@ -17741,147 +17880,332 @@
                         "xhr-request-promise": "^0.1.2"
                     }
                 },
-                "scrypt-shim": {
-                    "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
-                    "from": "github:web3-js/scrypt-shim",
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
                     "dev": true,
                     "requires": {
-                        "scryptsy": "^2.1.0",
-                        "semver": "^6.3.0"
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
                     }
                 },
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
                 }
             }
         },
-        "web3-eth-contract": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.2.tgz",
-            "integrity": "sha512-EKT2yVFws3FEdotDQoNsXTYL798+ogJqR2//CaGwx3p0/RvQIgfzEwp8nbgA6dMxCsn9KOQi7OtklzpnJMkjtA==",
-            "dev": true,
-            "requires": {
-                "@types/bn.js": "^4.11.4",
-                "underscore": "1.9.1",
-                "web3-core": "1.2.2",
-                "web3-core-helpers": "1.2.2",
-                "web3-core-method": "1.2.2",
-                "web3-core-promievent": "1.2.2",
-                "web3-core-subscriptions": "1.2.2",
-                "web3-eth-abi": "1.2.2",
-                "web3-utils": "1.2.2"
-            }
-        },
         "web3-eth-ens": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.2.tgz",
-            "integrity": "sha512-CFjkr2HnuyMoMFBoNUWojyguD4Ef+NkyovcnUc/iAb9GP4LHohKrODG4pl76R5u61TkJGobC2ij6TyibtsyVYg==",
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.7-rc.0.tgz",
+            "integrity": "sha512-Zqa2vrpFZN+3Cfrha8JohclOEMJ9FDOwXoGQLwanJElJXcRdYcoWr36lBWwvPtNoRfDUfnofZqdxieY2jwc37g==",
             "dev": true,
             "requires": {
                 "eth-ens-namehash": "2.0.8",
                 "underscore": "1.9.1",
-                "web3-core": "1.2.2",
-                "web3-core-helpers": "1.2.2",
-                "web3-core-promievent": "1.2.2",
-                "web3-eth-abi": "1.2.2",
-                "web3-eth-contract": "1.2.2",
-                "web3-utils": "1.2.2"
-            }
-        },
-        "web3-eth-iban": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.2.tgz",
-            "integrity": "sha512-gxKXBoUhaTFHr0vJB/5sd4i8ejF/7gIsbM/VvemHT3tF5smnmY6hcwSMmn7sl5Gs+83XVb/BngnnGkf+I/rsrQ==",
-            "dev": true,
-            "requires": {
-                "bn.js": "4.11.8",
-                "web3-utils": "1.2.2"
-            }
-        },
-        "web3-eth-personal": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.2.tgz",
-            "integrity": "sha512-4w+GLvTlFqW3+q4xDUXvCEMU7kRZ+xm/iJC8gm1Li1nXxwwFbs+Y+KBK6ZYtoN1qqAnHR+plYpIoVo27ixI5Rg==",
-            "dev": true,
-            "requires": {
-                "@types/node": "^12.6.1",
-                "web3-core": "1.2.2",
-                "web3-core-helpers": "1.2.2",
-                "web3-core-method": "1.2.2",
-                "web3-net": "1.2.2",
-                "web3-utils": "1.2.2"
-            }
-        },
-        "web3-net": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.2.tgz",
-            "integrity": "sha512-K07j2DXq0x4UOJgae65rWZKraOznhk8v5EGSTdFqASTx7vWE/m+NqBijBYGEsQY1lSMlVaAY9UEQlcXK5HzXTw==",
-            "dev": true,
-            "requires": {
-                "web3-core": "1.2.2",
-                "web3-core-method": "1.2.2",
-                "web3-utils": "1.2.2"
-            }
-        },
-        "web3-providers-http": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.2.tgz",
-            "integrity": "sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==",
-            "dev": true,
-            "requires": {
-                "web3-core-helpers": "1.2.2",
-                "xhr2-cookies": "1.1.0"
-            }
-        },
-        "web3-providers-ipc": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.2.tgz",
-            "integrity": "sha512-t97w3zi5Kn/LEWGA6D9qxoO0LBOG+lK2FjlEdCwDQatffB/+vYrzZ/CLYVQSoyFZAlsDoBasVoYSWZK1n39aHA==",
-            "dev": true,
-            "requires": {
-                "oboe": "2.1.4",
-                "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.2"
-            }
-        },
-        "web3-providers-ws": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.2.tgz",
-            "integrity": "sha512-Wb1mrWTGMTXOpJkL0yGvL/WYLt8fUIXx8k/l52QB2IiKzvyd42dTWn4+j8IKXGSYYzOm7NMqv6nhA5VDk12VfA==",
-            "dev": true,
-            "requires": {
-                "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.2",
-                "websocket": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e"
+                "web3-core": "1.2.7-rc.0",
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-core-promievent": "1.2.7-rc.0",
+                "web3-eth-abi": "1.2.7-rc.0",
+                "web3-eth-contract": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
             },
             "dependencies": {
-                "websocket": {
-                    "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-                    "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
                     "dev": true,
                     "requires": {
-                        "debug": "^2.2.0",
-                        "es5-ext": "^0.10.50",
-                        "nan": "^2.14.0",
-                        "typedarray-to-buffer": "^3.1.5",
-                        "yaeti": "^0.0.6"
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
                     }
                 }
             }
         },
-        "web3-shh": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.2.tgz",
-            "integrity": "sha512-og258NPhlBn8yYrDWjoWBBb6zo1OlBgoWGT+LL5/LPqRbjPe09hlOYHgscAAr9zZGtohTOty7RrxYw6Z6oDWCg==",
+        "web3-eth-iban": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.7-rc.0.tgz",
+            "integrity": "sha512-LSorPpb/pBcZFEULTIQInN2NY+UVxpI1aOXUHrtdsy6R+xBXxqWTka+lJQUKkJ7d7lEFrriZLpnw59z14iVn8Q==",
             "dev": true,
             "requires": {
-                "web3-core": "1.2.2",
-                "web3-core-method": "1.2.2",
-                "web3-core-subscriptions": "1.2.2",
-                "web3-net": "1.2.2"
+                "bn.js": "4.11.8",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
+            }
+        },
+        "web3-eth-personal": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.7-rc.0.tgz",
+            "integrity": "sha512-disFr7jcjYF7QyhSpEj1KuXDxg/nbZAP3pGNCwSrlH/TyQ7hHkxbRwgVqEGy8J55+Z7J/2ab3/WEa3K9X8JhNQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "^12.6.1",
+                "web3-core": "1.2.7-rc.0",
+                "web3-core-helpers": "1.2.7-rc.0",
+                "web3-core-method": "1.2.7-rc.0",
+                "web3-net": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
+            }
+        },
+        "web3-net": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.7-rc.0.tgz",
+            "integrity": "sha512-+zRVv9vEtQ942IM6r3cafL02+gmI4nM8tCuAsc7CnhJxvANqD9PjU4PWUGn9A5nhds2ZE7Xz+TWgRQdtHzH93A==",
+            "dev": true,
+            "requires": {
+                "web3-core": "1.2.7-rc.0",
+                "web3-core-method": "1.2.7-rc.0",
+                "web3-utils": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.7",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "number-to-bn": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+                    "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.6",
+                        "strip-hex-prefix": "1.0.0"
+                    },
+                    "dependencies": {
+                        "bn.js": {
+                            "version": "4.11.6",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+                            "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
+                            "dev": true
+                        }
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.7-rc.0",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.7-rc.0.tgz",
+                    "integrity": "sha512-yVRyxTeJazyEVRB+Iyzv5AZMDWD+NKXYm3YFCm5eCzjvKQgvKcv4oJITVZmVv6IRd9VccD3cTRNHkoQzbA7XzA==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "4.11.8",
+                        "eth-lib": "0.2.7",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
+            }
+        },
+        "web3-providers-http": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.7-rc.0.tgz",
+            "integrity": "sha512-0/QL3ybnm8pphtN9B1lo5ko4vPrlBgVp111LpoATt95A5oPrVGXAZVd6eNObQg4iwC9Gww8KdbFzpLGlYgHuPw==",
+            "dev": true,
+            "requires": {
+                "web3-core-helpers": "1.2.7-rc.0",
+                "xhr2-cookies": "1.1.0"
+            }
+        },
+        "web3-providers-ipc": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.7-rc.0.tgz",
+            "integrity": "sha512-BS41YKjlnXsKKOnhe7edaP6ZDfrgc63/s5K2/O4hTkG/9AENOWfxoVt6jXI4ET/+tnL11kVeezBH9zZy9xp04A==",
+            "dev": true,
+            "requires": {
+                "oboe": "2.1.4",
+                "underscore": "1.9.1",
+                "web3-core-helpers": "1.2.7-rc.0"
+            }
+        },
+        "web3-providers-ws": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.7-rc.0.tgz",
+            "integrity": "sha512-Pc7p0z8Y7VVLjfvSi36Wayoly+CU1+pDJVl89LHbluAZPiw7QqwDiGAoVLt6T9akT+F6GOpB7B7vRGj4qdoO6w==",
+            "dev": true,
+            "requires": {
+                "@web3-js/websocket": "^1.0.29",
+                "eventemitter3": "^4.0.0",
+                "underscore": "1.9.1",
+                "web3-core-helpers": "1.2.7-rc.0"
+            },
+            "dependencies": {
+                "eventemitter3": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+                    "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+                    "dev": true
+                }
+            }
+        },
+        "web3-shh": {
+            "version": "1.2.7-rc.0",
+            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.7-rc.0.tgz",
+            "integrity": "sha512-htH9fpvu0ccPfYE2JzkRdbuFXMFc7rCmhMqVD5fwv7sX+oduL4+CtjFkABCaud1AITBhg9bwVqXSjpRrvdkPJw==",
+            "dev": true,
+            "requires": {
+                "web3-core": "1.2.7-rc.0",
+                "web3-core-method": "1.2.7-rc.0",
+                "web3-core-subscriptions": "1.2.7-rc.0",
+                "web3-net": "1.2.7-rc.0"
             }
         },
         "web3-utils": {
@@ -18194,18 +18518,6 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
-            }
-        },
-        "websocket": {
-            "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-            "from": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-            "dev": true,
-            "requires": {
-                "debug": "^2.2.0",
-                "es5-ext": "^0.10.50",
-                "nan": "^2.14.0",
-                "typedarray-to-buffer": "^3.1.5",
-                "yaeti": "^0.0.6"
             }
         },
         "whatwg-url": {
@@ -18698,16 +19010,6 @@
                         "decamelize": "^1.2.0"
                     }
                 }
-            }
-        },
-        "yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
-            "dev": true,
-            "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.1.0"
             }
         },
         "yeast": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
     "devDependencies": {
         "@babel/core": "^7.6.4",
         "@babel/preset-env": "^7.6.3",
+        "@ensdomains/ens": "^0.4.0",
+        "@ensdomains/resolver": "^0.1.13",
         "@types/bignumber.js": "^4.0.2",
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.6.1",
@@ -132,18 +134,15 @@
         "karma-spec-reporter": "0.0.32",
         "lerna": "^3.18.3",
         "mocha": "^6.2.1",
-        "pify": "^4.0.1",
         "nyc": "^14.1.1",
+        "pify": "^4.0.1",
         "puppeteer": "^1.20.0",
+        "regenerator-runtime": "^0.13.3",
         "sandboxed-module": "^2.0.3",
         "surge": "^0.21.3",
         "typescript": "^3.8.3",
         "underscore": "^1.9.1",
         "vinyl-source-stream": "^2.0.0",
-        "wait-port": "^0.2.6",
-        "@ensdomains/ens": "^0.4.0",
-        "@ensdomains/resolver": "^0.1.13",
-        "truffle": "^5.1.8",
-        "regenerator-runtime": "^0.13.3"
+        "wait-port": "^0.2.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         "ethjs-signer": "^0.1.1",
         "exorcist": "^1.0.1",
         "ganache-cli": "^6.7.0",
-        "geth-dev-assistant": "^0.1.3",
+        "geth-dev-assistant": "^0.1.4",
         "gulp": "^4.0.2",
         "gulp-jshint": "^2.1.0",
         "gulp-rename": "^1.4.0",

--- a/test/e2e.contract.deploy.js
+++ b/test/e2e.contract.deploy.js
@@ -74,7 +74,7 @@ describe('contract.deploy [ @E2E ]', function() {
         it('errors on OOG reached while running EVM', async function(){
             const estimate = await basic
                 .deploy()
-                .estimateGas()
+                .estimateGas({from: accounts[0]})
 
             const gas = estimate - 1000;
 

--- a/test/e2e.method.call.js
+++ b/test/e2e.method.call.js
@@ -57,7 +57,7 @@ describe('method.call [ @E2E ]', function () {
                 await wrongInstance
                     .methods
                     .getValue()
-                    .call();
+                    .call({from: accounts[0]});
 
                 assert.fail();
 


### PR DESCRIPTION
## Description

Addresses some residual issues coming up in #3392
+ Removes truffle dev dep (should have been done in #3427). (Fixes build job?)
+ Updates geth-dev-assistant to 0.1.4. (Source of install crash on Node 13, mea culpa)
+ Fixes 2 client E2E tests for whose behavior changed due to the `eth_call` default account issue at Geth
+ Removes `e2e_ens` from matrix - this test was merged with `unit_and_e2e_clients` in #3427.

Fixes #3473

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] CI misc

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
- [x] I have executed ``npm run test:cov`` and my test cases do cover all lines and branches of the added code.
