### PR TITLE
Add provider existence check to WebsocketProvider close emitter logic

### DIFF
--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -131,11 +131,11 @@ RequestManager.prototype.setProvider = function (provider, net) {
                     _this.subscriptions.delete(subscription.subscription.id);
                 });
 
-                if(_this.provider.emit){
+                if(_this.provider && _this.provider.emit){
                     _this.provider.emit('error', errors.ConnectionCloseError(event));
                 }
             }
-            if(_this.provider.emit){
+            if(_this.provider && _this.provider.emit){
                 _this.provider.emit('end', event);
             }
         });


### PR DESCRIPTION
## Description

In #3487, the `ganache_e2e` test is [crashing unexpectedly][1] because the changes in #3486 (incorrectly) assume that a provider is set while running the close event handler. 

In practice, the handler's execution priority isn't guaranteed and the provider may no longer be around by the time this logic is run.  

[1]: https://github.com/ethereum/web3.js/pull/3487/checks?check_run_id=621549425#step:5:3123

Fixes #3487 (see #3488) 

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran ```npm run dtslint``` with success and extended the tests and types if necessary.
- [x] I ran ```npm run test:unit``` with success.
