### PR TITLE
Fix mosaic_e2e job error when CI run for fork PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
 
             - run: bash ./scripts/install.sh
             - run: bash ./scripts/ci.sh
-              continue-on-error: ${{ matrix.testCmd == 'e2e_ganache' || matrix.testCmd == 'e2e_mosiac' }}
+              continue-on-error: ${{ matrix.testCmd == 'e2e_ganache' || matrix.testCmd == 'e2e_mosaic' }}
 
             - name: Send coverage reports to Coveralls
               if: env.TEST == 'unit_and_e2e_clients'


### PR DESCRIPTION
## Description

@ryanio noted on gitter that in #3451 the mosaic_e2e job is erroring CI. 

The verdaccio jobs are marked continue-on-error because Lerna refuses to publish when the git head is in a detached state. We can checkout the branch if PR is made in the root repo but we'd need to add logic to pull in branches from an upstream remote to get this to work for PRs from forks.

Job's just error-ing because of a typo, should be fixed with d4fe796 
