### PR TITLE
Fix gnosis dex ci

### DIFF
--- a/scripts/e2e.gnosis.dex.sh
+++ b/scripts/e2e.gnosis.dex.sh
@@ -47,11 +47,11 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo "Running gnosis/dex-react: build             "
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 
-npm run build
+APP_ID=1 npm run build
 
 # Test
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 echo "Running gnosis/dex-react: test              "
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 
-npm test
+APP_ID=1 npm test


### PR DESCRIPTION
## Description

This PR sets the `APP_ID` env for the gnosis dex ci, as it was failing with:

```Error: The appId config, or APP_ID environment variable is required. Read more in https://github.com/gnosis/dex-react/wiki/App-Ids-for-Forks```

## Type of change

- [x] ci bug fix