### PR TITLE
Pin geth docker version to v1.9.13

### DIFF
--- a/scripts/e2e.geth.automine.sh
+++ b/scripts/e2e.geth.automine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --period 2 --accounts 1 --tag 'stable'
+geth-dev-assistant --period 2 --accounts 1 --tag 'v1.9.13'
 
 # Test
 GETH_AUTOMINE=true nyc --no-clean --silent _mocha -- \

--- a/scripts/e2e.geth.instamine.sh
+++ b/scripts/e2e.geth.instamine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, bal=50 eth, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --accounts 1 --tag 'stable'
+geth-dev-assistant --accounts 1 --tag 'v1.9.13'
 
 # Test
 GETH_INSTAMINE=true nyc --no-clean --silent _mocha -- \


### PR DESCRIPTION
## Description

The revert reason tests are failing against the geth `stable` tag published today (v.1.9.14). 

At first glance it looks like geth is no longer passing back the return data which encodes reason strings when failing transactions are replayed as calls. 

(A temporary patch to get CI working again - issue is under investigation).

## Type of change

- [x] CI fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] My changes generate no new warnings.
