### PR TITLE
Add undefined callback check to websocket provider response queue

### DIFF
--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -130,7 +130,9 @@ WebsocketProvider.prototype._onMessage = function (e) {
         }
 
         if (_this.responseQueue.has(id)) {
-            _this.responseQueue.get(id).callback(false, result);
+            if(_this.responseQueue.get(id).callback !== undefined) {
+                _this.responseQueue.get(id).callback(false, result);
+            }
             _this.responseQueue.delete(id);
         }
     });


### PR DESCRIPTION
Defensive programming per last sentence of paragraph 8 in https://github.com/ethereum/web3.js/issues/3573#issuecomment-640931151.

The now-doubled call to `.get(id)` seems like it might be a little inefficient.  I'm not sure how that compares to calling `.get(id)` once and assigning the result a temporary variable in terms of efficiency, but if someone wants to put some rigor into that selection it'd be helpful. 

I don't believe that any corresponding documentation changes are necessary.

A corresponding change in 2.x might be a good idea. 

## Description
Fixes #3573

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
This is as complete as of initial PR submission as the original submitter will get it:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] The browser visual inspection check looks ok: [sudden-playground.surge.sh][1]

[1]: http://sudden-playground.surge.sh/
