### PR TITLE
Adds a missing list item number in the methods.myMethod.call docs

### DIFF
--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -749,7 +749,7 @@ Parameters
     * ``from`` - ``String`` (optional): The address the call "transaction" should be made from. For calls the ``from`` property is optional however it is highly recommended to explicitly set it or it may default to `address(0)` depending on your node or provider.
     * ``gasPrice`` - ``String`` (optional): The gas price in wei to use for this call "transaction".
     * ``gas`` - ``Number`` (optional): The maximum gas provided for this call "transaction" (gas limit).
-2. ``Number|String|BN|BigNumber`` - (optional) If you pass this parameter it will not use the default block set with :ref:`contract.defaultBlock <defaultblock>`. Pre-defined block numbers as ``"latest"``, ``"earliest"``, ``"pending"``, and ``"genesis"`` can also be used.  Useful for requesting data from or replaying transactions in past blocks.
+2. ``defaultBlock`` - ``Number|String|BN|BigNumber`` (optional): If you pass this parameter it will not use the default block set with :ref:`contract.defaultBlock <defaultblock>`. Pre-defined block numbers as ``"earliest"``, ``"latest"``, and ``"pending"`` can also be used.  Useful for requesting data from or replaying transactions in past blocks.
 3. ``callback`` - ``Function`` (optional): This callback will be fired with the result of the smart contract method execution as the second argument, or with an error object as the first argument.
 
 -------

--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -749,7 +749,7 @@ Parameters
     * ``from`` - ``String`` (optional): The address the call "transaction" should be made from. For calls the ``from`` property is optional however it is highly recommended to explicitly set it or it may default to `address(0)` depending on your node or provider.
     * ``gasPrice`` - ``String`` (optional): The gas price in wei to use for this call "transaction".
     * ``gas`` - ``Number`` (optional): The maximum gas provided for this call "transaction" (gas limit).
-``Number|String|BN|BigNumber`` - (optional) If you pass this parameter it will not use the default block set with :ref:`contract.defaultBlock <defaultblock>`. Pre-defined block numbers as ``"latest"``, ``"earliest"``, ``"pending"``, and ``"genesis"`` can also be used.  Useful for requesting data from or replaying transactions in past blocks.
+2. ``Number|String|BN|BigNumber`` - (optional) If you pass this parameter it will not use the default block set with :ref:`contract.defaultBlock <defaultblock>`. Pre-defined block numbers as ``"latest"``, ``"earliest"``, ``"pending"``, and ``"genesis"`` can also be used.  Useful for requesting data from or replaying transactions in past blocks.
 3. ``callback`` - ``Function`` (optional): This callback will be fired with the result of the smart contract method execution as the second argument, or with an error object as the first argument.
 
 -------


### PR DESCRIPTION
## Description

Adds a missing list item number in the docs under the section for Contract -> methods.myMethod.call().  Prior to this fix, this section's method parameters list had no `2. ` item.

## Type of change

- Documentation

