### PR TITLE
replaced boolean "values" with types in d.ts

### DIFF
--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -211,7 +211,7 @@ export class Eth {
     getBlock(blockHashOrBlockNumber: BlockNumber | string): Promise<BlockTransactionString>;
     getBlock(
         blockHashOrBlockNumber: BlockNumber | string,
-        returnTransactionObjects: true
+        returnTransactionObjects: boolean
     ): Promise<BlockTransactionObject>;
     getBlock(
         blockHashOrBlockNumber: BlockNumber | string,
@@ -219,7 +219,7 @@ export class Eth {
     ): Promise<BlockTransactionString>;
     getBlock(
         blockHashOrBlockNumber: BlockNumber | string,
-        returnTransactionObjects: true,
+        returnTransactionObjects: boolean,
         callback?: (error: Error, block: BlockTransactionObject) => void
     ): Promise<BlockTransactionObject>;
 
@@ -240,7 +240,7 @@ export class Eth {
     getUncle(
         blockHashOrBlockNumber: BlockNumber | string,
         uncleIndex: number | string | BN,
-        returnTransactionObjects: true
+        returnTransactionObjects: boolean
     ): Promise<BlockTransactionObject>;
     getUncle(
         blockHashOrBlockNumber: BlockNumber | string,
@@ -250,7 +250,7 @@ export class Eth {
     getUncle(
         blockHashOrBlockNumber: BlockNumber | string,
         uncleIndex: number | string | BN,
-        returnTransactionObjects: true,
+        returnTransactionObjects: boolean,
         callback?: (error: Error, uncle: any) => void
     ): Promise<BlockTransactionObject>;
 


### PR DESCRIPTION
changed "default" values to type defs.

I'm not a 100% TS mage but that... true in TS... seems wrong. Think mine is better now but I could be wrong.

## Description

noticed that the web3-eth typedefs contain default values instead of (boolean) type defs. Stumbled upon it in VSC:

![Screenshot from 2020-06-23 22-33-15](https://user-images.githubusercontent.com/1344649/85458685-ab81e400-b5a1-11ea-8dd9-a9cef5e31757.png)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
