### PR TITLE
Fix buffer incompatibility issue when used inside React (issue/3580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,4 +236,4 @@ Released with 1.0.0-beta.37 code base.
 ### Fixed
 
 - Extend `_txInputFormatter` with hex prefix check (#3317)
-- Fixed `Buffer.concat` breaking the new scrypt responses in browsers (#3580)
+- Fixed `Buffer.concat` incompatibility to the Buffer impl in React (#3580)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,3 +236,4 @@ Released with 1.0.0-beta.37 code base.
 ### Fixed
 
 - Extend `_txInputFormatter` with hex prefix check (#3317)
+- Fixed `Buffer.concat` breaking the new scrypt responses in browsers (#3580)

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -381,7 +381,7 @@ Accounts.prototype.decrypt = function(v3Keystore, password, nonStrict) {
 
     var ciphertext = Buffer.from(json.crypto.ciphertext, 'hex');
 
-    var mac = utils.sha3(Buffer.concat([derivedKey.slice(16, 32), ciphertext])).replace('0x', '');
+    var mac = utils.sha3(Buffer.from([...derivedKey.slice(16, 32), ...ciphertext])).replace('0x', '');
     if (mac !== json.crypto.mac) {
         throw new Error('Key derivation failed - possibly wrong password');
     }

--- a/test/e2e.account.wallet.js
+++ b/test/e2e.account.wallet.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var utils = require('./helpers/test.utils');
+var Web3 = utils.getWeb3();
+
+describe('decrypt keystore [ @E2E ]', function () {
+    var web3;
+    var keystore = {
+        "json": [
+        {
+            "version": 3,
+            "id": "cd3f55c7-b84d-4708-956a-23725971c7e3",
+            "address": "cc9967fa5b8185354492da1ac2d40da092366a8f",
+            "crypto": {
+            "ciphertext": "6c8b5a914daaa840ae4589fdc970946bd588f339e3c7d947fc074ad0bf2cc06f",
+            "cipherparams": {
+                "iv": "7403a6cb6d5685d92e536efd324d40f2"
+            },
+            "cipher": "aes-128-ctr",
+            "kdf": "scrypt",
+            "kdfparams": {
+                "dklen": 32,
+                "salt": "68b700715a3e4fe85c5aae7b62094cf2856b2f4b5546f0c2b0e7f1124f7c7162",
+                "n": 8192,
+                "r": 8,
+                "p": 1
+            },
+            "mac": "d89c36cbe31f3046688fc3b97f77129edd6766b57b2f49457a1ff445c54bdd7f"
+            }
+        }
+        ],
+        "password": "test",
+        "priv": "0xce8347345071827fdf34ad9eb87fd10e857cd965738e5e4965319172bf051694"
+    }
+
+    before(function () {
+        web3 = new Web3('http://localhost:8545');
+    })
+
+    it('decrypts a password protected keystore file correctly', async function () {
+        var res = web3.eth.accounts.wallet.decrypt(keystore.json, keystore.password);
+        assert.equal(keystore.priv, res[0].privateKey);
+
+    });
+});


### PR DESCRIPTION
**NOTE: PR targets #3583**
 
fixes a type issue between UInt8Arrays and Buffer.concat in browsers.

## Description

Please include a summary of the changes and be sure to follow our [Contribution Guidelines](../CONTRIBUTIONS.md).

Optional if an issue is fixed:
Fixes #3580 

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ x ] I have selected the correct base branch.
- [ x ] I have performed a self-review of my own code.
- [ o ] I have commented my code, particularly in hard-to-understand areas.
- [ o ] I have made corresponding changes to the documentation.
- [ o ] My changes generate no new warnings.
- [ o ] Any dependent changes have been merged and published in downstream modules.
- [ x ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ x ] I ran `npm run test:unit` with success.
- [ x ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ x ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ x ] I have updated the `CHANGELOG.md` file in the root folder.
- [ - ] I have tested my code on the live network.
- [ x ] I have checked the Deploy Preview and it looks correct.
