### PR TITLE
Docs: fix newline in `sendTransaction` note

### DIFF
--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -1346,8 +1346,7 @@ Parameters
 
 2. ``callback`` - ``Function``: (optional) Optional callback, returns an error object as first parameter and the result as second.
 
-.. note:: The ``from`` property can also be an address or index from the :ref:`web3.eth.accounts.wallet <eth_accounts_wallet>`. It will then sign locally using the private key of that account, and send the transaction via :ref:`web3.eth.sendSignedTransaction() <eth-sendsignedtransaction>`. If the properties ``chain`` and ``hardfork`` or ``common`` are not set, Web3 will try to set appropriate values by
-querying the network for its chainId and networkId.
+.. note:: The ``from`` property can also be an address or index from the :ref:`web3.eth.accounts.wallet <eth_accounts_wallet>`. It will then sign locally using the private key of that account, and send the transaction via :ref:`web3.eth.sendSignedTransaction() <eth-sendsignedtransaction>`. If the properties ``chain`` and ``hardfork`` or ``common`` are not set, Web3 will try to set appropriate values by querying the network for its chainId and networkId.
 
 .. _eth-sendtransaction-return:
 


### PR DESCRIPTION
## Description

The "Note" in the docs for [sendTransaction](https://web3js.readthedocs.io/en/v1.2.7/web3-eth.html#sendtransaction) has a newline in its last sentence that breaks its formatting.

Screenshot:

<img width="753" alt="Screen Shot 2020-05-12 at 3 44 29 PM" src="https://user-images.githubusercontent.com/22116/81752955-7f822780-9467-11ea-8b6c-9c7522a39f9b.png">

This PR simply removes the newline.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Docs fix 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.