### PR TITLE
web3-core-promievent README.md fix

### DIFF
--- a/packages/web3-core-promievent/README.md
+++ b/packages/web3-core-promievent/README.md
@@ -48,8 +48,8 @@ var myFunc = function(){
 
 // and run it
 myFunc()
+.on('done', console.log)
 .then(console.log);
-.on('done', console.log);
 ```
 
 [docs]: http://web3js.readthedocs.io/en/1.0/


### PR DESCRIPTION
on() before then()
no semicolon

## Description

README.md example was broken
```
.on('done', console.log);
^

SyntaxError: Unexpected token '.'
```
