### PR TITLE
Check for duplicate queue entries in WebsocketProvider

### DIFF
--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -74,6 +74,11 @@ module.exports = {
 
         return error;
     },
+    DuplicateRequestIDError: function(id){
+        return new Error('Duplicate request id '+id+
+                         ' sent to provider. Try setting a unique provider object for each copy of'+
+                         ' jsonrpc.js used in the project instead of sharing a single Provider.');
+    },
     RevertInstructionError: function(reason, signature) {
         var error = new Error('Your request got reverted with the following reason string: ' + reason);
         error.reason = reason;

--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -76,7 +76,7 @@ module.exports = {
     },
     DuplicateRequestIDError: function(id){
         return new Error('Duplicate request id '+id+
-                         ' sent to provider. Try setting a unique provider object for each copy of'+
+                         ' sent to Provider. Try setting a unique provider object for each copy of'+
                          ' jsonrpc.js used in the project instead of sharing a single Provider.');
     },
     RevertInstructionError: function(reason, signature) {

--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -76,7 +76,7 @@ module.exports = {
     },
     DuplicateRequestIDError: function(id){
         return new Error('Duplicate request id '+id+
-                         ' sent to Provider. Try setting a unique provider object for each copy of'+
+                         ' sent to Provider. Try setting a unique Provider object for each copy of'+
                          ' jsonrpc.js used in the project instead of sharing a single Provider.');
     },
     RevertInstructionError: function(reason, signature) {

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -73,6 +73,7 @@ export class errors {
     static MaxAttemptsReachedOnReconnectingError(): Error;
     static PendingRequestsOnReconnectingError(): Error;
     static ConnectionError(msg: string, event?: WebSocketEvent): ConnectionError;
+    static DuplicateRequestIDError(id: string | number): Error;
     static RevertInstructionError(reason: string, signature: string): RevertInstructionError
     static TransactionRevertInstructionError(reason: string, signature: string, receipt: object): TransactionRevertInstructionError
     static TransactionError(message: string, receipt: object): TransactionError

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -308,6 +308,11 @@ WebsocketProvider.prototype.send = function (payload, callback) {
         id = payload[0].id;
     }
 
+    if(this.requestQueue.has(id) || this.responseQueue.has(id)) {
+        this.emit(this.ERROR, errors.DuplicateRequestIDError(id));
+        return;
+    }
+    
     if (this.connection.readyState === this.connection.CONNECTING || this.reconnecting) {
         this.requestQueue.set(id, request);
 


### PR DESCRIPTION
## Description
This is intended to address the issue found in #3568 by detecting the condition causing that issue, and emitting an error instead of sending data to incorrect formatters and callbacks.  This error will not be emitted in cases where intended operation can continue because only ids that have already been fully used and deleted from queues are being reused, as the existing behavior is not specifically problematic in that case, though this may lead some bugs to go undiscovered in light testing.  

I have marked this as a draft because in limited testing with the example code of #3573, this does not produce helpful output such as the text of the error message; execution just silently stops and it's not clear why.  If someone else can do more testing or edits to make that clearer, that would be helpful. 

A corresponding change in 2.x might be a good idea. 

Fixes #3568

## Type of change
I am not sure if this should be considered a bug fix or breaking change.  It would only break code in cases where the code is already broken but where an existing issue might not be evident, making the issue more evident.

## Checklist:
This is as complete as of initial PR submission as the original submitter will get it:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
