### PR TITLE
Fix eth.clearSubscriptions size property de-referencing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,3 +210,5 @@ Released with 1.0.0-beta.37 code base.
 ### Changed
 
 ### Fixed
+
+- Fix size property de-referencing crash when calling web3.eth.clearSubscriptions (#3527)

--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -265,7 +265,7 @@ var Eth = function Eth() {
     });
 
 
-    this.clearSubscriptions = _this._requestManager.clearSubscriptions;
+    this.clearSubscriptions = _this._requestManager.clearSubscriptions.bind(_this._requestManager);
 
     // add net
     this.net = new Net(this);

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -54,6 +54,15 @@ describe('subscription connect/reconnect', function () {
             });
     });
 
+    it('clearSubscriptions', async function() {
+        web3.eth.subscribe('newBlockHeaders');
+        await waitSeconds(1); // Sub need a little time to set up
+
+        assert.equal(1, web3.eth._requestManager.subscriptions.size);
+        web3.eth.clearSubscriptions();
+        assert.equal(0, web3.eth._requestManager.subscriptions.size);
+    });
+
     it('resubscribes to an existing subscription', function (done) {
         this.timeout(5000);
 


### PR DESCRIPTION
## Description

The `this` property is not bound correctly at the `web3.eth` scope when calling clearSubscriptions:

https://github.com/ethereum/web3.js/blob/740a98258ead66c16b1ec12f3f888baee64694b6/packages/web3-eth/src/index.js#L268


...results in `this` referring to `web3.eth` rather than RequestManager when run here:

https://github.com/ethereum/web3.js/blob/740a98258ead66c16b1ec12f3f888baee64694b6/packages/web3-core-requestmanager/src/index.js#L269-L274

+ Failing test: commit 1616d2f [CI link][1]

[1]: https://github.com/ethereum/web3.js/pull/3531/checks?check_run_id=697255141#step:5:3195


Fixes #3527

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
