### PR TITLE
Fix misleading comment

### DIFF
--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -306,7 +306,7 @@ var toChecksumAddress = function (address) {
     var checksumAddress = '0x';
 
     for (var i = 0; i < address.length; i++ ) {
-        // If ith character is 9 to f then make it uppercase
+        // If ith character is 8 to f then make it uppercase
         if (parseInt(addressHash[i], 16) > 7) {
             checksumAddress += address[i].toUpperCase();
         } else {


### PR DESCRIPTION
When looking through the source code to find the address checksum method, I was confused by this comment.

Basically you are making it upper case if the most significant bit of the 4-bit set is 1. (which for a 4 bit number would mean > 7)

9 to f threw me off for a bit.