### PR TITLE
Remove invisible Â char from web3-utils files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,3 +238,4 @@ Released with 1.0.0-beta.37 code base.
 - Extend `_txInputFormatter` with hex prefix check (#3317)
 - Extract revert reason string for geth >= 1.9.15 (#3520)
 - Incorrect param encoding of BN object in arrayed inputs (#3592)
+- Fix Chrome syntax error by removing mis-encoded whitespace characters from web3-utils files (#3601)

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -372,12 +372,12 @@ module.exports = {
     leftPad: utils.leftPad,
     padRight: utils.rightPad,
     rightPad: utils.rightPad,
-    toTwosComplement: utils.toTwosComplement,
+    toTwosComplement: utils.toTwosComplement,
 
-    isBloom: utils.isBloom,
-    isUserEthereumAddressInBloom: utils.isUserEthereumAddressInBloom,
-    isContractAddressInBloom: utils.isContractAddressInBloom,
-    isTopic: utils.isTopic,
-    isTopicInBloom: utils.isTopicInBloom,
-    isInBloom: utils.isInBloom
+    isBloom: utils.isBloom,
+    isUserEthereumAddressInBloom: utils.isUserEthereumAddressInBloom,
+    isContractAddressInBloom: utils.isContractAddressInBloom,
+    isTopic: utils.isTopic,
+    isTopicInBloom: utils.isTopicInBloom,
+    isInBloom: utils.isInBloom
 };

--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -401,7 +401,7 @@ var isBloom = function (bloom) {
 };
 
 /**
- * Returns true if the ethereum users address is part of the given bloom 
+ * Returns true if the ethereum users address is part of the given bloom
  * note: false positives are possible.
  *
  * @method isUserEthereumAddressInBloom
@@ -414,7 +414,7 @@ var isUserEthereumAddressInBloom = function (bloom, ethereumAddress) {
 };
 
 /**
- * Returns true if the contract address is part of the given bloom 
+ * Returns true if the contract address is part of the given bloom
  * note: false positives are possible.
  *
  * @method isUserEthereumAddressInBloom


### PR DESCRIPTION
## Description

These characters were accidentally introduced in #3291 and #3137. 

They can be made visible in a text editor by setting the file encoding to ISO-8859-1. 

Ran a local search and was not able to find any other instances of it.

Fixes #3601

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build-all` and tested the resulting files from `dist` folder in a browser.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
