### PR TITLE
Fix parsing of non-`eth_subscription` provider events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,3 +279,4 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix parsing of non-`eth_subscription` provider events (#3660)

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -101,8 +101,8 @@ RequestManager.prototype.setProvider = function (provider, net) {
         this.provider.on('data', function data(result, deprecatedResult) {
             result = result || deprecatedResult; // this is for possible old providers, which may had the error first handler
 
-            // check for result.method, to prevent old providers errors to pass as result
-            if (result.method && _this.subscriptions.has(result.params.subscription)) {
+            // if result is a subscription, call callback for that subscription
+            if (result.method && result.params && result.params.subscription && _this.subscriptions.has(result.params.subscription)) {
                 _this.subscriptions.get(result.params.subscription).callback(null, result.params.result);
             }
         });


### PR DESCRIPTION
## Description

This PR fixes parsing of non-`eth_subscription` provider events, such as the new `wallet_accountsChanged` found in #3659, by adding some additional guards when checking for a subscription callback.

Fixes #3659

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
