### PR TITLE
Emit "error" and "end" events on WebsocketProvider close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,3 +185,4 @@ Released with 1.0.0-beta.37 code base.
 ### Fixed
 
 - Fix intermittent CI build issues with `dtslint`. (#3479)
+- Fix provider "error" / "end" events not fired when Websocket provider disconnects (#3485)

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -130,6 +130,13 @@ RequestManager.prototype.setProvider = function (provider, net) {
                     subscription.callback(errors.ConnectionCloseError(event));
                     _this.subscriptions.delete(subscription.subscription.id);
                 });
+
+                if(_this.provider.emit){
+                    _this.provider.emit('error', errors.ConnectionCloseError(event));
+                }
+            }
+            if(_this.provider.emit){
+                _this.provider.emit('end', event);
             }
         });
 


### PR DESCRIPTION
## Description

Adds "error" and "end" event emissions to the Provider "close" logic, restoring behavior that existed in the WebsocketProvider prior to 1.2.7. 

At the moment if you've attached these listeners directly to the provider, they're not firing as expected when the client drops.

For background, this topic was raised in the #3190 review [here][1]. @nivida noted:

> The old WS provider did have an error listener which triggered the same error as the close listener and because it was cleaning up the response callback array in the provider on errorwasn't it triggering the error a second time when the close listener got triggered. Another difference is that the RequestManager wasn't listening to provider errors before. One of these provider-specific and not request specific errors is the MaxAttemptsReachedOnReconnectingError on line 412.

Believe the change in this PR addresses that concern. The subscription error callbacks are fired and deleted in the close handler before the final error event is emitted. Have added test logic in 4a3ef1e to verify that subscription error handlers are only run once when the connection drops.
 
Fixes #3485

[1]: https://github.com/ethereum/web3.js/pull/3190#issuecomment-572943326
## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
- [x] I have updated the ``CHANGELOG.md`` file in the root folder.
- [ ] I have tested my code on the live network.
