### PR TITLE
Upgrade github actions/checkout to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 12
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
             - uses: actions/cache@v2
               id: cache-deps
               with:
@@ -41,7 +41,7 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: ${{ matrix.node }}
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
             - uses: actions/cache@v2
               id: cache-deps
               with:
@@ -71,7 +71,7 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 12
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
             - uses: actions/cache@v2
               id: cache-deps
               with:
@@ -95,5 +95,5 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 12
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
             - run: bash ./scripts/ci.sh


### PR DESCRIPTION
## Description

This PR simply upgrades github actions/checkout to v2 to try to solve an issue we are running into outlined [here](https://github.com/coverallsapp/github-action/issues/55).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] ci upgrade