### PR TITLE
Handle revert reason errors for geth >= 1.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,3 +236,4 @@ Released with 1.0.0-beta.37 code base.
 ### Fixed
 
 - Extend `_txInputFormatter` with hex prefix check (#3317)
+- Extract revert reason string for geth >= 1.9.15 (#3520)

--- a/TESTING.md
+++ b/TESTING.md
@@ -46,8 +46,8 @@ CI job.
 The npm script `test:e2e:clients` greps all tests with an `[ @E2E ]` tag
 in their mocha test description and runs them against:
 + ganache-cli
-+ geth 1.9.13 (POA, single instance, instamining)
-+ geth 1.9.13 (POA, single instance, mining at 2s intervals)
++ geth stable (POA, single instance, instamining)
++ geth stable (POA, single instance, mining at 2s intervals)
 
 These tests are grouped in files prefixed by "e2e", ex: `test/e2e.method.call.js`.
 

--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -26,7 +26,10 @@
 module.exports = {
     ErrorResponse: function (result) {
         var message = !!result && !!result.error && !!result.error.message ? result.error.message : JSON.stringify(result);
-        return new Error('Returned error: ' + message);
+        var data = (!!result.error && !!result.error.data) ? result.error.data : null;
+        var err = new Error('Returned error: ' + message);
+        err.data = data;
+        return err;
     },
     InvalidNumberOfParams: function (got, expected, method) {
         return new Error('Invalid number of parameters for "'+ method +'". Got '+ got +' expected '+ expected +'!');

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -623,6 +623,7 @@ Method.prototype.buildCall = function () {
 
                 // Ganache / Geth <= 1.9.13 return the reason data as a successful eth_call response
                 // Geth >= 1.9.15 attaches the reason data to an error object.
+                // Geth 1.9.14 is missing revert reason (https://github.com/ethereum/web3.js/issues/3520)
                 if (!err && method.isRevertReasonString(result)){
                     reasonData = result.substring(10);
                 } else if (err && err.data){

--- a/scripts/e2e.geth.automine.sh
+++ b/scripts/e2e.geth.automine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --period 2 --accounts 1 --tag 'v1.9.13'
+geth-dev-assistant --period 2 --accounts 1 --tag 'stable'
 
 # Test
 GETH_AUTOMINE=true nyc --no-clean --silent _mocha -- \

--- a/scripts/e2e.geth.instamine.sh
+++ b/scripts/e2e.geth.instamine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, bal=50 eth, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --accounts 1 --tag 'v1.9.13'
+geth-dev-assistant --accounts 1 --tag 'stable'
 
 # Test
 GETH_INSTAMINE=true nyc --no-clean --silent _mocha -- \

--- a/test/e2e.method.call.js
+++ b/test/e2e.method.call.js
@@ -62,8 +62,14 @@ describe('method.call [ @E2E ]', function () {
                 assert.fail();
 
             } catch (err) {
-                assert(err.message.includes("Returned values aren't valid"));
-                assert(err.message.includes('the correct ABI'));
+                // ganache | geth <= 1.9.13
+                const nullDataResponse = err.message.includes("Returned values aren't valid") &&
+                                         err.message.includes('the correct ABI');
+
+                // geth >= 1.9.15
+                const gethErrResponse = err.message.includes("revert");
+
+                assert(nullDataResponse || gethErrResponse);
             }
         })
     });


### PR DESCRIPTION
## Description

Adds logic to handle a new error response from geth when `eth_call` executes revert with reason.

Beginning with v1.9.15, geth's response for this case looks like:
```
{ 
  jsonrpc: '2.0',
  id: 7,
  error: { 
     code: 3,
     message: 'execution reverted: REVERTED WITH REQUIRE',
     data: '0x08c379a00000....' 
  }
}
```

Previously, it didn't error and the data was an outer level key. 

Fixes #3520

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] The browser visual inspection check looks ok: [sudden-playground.surge.sh][1]

[1]: http://sudden-playground.surge.sh/
