### PR TITLE
Add --ignore-scripts to lerna publish command for E2E publishing tests

### DIFF
--- a/scripts/e2e.npm.publish.sh
+++ b/scripts/e2e.npm.publish.sh
@@ -60,6 +60,7 @@ lerna version minor \
   --no-git-tag-version \
   --no-push \
   --allow-branch $BRANCH \
+  --ignore-scripts \
   --yes
 
 # Set identity prior to publishing (necessary for Windows)
@@ -73,5 +74,6 @@ git commit -a -m 'virtual-version-bump'
 lerna publish from-package \
   --dist-tag e2e \
   --registry http://localhost:4873 \
+  --ignore-scripts \
   --yes
 


### PR DESCRIPTION
## Description

**Revival of #3472**

In #3470, the publishing steps are managed with npm lifecycle scripts. However the E2E npm installation tests don't install the dev dependencies required for the build (in order to preserve as much dep. isolation as possible) so that step fails. 

We don't use the minified bundle in these tests so we can safely skip here... 

The target branch for this is an open question...it might be nice to see those tests pass for the release and they're intended as pre-publication sanity checks. On the other hand maybe this fix belongs outside the release process.

(The tests pass here ... it could be floated in next week after the release is complete)


## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.