### PR TITLE
Fix Provider.request response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,8 +229,6 @@ Released with 1.0.0-beta.37 code base.
 - Docs: spelling of pre-defined block number (#3539)
 - Docs: missing defaultBlock param option in `method.call` description (#3558)
 
-## [Unreleased]
-
 ## [1.2.10]
 
 ### Added
@@ -256,9 +254,15 @@ Released with 1.0.0-beta.37 code base.
 - Add undefined callback check to websocket provider response queue (#3574)
 - Fix WS clientConfig type (#3563)
 
+## [1.2.11]
+
+### Fixed
+
+- Fix Provider.request response (#3647)
+
 ## [Unreleased]
 
-## [1.2.11]
+## [1.2.12]
 
 ### Added
 

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -159,7 +159,7 @@ RequestManager.prototype.send = function (data, callback) {
 
     const payload = Jsonrpc.toPayload(data.method, data.params);
 
-    const onResult = function (err, result) {
+    const onJsonrpcResult = function (err, result) {
         if(result && result.id && payload.id !== result.id) {
             return callback(new Error(`Wrong response id ${result.id} (expected: ${payload.id}) in ${JSON.stringify(payload)}`));
         }
@@ -180,11 +180,11 @@ RequestManager.prototype.send = function (data, callback) {
     };
 
     if (this.provider.request) {
-        callbackify(this.provider.request.bind(this.provider))(payload, onResult);
+        callbackify(this.provider.request.bind(this.provider))(payload, callback);
     } else if (this.provider.sendAsync) {
-        this.provider.sendAsync(payload, onResult);
+        this.provider.sendAsync(payload, onJsonrpcResult);
     } else if (this.provider.send) {
-        this.provider.send(payload, onResult);
+        this.provider.send(payload, onJsonrpcResult);
     } else {
         throw new Error('Provider does not have a request or send method to use.');
     }

--- a/test/1_givenProvider-ethereumProvider.js
+++ b/test/1_givenProvider-ethereumProvider.js
@@ -40,7 +40,7 @@ describe('Web3.providers.givenProvider', function () {
 
         it('should use request()', async function () {
             global.ethereum = {
-                request: async () => { return { jsonrpc: '2.0', id: 0, result: 100 } },
+                request: async () => { return '0x64' },
                 sendAsync: () => { throw new Error('used sendAsync') }, 
                 send: () => { throw new Error('used send') }
             };


### PR DESCRIPTION
## Description

This PR fixes the Provider.request response (new in MetaMask v8) as it returns just the inner result and not a jsonrpc response object.

Fixes #3646

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
