### PR TITLE
Fix web3-eth-abi export types

### DIFF
--- a/packages/web3-eth-abi/types/index.d.ts
+++ b/packages/web3-eth-abi/types/index.d.ts
@@ -19,7 +19,7 @@
 
 import { AbiInput, AbiItem } from 'web3-utils';
 
-export class AbiCoder {
+declare class AbiCoder {
     encodeFunctionSignature(functionName: string | AbiItem): string;
 
     encodeEventSignature(functionName: string | AbiItem): string;
@@ -40,3 +40,9 @@ export class AbiCoder {
         topics: string[]
     ): { [key: string]: string };
 }
+
+export type { AbiCoder }
+
+declare const abiCoder: AbiCoder
+
+export default abiCoder

--- a/packages/web3-eth-abi/types/tests/abi-coder-test.ts
+++ b/packages/web3-eth-abi/types/tests/abi-coder-test.ts
@@ -20,9 +20,7 @@
  * @date 2018
  */
 
-import { AbiCoder } from 'web3-eth-abi';
-
-const abiCoder = new AbiCoder();
+import abiCoder from 'web3-eth-abi';
 
 // $ExpectType string
 abiCoder.encodeFunctionSignature('myMethod(uint256,string)');


### PR DESCRIPTION
## Description

Currently if I want to use `web3-eth-abi` separate from the whole `web3` in Typescript I get wrong types on import
Declarations in `index.d.ts` specify `export class AbiCoder` as the only export, so TS expects the following to work
```ts
import { AbiCoder } from 'web3-eth-abi'
const  coder = new AbiCoder()
coder.encodeFunctionSignature('myMethod(uint256,string)')
```

But in reality `src/index.js` exports a singleton instance of `AbiCoder` as default
```js
var coder = new ABICoder();

module.exports = coder;
```

And TS code breaks with `Uncaught TypeError: web3_eth_abi__WEBPACK_IMPORTED_MODULE_1__.AbiCoder is not a constructor`
To properly use abi I have to 
```ts
import Web3Abi, { AbiCoder } from 'web3-eth-abi'

const Abi = (Web3Abi as unknown) as AbiCoder
```

To sum it up, TS declarations export named export class, whereas real JS export is default of that class instance.
I think there's a similar problem (sans singleton aspect) in `web3-eth-ens` and  `web3-eth-contract`, maybe more. Didn't look too deep into it.


This PR switches named export of `class AbiCoder` to type only export (as JS doesn't export class at all), and adds a default export of `AbiCoder` instance.
As an alternative, you may want to export both class and singleton instance in both JS and TS.
<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

I believe #3198 is a related issue.

## Type of change

<!-- Please delete options that are not relevant. -->

Type fix

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
