### PR TITLE
Expose bundlesize token in GH Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
             PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
             SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
             SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+            BUNDLESIZE_GITHUB_TOKEN: ${{ secrets.BUNDLESIZE_GITHUB_TOKEN }}
         steps:
             - uses: actions/setup-node@v1
               with:


### PR DESCRIPTION
## Description

In #3260 we added a bundle size checker to CI to track minified package size increases (cf: #1178). It relies on a CI env secret that needs to be ported to GH actions.

Looks like this on Travis:

![Screen Shot 2019-12-07 at 1 12 08 PM](https://user-images.githubusercontent.com/7332026/70380631-4dd2c680-18f3-11ea-965b-2b23689eec03.png)

## Type of change

- [x] CI tuning 🎶 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
