### PR TITLE
Upgrade from `@web3-js/scrypt-shim` to `scrypt-js`

### DIFF
--- a/packages/web3-eth-accounts/package-lock.json
+++ b/packages/web3-eth-accounts/package-lock.json
@@ -29,15 +29,6 @@
 			"integrity": "sha512-MoF2IC9oGSgArJwlxdst4XsvWuoYfNUWtBw0kpnCi6K05kV+Ecl7siEeJ40tgCbI9uqEMGQL/NlPMRv6KVkY5Q==",
 			"dev": true
 		},
-		"@web3-js/scrypt-shim": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
-			"integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
-			"requires": {
-				"scryptsy": "^2.1.0",
-				"semver": "^6.3.0"
-			}
-		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1243,10 +1234,10 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
 			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 		},
-		"scryptsy": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
-			"integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
+		"scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
 		},
 		"secp256k1": {
 			"version": "3.8.0",
@@ -1266,7 +1257,8 @@
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
 		},
 		"set-blocking": {
 			"version": "2.0.0",

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -13,11 +13,11 @@
     },
     "main": "src/index.js",
     "dependencies": {
-        "@web3-js/scrypt-shim": "^0.1.0",
         "crypto-browserify": "3.12.0",
         "eth-lib": "^0.2.8",
         "ethereumjs-common": "^1.3.2",
         "ethereumjs-tx": "^2.1.1",
+        "scrypt-js": "^3.0.1",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
         "web3-core": "1.2.8",

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -30,7 +30,7 @@ var Hash = require('eth-lib/lib/hash');
 var RLP = require('eth-lib/lib/rlp');// jshint ignore:line
 var Bytes = require('eth-lib/lib/bytes');// jshint ignore:line
 var cryp = (typeof global === 'undefined') ? require('crypto-browserify') : require('crypto');
-var scrypt = require('@web3-js/scrypt-shim');
+var scrypt = require('scrypt-js');
 var uuid = require('uuid');
 var utils = require('web3-utils');
 var helpers = require('web3-core-helpers');
@@ -366,7 +366,7 @@ Accounts.prototype.decrypt = function(v3Keystore, password, nonStrict) {
         kdfparams = json.crypto.kdfparams;
 
         // FIXME: support progress reporting callback
-        derivedKey = scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
+        derivedKey = scrypt.syncScrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
     } else if (json.crypto.kdf === 'pbkdf2') {
         kdfparams = json.crypto.kdfparams;
 
@@ -416,7 +416,7 @@ Accounts.prototype.encrypt = function(privateKey, password, options) {
         kdfparams.n = options.n || 8192; // 2048 4096 8192 16384
         kdfparams.r = options.r || 8;
         kdfparams.p = options.p || 1;
-        derivedKey = scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
+        derivedKey = scrypt.syncScrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen);
     } else {
         throw new Error('Unsupported kdf');
     }

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -84,11 +84,6 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -98,16 +93,6 @@
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
-		},
-		"brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
-		},
-		"buffer-to-arraybuffer": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
-			"integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
@@ -246,29 +231,11 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
-		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-		},
-		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"requires": {
-				"mimic-response": "^1.0.0"
-			}
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
-		},
-		"dom-walk": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-			"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 		},
 		"dts-critic": {
 			"version": "3.0.1",
@@ -355,20 +322,6 @@
 				}
 			}
 		},
-		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-			"requires": {
-				"bn.js": "^4.4.0",
-				"brorand": "^1.0.1",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.0",
-				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.0"
-			}
-		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -430,40 +383,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
-		},
-		"eth-lib": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-			"integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-			"requires": {
-				"bn.js": "^4.11.6",
-				"elliptic": "^6.4.0",
-				"xhr-request-promise": "^0.1.2"
-			}
-		},
-		"ethereum-bloom-filters": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
-			"integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
-			"requires": {
-				"js-sha3": "^0.8.0"
-			}
-		},
-		"ethjs-unit": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
-			"integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
-			"requires": {
-				"bn.js": "4.11.6",
-				"number-to-bn": "1.7.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.6",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-				}
-			}
 		},
 		"eventemitter3": {
 			"version": "4.0.0",
@@ -555,15 +474,6 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
-		"global": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-			"requires": {
-				"min-document": "^2.19.0",
-				"process": "~0.5.1"
-			}
-		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -593,25 +503,6 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
-		"hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"requires": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
-		"hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-			"requires": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -625,7 +516,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"invert-kv": {
 			"version": "2.0.0",
@@ -638,16 +530,6 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 			"dev": true
-		},
-		"is-function": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
-		},
-		"is-hex-prefixed": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -665,11 +547,6 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
-		},
-		"js-sha3": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -756,29 +633,6 @@
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
 		},
-		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-		},
-		"min-document": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-			"requires": {
-				"dom-walk": "^0.1.0"
-			}
-		},
-		"minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-		},
-		"minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -839,31 +693,11 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
-		"number-to-bn": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
-			"integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
-			"requires": {
-				"bn.js": "4.11.6",
-				"strip-hex-prefix": "1.0.0"
-			},
-			"dependencies": {
-				"bn.js": {
-					"version": "4.11.6",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-				}
-			}
-		},
-		"object-assign": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -921,11 +755,6 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
-		"parse-headers": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
-			"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
-		},
 		"parsimmon": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.13.0.tgz",
@@ -956,11 +785,6 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
-		"process": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -969,24 +793,6 @@
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
-			}
-		},
-		"query-string": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-			"requires": {
-				"decode-uri-component": "^0.2.0",
-				"object-assign": "^4.1.0",
-				"strict-uri-encode": "^1.0.0"
-			}
-		},
-		"randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"requires": {
-				"safe-buffer": "^5.1.0"
 			}
 		},
 		"require-directory": {
@@ -1009,11 +815,6 @@
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
-		},
-		"safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"semver": {
 			"version": "6.3.0",
@@ -1048,31 +849,11 @@
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
-		"simple-concat": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
-		},
-		"simple-get": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-			"requires": {
-				"decompress-response": "^3.3.0",
-				"once": "^1.3.1",
-				"simple-concat": "^1.0.0"
-			}
-		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
-		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -1099,14 +880,6 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
-		"strip-hex-prefix": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-			"requires": {
-				"is-hex-prefixed": "1.0.0"
-			}
-		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1118,11 +891,6 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 			"dev": true
-		},
-		"timed-out": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"tslib": {
 			"version": "1.11.1",
@@ -1197,50 +965,6 @@
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
-		},
-		"url-set-query": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
-			"integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
-		},
-		"utf8": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-		},
-		"web3-core-helpers": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.8.tgz",
-			"integrity": "sha512-Wrl7ZPKn3Xyg0Hl5+shDnJcLP+EtTfThmQ1eCJLcg/BZqvLUR1SkOslNlhEojcYeBwhhymAKs8dfQbtYi+HMnw==",
-			"requires": {
-				"underscore": "1.9.1",
-				"web3-eth-iban": "1.2.8",
-				"web3-utils": "1.2.8"
-			}
-		},
-		"web3-eth-iban": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.8.tgz",
-			"integrity": "sha512-xgPUOuDOQJYloUS334/wot6jvp6K8JBz8UvQ1tAxU9LO2v2DW+IDTJ5gQ6TdutTmzdDi97KdwhwnQwhQh5Z1PA==",
-			"requires": {
-				"bn.js": "4.11.8",
-				"web3-utils": "1.2.8"
-			}
-		},
-		"web3-utils": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
-			"integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
-			"requires": {
-				"bn.js": "4.11.8",
-				"eth-lib": "0.2.7",
-				"ethereum-bloom-filters": "^1.0.6",
-				"ethjs-unit": "0.1.6",
-				"number-to-bn": "1.7.0",
-				"randombytes": "^2.1.0",
-				"underscore": "1.9.1",
-				"utf8": "3.0.0"
-			}
 		},
 		"websocket": {
 			"version": "1.0.31",
@@ -1319,45 +1043,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"xhr": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
-			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
-			"requires": {
-				"global": "~4.3.0",
-				"is-function": "^1.0.1",
-				"parse-headers": "^2.0.0",
-				"xtend": "^4.0.0"
-			}
-		},
-		"xhr-request": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
-			"integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
-			"requires": {
-				"buffer-to-arraybuffer": "^0.0.5",
-				"object-assign": "^4.1.1",
-				"query-string": "^5.0.1",
-				"simple-get": "^2.7.0",
-				"timed-out": "^4.0.1",
-				"url-set-query": "^1.0.0",
-				"xhr": "^2.0.4"
-			}
-		},
-		"xhr-request-promise": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
-			"integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
-			"requires": {
-				"xhr-request": "^1.1.0"
-			}
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"y18n": {
 			"version": "4.0.0",


### PR DESCRIPTION
## Description

This PR upgrades `scrypt` from [`@web3-js/scrypt-shim`](https://github.com/web3-js/scrypt-shim) to [`scrypt-js`](https://github.com/ricmoo/scrypt-js), a pure JavaScript implementation.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Dependency upgrade

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
