### PR TITLE
Use provider.request() when available

### DIFF
--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -155,7 +155,7 @@ RequestManager.prototype.request = async function (data) {
     const payload = Jsonrpc.toPayload(data.method, data.params);
 
     try {
-        const result = await this.provider.request(payload)
+        const result = await this.provider.request(payload);
 
         if (result && result.id && payload.id !== result.id) {
             return new Error(`Wrong response id ${result.id} (expected: ${payload.id}) in ${JSON.stringify(payload)}`);
@@ -165,9 +165,9 @@ RequestManager.prototype.request = async function (data) {
             return errors.InvalidResponse(result);
         }
 
-        return result.result
+        return result.result;
     } catch (error) {
-        return errors.ErrorResponse(error)
+        return errors.ErrorResponse(error);
     }
 };
 
@@ -209,13 +209,13 @@ RequestManager.prototype.send = function (data, callback) {
     // `send` and `sendAsync` are deprecated in favor of `request` (see EIP-1193),
     // however if we have `sendAsync`, prefer to use it over `send`.
     if (this.provider.request) {
-        return callbackify(this.provider.request.bind(this.provider))(payload, onResult)
+        return callbackify(this.provider.request.bind(this.provider))(payload, onResult);
     } else if (this.provider.sendAsync) {
-        this.provider.sendAsync(payload, onResult)
+        this.provider.sendAsync(payload, onResult);
     } else if (this.provider.send) {
-        this.provider.send(payload, onResult)
+        this.provider.send(payload, onResult);
     } else {
-        throw new Error('Provider does not have a request or send method to use.')
+        throw new Error('Provider does not have a request or send method to use.');
     }
 };
 

--- a/test/1_givenProvider-ethereumProvider.js
+++ b/test/1_givenProvider-ethereumProvider.js
@@ -31,5 +31,69 @@ describe('Web3.providers.givenProvider', function () {
             assert.deepEqual(Bzz.givenProvider, global.ethereum.bzz);
         });
     });
+
+    describe('should use request() if available, otherwise falling back to sendAsync() and send()', function () {
+
+        after(function(){
+            global.ethereum = undefined
+        })
+
+        it('should use request()', function () {
+            global.ethereum = {
+                request: () => { throw new Error('used request') },
+                sendAsync: () => { throw new Error('used sendAsync') }, 
+                send: () => { throw new Error('used send') }
+            };
+            
+            const Web3 = require('../packages/web3');
+            const web3 = new Web3(Web3.givenProvider)
+            try {
+                web3.eth.getBlockNumber()
+            } catch (error) {
+                assert.equal(error.message, 'used request')
+            }
+        });
+
+        it('should use sendAsync()', function () {
+            global.ethereum = {
+                sendAsync: () => { throw new Error('used sendAsync') }, 
+                send: () => { throw new Error('used send') }
+            };
+            
+            const Web3 = require('../packages/web3');
+            const web3 = new Web3(Web3.givenProvider)
+            try {
+                web3.eth.getBlockNumber()
+            } catch (error) {
+                assert.equal(error.message, 'used sendAsync')
+            }
+        });
+
+        it('should use send()', function () {
+            global.ethereum = {
+                send: () => { throw new Error('used send') }
+            };
+            
+            const Web3 = require('../packages/web3');
+            const web3 = new Web3(Web3.givenProvider)
+            try {
+                web3.eth.getBlockNumber()
+            } catch (error) {
+                assert.equal(error.message, 'used send')
+            }
+        });
+        
+        it('should error without any request or send method', function () {
+            global.ethereum = {};
+            
+            const Web3 = require('../packages/web3');
+            const web3 = new Web3(Web3.givenProvider)
+            try {
+                web3.eth.getBlockNumber()
+            } catch (error) {
+                assert.equal(error.message, 'Provider does not have a request or send method to use.')
+            }
+        });
+    });
 });
 

--- a/test/1_givenProvider-ethereumProvider.js
+++ b/test/1_givenProvider-ethereumProvider.js
@@ -35,7 +35,7 @@ describe('Web3.providers.givenProvider', function () {
     describe('should use request() if available, otherwise falling back to sendAsync() and send()', function () {
 
         after(function(){
-            global.ethereum = undefined
+            global.ethereum = undefined;
         })
 
         it('should use request()', function () {
@@ -44,13 +44,13 @@ describe('Web3.providers.givenProvider', function () {
                 sendAsync: () => { throw new Error('used sendAsync') }, 
                 send: () => { throw new Error('used send') }
             };
-            
             const Web3 = require('../packages/web3');
-            const web3 = new Web3(Web3.givenProvider)
+            const web3 = new Web3(Web3.givenProvider);
             try {
-                web3.eth.getBlockNumber()
+                web3.eth.getBlockNumber();
+                assert.fail('should error');
             } catch (error) {
-                assert.equal(error.message, 'used request')
+                assert.equal(error.message, 'used request');
             }
         });
 
@@ -59,13 +59,13 @@ describe('Web3.providers.givenProvider', function () {
                 sendAsync: () => { throw new Error('used sendAsync') }, 
                 send: () => { throw new Error('used send') }
             };
-            
             const Web3 = require('../packages/web3');
-            const web3 = new Web3(Web3.givenProvider)
+            const web3 = new Web3(Web3.givenProvider);
             try {
-                web3.eth.getBlockNumber()
+                web3.eth.getBlockNumber();
+                assert.fail('should error');
             } catch (error) {
-                assert.equal(error.message, 'used sendAsync')
+                assert.equal(error.message, 'used sendAsync');
             }
         });
 
@@ -73,25 +73,25 @@ describe('Web3.providers.givenProvider', function () {
             global.ethereum = {
                 send: () => { throw new Error('used send') }
             };
-            
             const Web3 = require('../packages/web3');
-            const web3 = new Web3(Web3.givenProvider)
+            const web3 = new Web3(Web3.givenProvider);
             try {
-                web3.eth.getBlockNumber()
+                web3.eth.getBlockNumber();
+                assert.fail('should error');
             } catch (error) {
-                assert.equal(error.message, 'used send')
+                assert.equal(error.message, 'used send');
             }
         });
         
         it('should error without any request or send method', function () {
             global.ethereum = {};
-            
             const Web3 = require('../packages/web3');
-            const web3 = new Web3(Web3.givenProvider)
+            const web3 = new Web3(Web3.givenProvider);
             try {
-                web3.eth.getBlockNumber()
+                web3.eth.getBlockNumber();
+                assert.fail('should error');
             } catch (error) {
-                assert.equal(error.message, 'Provider does not have a request or send method to use.')
+                assert.equal(error.message, 'Provider does not have a request or send method to use.');
             }
         });
     });

--- a/test/1_givenProvider-ethereumProvider.js
+++ b/test/1_givenProvider-ethereumProvider.js
@@ -38,57 +38,45 @@ describe('Web3.providers.givenProvider', function () {
             global.ethereum = undefined;
         })
 
-        it('should use request()', function () {
+        it('should use request()', async function () {
             global.ethereum = {
-                request: () => { throw new Error('used request') },
+                request: async () => { return { jsonrpc: '2.0', id: 0, result: 100 } },
                 sendAsync: () => { throw new Error('used sendAsync') }, 
                 send: () => { throw new Error('used send') }
             };
             const Web3 = require('../packages/web3');
             const web3 = new Web3(Web3.givenProvider);
-            try {
-                web3.eth.getBlockNumber();
-                assert.fail('should error');
-            } catch (error) {
-                assert.equal(error.message, 'used request');
-            }
+            const blockNumber = await web3.eth.getBlockNumber();
+            assert.equal(blockNumber, 100)
         });
 
-        it('should use sendAsync()', function () {
+        it('should use sendAsync()', async function () {
             global.ethereum = {
-                sendAsync: () => { throw new Error('used sendAsync') }, 
+                sendAsync: (args, callback) => { return callback(null, {jsonrpc: '2.0', id: 0, result: 101}) }, 
                 send: () => { throw new Error('used send') }
             };
             const Web3 = require('../packages/web3');
             const web3 = new Web3(Web3.givenProvider);
-            try {
-                web3.eth.getBlockNumber();
-                assert.fail('should error');
-            } catch (error) {
-                assert.equal(error.message, 'used sendAsync');
-            }
+            const blockNumber = await web3.eth.getBlockNumber();
+            assert.equal(blockNumber, 101)
         });
 
-        it('should use send()', function () {
+        it('should use send()', async function () {
             global.ethereum = {
-                send: () => { throw new Error('used send') }
+                send: (args, callback) => { return callback(null, {jsonrpc: '2.0', id: 0, result: 102}) }
             };
             const Web3 = require('../packages/web3');
             const web3 = new Web3(Web3.givenProvider);
-            try {
-                web3.eth.getBlockNumber();
-                assert.fail('should error');
-            } catch (error) {
-                assert.equal(error.message, 'used send');
-            }
+            const blockNumber = await web3.eth.getBlockNumber();
+            assert.equal(blockNumber, 102)
         });
         
-        it('should error without any request or send method', function () {
+        it('should error without any request or send method', async function () {
             global.ethereum = {};
             const Web3 = require('../packages/web3');
             const web3 = new Web3(Web3.givenProvider);
             try {
-                web3.eth.getBlockNumber();
+                await web3.eth.getBlockNumber();
                 assert.fail('should error');
             } catch (error) {
                 assert.equal(error.message, 'Provider does not have a request or send method to use.');


### PR DESCRIPTION
## Description

This PR modifies `RequestManager.send` to prefer to use `provider.request()` when available,  otherwise falling back to `sendAsync` and `send`.

To learn more, see [EIP-1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] EIP-1193 functionality (non-breaking change)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
