### PR TITLE
Update AbstractProvider and contract.methods TS definitions 

### DIFF
--- a/packages/web3-core/types/index.d.ts
+++ b/packages/web3-core/types/index.d.ts
@@ -420,6 +420,7 @@ export interface AbstractProvider {
     sendAsync(payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void;
     send?(payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void;
     request?(args: RequestArguments): Promise<any>;
+    connected?: boolean;
   }
 
 export type provider =

--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -46,9 +46,7 @@ export class Contract {
 
     deploy(options: DeployOptions): ContractSendMethod;
 
-    methods: {
-        [key: string]: ContractSendMethod;
-    };
+    methods: any;
 
     once(
         event: string,

--- a/scripts/e2e.geth.automine.sh
+++ b/scripts/e2e.geth.automine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --period 2 --accounts 1 --tag 'stable'
+geth-dev-assistant --period 2 --accounts 1 --tag 'v1.9.13'
 
 # Test
 GETH_AUTOMINE=true nyc --no-clean --silent _mocha -- \

--- a/scripts/e2e.geth.instamine.sh
+++ b/scripts/e2e.geth.instamine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, bal=50 eth, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --accounts 1 --tag 'stable'
+geth-dev-assistant --accounts 1 --tag 'v1.9.13'
 
 # Test
 GETH_INSTAMINE=true nyc --no-clean --silent _mocha -- \


### PR DESCRIPTION
## Description

**:warning: PR targets `release/1.2.8` branch :warning:**

Addresses tsc compilation errors generated while E2E testing 1.2.8 release vs. gnosis/dex-react as noted in [this review comment][1].

+ Reverts contract.method definition change in #3454 
  + tried OR-ing with `any` but that violates a TS lint rule about "union with any"
+ Adds optional `connected` property to AbstractProvider

As discussed in chat, the error thrown by the AbstractProvider definition is a little confusing. 
```
ERROR in /Users/cgewecke/code/ef/synII/dex-react/src/api/wallet/WalletApi.ts
ERROR in /Users/cgewecke/code/ef/synII/dex-react/src/api/wallet/WalletApi.ts(184,27):
TS2339: Property 'connected' does not exist on type 'HttpProvider | IpcProvider | WebsocketProvider | AbstractProvider'.
  Property 'connected' does not exist on type 'AbstractProvider'.
```

The problematic code [can be found here][2] and looks like:
```js
// needed if Web3 was pre-instantiated with wss | WebsocketProvider
const closeOpenWebSocketConnection = (web3: Web3): void => {
  if (
    web3 &&
    typeof web3.currentProvider === 'object' &&
    web3.currentProvider?.connected &&
    'disconnect' in web3.currentProvider
  ) {
    // code=1000 - Normal Closure
    web3.currentProvider.disconnect(1000, 'Switching provider')
  }
}
```

All the other Web3 providers have a connected property. Idk if the change in this PR is the right solution (...it squashes the tsc complaint though). 

[1]: https://github.com/ethereum/web3.js/pull/3510#issuecomment-628209636
[2]: https://github.com/gnosis/dex-react/blob/4e0557318356c0ab6b6e9124ce93496aa64407d7/src/api/wallet/WalletApi.ts#L179-L190

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
