### PR TITLE
Fix WS clientConfig type and clarify docs

### DIFF
--- a/docs/include_package-core.rst
+++ b/docs/include_package-core.rst
@@ -146,10 +146,14 @@ Configuration
           authorization: 'Basic username:password'
         },
 
-        // Useful if requests result are large
         clientConfig: {
+          // Useful if requests are large
           maxReceivedFrameSize: 100000000,   // bytes - default: 1MiB
           maxReceivedMessageSize: 100000000, // bytes - default: 8MiB
+
+          // Useful to keep a connection alive
+          keepalive: true,
+          keepaliveInterval: 60000 // ms
         },
 
         // Enable auto reconnection

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -188,7 +188,7 @@ export interface WebsocketProviderOptions {
     reconnectDelay?: number;
     headers?: any;
     protocol?: string;
-    clientConfig?: string;
+    clientConfig?: object;
     requestOptions?: any;
     origin?: string;
     reconnect?: ReconnectOptions;

--- a/packages/web3-providers-ws/README.md
+++ b/packages/web3-providers-ws/README.md
@@ -41,10 +41,14 @@ var options = {
       authorization: 'Basic username:password'
     },
 
-    // Useful if requests are large
     clientConfig: {
+      // Useful if requests are large
       maxReceivedFrameSize: 100000000,   // bytes - default: 1MiB
       maxReceivedMessageSize: 100000000, // bytes - default: 8MiB
+
+      // Useful to keep a connection alive
+      keepalive: true,
+      keepaliveInterval: 60000 // ms
     },
 
     // Enable auto reconnection
@@ -57,11 +61,9 @@ var options = {
 };
 
 var ws = new Web3WsProvider('ws://localhost:8546', options);
-
-(Additional client config options can be found [here][1])
-
-[1]: https://github.com/web3-js/WebSocket-Node/blob/polyfill/globalThis/docs/WebSocketClient.md
 ```
+
+Additional client config options can be found [here](https://github.com/theturtle32/WebSocket-Node/blob/v1.0.31/docs/WebSocketClient.md#client-config-options).
 
 ## Types
 


### PR DESCRIPTION
## Description

This PR fixes the WS clientConfig type and adds to the docs for the option `keepalive`.

Closes #3563 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have tested my code on the live network.
- [x] The browser visual inspection check looks ok: [sudden-playground.surge.sh][1]

[1]: http://sudden-playground.surge.sh/
