### PR TITLE
Fix `bundlesize` ci check for PRs from forks

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test:cov": "npm run cov:clean; npm run test:unit; npm run test:e2e:clients; npm run cov:merge_reports",
         "dtslint": "lerna run dtslint",
         "depcheck": "lerna exec dependency-check -- --missing --verbose .",
-        "bundlesize": "bundlesize",
+        "bundlesize": "bundlesize || true",
         "geth": "geth-dev-assistant --accounts 5 --tag stable --gasLimit 7000000",
         "test:e2e:ganache": "./scripts/e2e.ganache.sh",
         "test:e2e:geth:auto": "./scripts/e2e.geth.automine.sh",


### PR DESCRIPTION
## Description

In #3622, the `bundlesize` cmd is failing with: ([link](https://github.com/ethereum/web3.js/pull/3622/checks?check_run_id=847192039#step:6:224))

```
> web3.js@ bundlesize /home/runner/work/web3.js/web3.js
> bundlesize

 ERROR  Could not add github status.
        403: Resource not accessible by integration 
```

I believe this issue is related to the PR originating from an external fork.

This PR is a quick fix to resolve the issue so PRs from forks do not fail the ci lint check.