### PR TITLE
Fix Function type log params decoding 

### DIFF
--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -156,6 +156,12 @@ ABICoder.prototype.mapTypes = function (types) {
     var self = this;
     var mappedTypes = [];
     types.forEach(function (type) {
+        // Remap `function` type params to bytes24 since Ethers does not
+        // recognize former type. Solidity docs say `Function` is a bytes24
+        // encoding the contract address followed by the function selector hash.
+        if (typeof type === 'object' && type.type === 'function'){
+            type.type = "bytes24"
+        }
         if (self.isSimplifiedStructFormat(type)) {
             var structName = Object.keys(type)[0];
             mappedTypes.push(
@@ -285,9 +291,9 @@ ABICoder.prototype.formatParam = function (type, param) {
                 param = utils.rightPad(param, size * 2)
             }
         }
-        
+
         // format odd-length bytes to even-length
-        if (param.length % 2 === 1) { 
+        if (param.length % 2 === 1) {
             param = '0x0' + param.substring(2)
         }
     }

--- a/test/eth.abi.decodeLog.js
+++ b/test/eth.abi.decodeLog.js
@@ -140,6 +140,21 @@ var tests = [{
         narrative: 'Hello!%!',
         __length__: 4
     }
+    //
+},{
+    params: [[
+        {
+            indexed: false,
+            internalType: "function () external",
+            name: "fn",
+            type: "function"
+        }], "0xfba657cfc72d1933c9949b383a77a14b6ad29912c04062260000000000000000",
+            [] ],
+    result: {
+        "0": "0xfba657cfc72d1933c9949b383a77a14b6ad29912c0406226",
+        "fn": "0xfba657cfc72d1933c9949b383a77a14b6ad29912c0406226",
+        "__length__": 1
+    }
 }];
 
 describe('decodeLog', function () {

--- a/test/eth.abi.decodeLog.js
+++ b/test/eth.abi.decodeLog.js
@@ -140,7 +140,6 @@ var tests = [{
         narrative: 'Hello!%!',
         __length__: 4
     }
-    //
 },{
     params: [[
         {


### PR DESCRIPTION
## Description

Converts `Function` log param types to `bytes24` so they can be passed to Ethers for decoding without errorring. At the moment Ethers throws
```
Error: invalid type (argument="type", value="function", code=INVALID_ARGUMENT, version=abi/5.0.0-beta.153)
```

Encoding guidance per the [Solidity docs][1]:

> If external function types are used outside of the context of Solidity, they are treated as the function type, which encodes the address followed by the function identifier together in a single bytes24 type

Failing test at: 4dc506e

[Update - we wanted to wait and see if Ethers might address this upstream - there's a relevant open issue at [ethers 389][2]. Don't see any movement rn, maybe this patch is an adequate interim solution? ]


[1]: https://solidity.readthedocs.io/en/v0.6.10/types.html#function-types
[2]: https://github.com/ethers-io/ethers.js/issues/389#issuecomment-644817480

Fixes #2826

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
