### PR TITLE
Fix WSS credentials Base64 encoding (for browser) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,3 +193,4 @@ Released with 1.0.0-beta.37 code base.
 
 - Fix intermittent CI build issues with `dtslint`. (#3479)
 - Fix provider "error" / "end" events not fired when Websocket provider disconnects (#3485)
+- Fix WSS credentials Base64 encoding (for browser) (#3508)

--- a/packages/web3-providers-ws/src/helpers.js
+++ b/packages/web3-providers-ws/src/helpers.js
@@ -18,7 +18,7 @@ if (isNode) {
         helpers = require('url').parse;
     }
 } else {
-    _btoa = btoa;
+    _btoa = btoa.bind(window);
     helpers = function(url) {
         return new URL(url);
     };

--- a/test/e2e.contract.deploy.js
+++ b/test/e2e.contract.deploy.js
@@ -151,9 +151,10 @@ describe('contract.deploy [ @E2E ]', function() {
     describe('ws', function() {
         // Websockets extremely erratic for geth instamine...
         if (process.env.GETH_INSTAMINE) return;
+        var port;
 
         before(async function(){
-            var port = utils.getWebsocketPort();
+            port = utils.getWebsocketPort();
 
             web3 = new Web3('ws://localhost:' + port);
             accounts = await web3.eth.getAccounts();
@@ -259,6 +260,10 @@ describe('contract.deploy [ @E2E ]', function() {
                     done();
                 })
         })
+
+        it('can connect over wss with username:password header', function(){
+            const _web3 = new Web3('wss://usr:psswrd@localhost:' + port);
+        });
     });
 });
 


### PR DESCRIPTION
## Description

Binds `btoa` to window correctly. 

```js
const _web3 = new Web3('wss://usr:psswrd@localhost:8546)
```
Currently the example above throws these errors in the browser:

**Chrome**
```
TypeError: Illegal invocation
    at new s (/var/folders/_p/1jdl7zfx1473cwzhqsz8gx4r0000gn/T/880f08d03d5a7b63dd93c6a4c8d3d895.browserify.js:125206:1235495)
```

**Firefox**
```
'btoa' called on an object that does not implement interface Window.
	s@/var/folders/_p/1jdl7zfx1473cwzhqsz8gx4r0000gn/T/3c102c58b323c6dbbf38414c1423b68e.browserify.js:125206:1235164
```

+ 17e9671 adds a test that can be seen [failing here][1]
+ 9be703d is the fix proposed by @vsleibenko in #3508 

[1]: https://github.com/ethereum/web3.js/pull/3509/checks?check_run_id=656626724#step:5:181
Fixes #3508


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
