### PR TITLE
format fromBlock param on resubscription

### DIFF
--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -228,7 +228,7 @@ Subscription.prototype.subscribe = function() {
     // a dropped connection may have resulted in gaps in the logs...
     if (this.lastBlock && _.isObject(this.options.params)){
         payload.params[1] = this.options.params
-        payload.params[1].fromBlock = this.lastBlock +1;
+        payload.params[1].fromBlock = formatters.inputBlockNumberFormatter(this.lastBlock + 1);
     }
 
     // if id is there unsubscribe first
@@ -245,9 +245,6 @@ Subscription.prototype.subscribe = function() {
 
         // copy the params to avoid race-condition with deletion below this block
         var blockParams = Object.assign({}, payload.params[1]);
-
-        // ensure the block number is properly formatted
-        blockParams.fromBlock = formatters.inputBlockNumberFormatter(blockParams.fromBlock)
 
         this.options.requestManager.send({
             method: 'eth_getLogs',

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -25,6 +25,7 @@
 var _ = require('underscore');
 var errors = require('web3-core-helpers').errors;
 var EventEmitter = require('eventemitter3');
+var formatters = require('web3-core-helpers').formatters;
 
 function Subscription(options) {
     EventEmitter.call(this);
@@ -227,7 +228,7 @@ Subscription.prototype.subscribe = function() {
     // a dropped connection may have resulted in gaps in the logs...
     if (this.lastBlock && _.isObject(this.options.params)){
         payload.params[1] = this.options.params
-        payload.params[1].fromBlock = this.lastBlock +1;
+        payload.params[1].fromBlock = formatters.inputBlockNumberFormatter(this.lastBlock + 1);
     }
 
     // if id is there unsubscribe first

--- a/packages/web3-core-subscriptions/src/subscription.js
+++ b/packages/web3-core-subscriptions/src/subscription.js
@@ -228,7 +228,7 @@ Subscription.prototype.subscribe = function() {
     // a dropped connection may have resulted in gaps in the logs...
     if (this.lastBlock && _.isObject(this.options.params)){
         payload.params[1] = this.options.params
-        payload.params[1].fromBlock = formatters.inputBlockNumberFormatter(this.lastBlock + 1);
+        payload.params[1].fromBlock = this.lastBlock +1;
     }
 
     // if id is there unsubscribe first
@@ -245,6 +245,9 @@ Subscription.prototype.subscribe = function() {
 
         // copy the params to avoid race-condition with deletion below this block
         var blockParams = Object.assign({}, payload.params[1]);
+
+        // ensure the block number is properly formatted
+        blockParams.fromBlock = formatters.inputBlockNumberFormatter(blockParams.fromBlock)
 
         this.options.requestManager.send({
             method: 'eth_getLogs',


### PR DESCRIPTION
## Description

Added use of `inputBlockNumberFormatter` to ensure `fromBlock` is formatted properly when resubscribing. Currently when resubscribing, the plain incremented number field is put into the RPC call.

The [JSON-RPC docs](https://eth.wiki/json-rpc/API#hex-value-encoding) mention that values like fromBlock should be hex encoded. I ran into an issue where Besu will return "Invalid Params" when web3 passes in the plain number value when reconnecting on a flaky WS connection: https://github.com/hyperledger/besu/issues/1088.

I'm not familiar with the web3 codebase, so it would be great if someone could point me in the right direction for adding/updating tests.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
