### PR TITLE
Closes #3685 - switch websocket package to remove node-gyp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,7 +278,7 @@ Released with 1.0.0-beta.37 code base.
 - `npm run build` now uses TSC to compile (.js allowed) and the build folder is now located under `lib` (#3652)
 - Modernized web3-core to use newer es syntax (#3652)
 - Bump lodash from 4.17.15 to 4.17.19
-- Switch websocket library to use @nomiclabs fork for removal of node-gyp
+- Switch websocket library to use @chainsafe fork for removal of node-gyp
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,7 @@ Released with 1.0.0-beta.37 code base.
 - `npm run build` now uses TSC to compile (.js allowed) and the build folder is now located under `lib` (#3652)
 - Modernized web3-core to use newer es syntax (#3652)
 - Bump lodash from 4.17.15 to 4.17.19
+- Switch websocket library to use @nomiclabs fork for removal of node-gyp
 
 ### Fixed
 

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -4,10 +4,10 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@nomiclabs/websocket": {
+		"@chainsafe/websocket": {
 			"version": "1.0.31",
-			"resolved": "https://registry.npmjs.org/@nomiclabs/websocket/-/websocket-1.0.31.tgz",
-			"integrity": "sha512-Tiub0/Rsm9CMkHwjlSP5uM0lr6m6BV87rUM8Rxvpmcs+/Cq75jNB/YSk2B3tCPCoCQ5uzW7sNaDyhKG6EwdYZw==",
+			"resolved": "https://registry.npmjs.org/@chainsafe/websocket/-/websocket-1.0.31.tgz",
+			"integrity": "sha512-HeTZAmHJBt8bmTyJ28d8lX+6kHnvQ3Wg18ahn2dRq7ZNaOTZ9F0+6yA3qqHKR+7t2MGutP1yM9muX6ozyFyP1A==",
 			"requires": {
 				"bufferutil": "^4.0.1",
 				"debug": "^2.2.0",
@@ -97,6 +97,11 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"bn.js": {
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -106,6 +111,16 @@
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"buffer-to-arraybuffer": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+			"integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
 		},
 		"bufferutil": {
 			"version": "4.0.1",
@@ -252,11 +267,29 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
+		},
+		"dom-walk": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+			"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 		},
 		"dts-critic": {
 			"version": "3.0.1",
@@ -343,6 +376,20 @@
 				}
 			}
 		},
+		"elliptic": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"requires": {
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -404,6 +451,45 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"eth-lib": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+			"integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+			"requires": {
+				"bn.js": "^4.11.6",
+				"elliptic": "^6.4.0",
+				"xhr-request-promise": "^0.1.2"
+			}
+		},
+		"ethereum-bloom-filters": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
+			"integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
+			"requires": {
+				"js-sha3": "^0.8.0"
+			}
+		},
+		"ethjs-unit": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+			"integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+			"requires": {
+				"bn.js": "4.11.6",
+				"number-to-bn": "1.7.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
+			}
+		},
+		"eventemitter3": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
 		},
 		"execa": {
 			"version": "1.0.0",
@@ -490,6 +576,15 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"global": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+			"requires": {
+				"min-document": "^2.19.0",
+				"process": "~0.5.1"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -519,10 +614,24 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
-		"i": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
-			"integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -537,8 +646,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"invert-kv": {
 			"version": "2.0.0",
@@ -551,6 +659,16 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 			"dev": true
+		},
+		"is-function": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+		},
+		"is-hex-prefixed": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -568,6 +686,11 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
+		},
+		"js-sha3": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -654,6 +777,29 @@
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
 		},
+		"mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+		},
+		"min-document": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"requires": {
+				"dom-walk": "^0.1.0"
+			}
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -699,3091 +845,6 @@
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
 			"integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
 		},
-		"npm": {
-			"version": "6.14.7",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
-			"integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
-			"requires": {
-				"JSONStream": "^1.3.5",
-				"abbrev": "~1.1.1",
-				"ansicolors": "~0.3.2",
-				"ansistyles": "~0.1.3",
-				"aproba": "^2.0.0",
-				"archy": "~1.0.0",
-				"bin-links": "^1.1.8",
-				"bluebird": "^3.5.5",
-				"byte-size": "^5.0.1",
-				"cacache": "^12.0.3",
-				"call-limit": "^1.1.1",
-				"chownr": "^1.1.4",
-				"ci-info": "^2.0.0",
-				"cli-columns": "^3.1.2",
-				"cli-table3": "^0.5.1",
-				"cmd-shim": "^3.0.3",
-				"columnify": "~1.5.4",
-				"config-chain": "^1.1.12",
-				"debuglog": "*",
-				"detect-indent": "~5.0.0",
-				"detect-newline": "^2.1.0",
-				"dezalgo": "~1.0.3",
-				"editor": "~1.0.0",
-				"figgy-pudding": "^3.5.1",
-				"find-npm-prefix": "^1.0.2",
-				"fs-vacuum": "~1.2.10",
-				"fs-write-stream-atomic": "~1.0.10",
-				"gentle-fs": "^2.3.1",
-				"glob": "^7.1.6",
-				"graceful-fs": "^4.2.4",
-				"has-unicode": "~2.0.1",
-				"hosted-git-info": "^2.8.8",
-				"iferr": "^1.0.2",
-				"imurmurhash": "*",
-				"infer-owner": "^1.0.4",
-				"inflight": "~1.0.6",
-				"inherits": "^2.0.4",
-				"ini": "^1.3.5",
-				"init-package-json": "^1.10.3",
-				"is-cidr": "^3.0.0",
-				"json-parse-better-errors": "^1.0.2",
-				"lazy-property": "~1.0.0",
-				"libcipm": "^4.0.8",
-				"libnpm": "^3.0.1",
-				"libnpmaccess": "^3.0.2",
-				"libnpmhook": "^5.0.3",
-				"libnpmorg": "^1.0.1",
-				"libnpmsearch": "^2.0.2",
-				"libnpmteam": "^1.0.2",
-				"libnpx": "^10.2.4",
-				"lock-verify": "^2.1.0",
-				"lockfile": "^1.0.4",
-				"lodash._baseindexof": "*",
-				"lodash._baseuniq": "~4.6.0",
-				"lodash._bindcallback": "*",
-				"lodash._cacheindexof": "*",
-				"lodash._createcache": "*",
-				"lodash._getnative": "*",
-				"lodash.clonedeep": "~4.5.0",
-				"lodash.restparam": "*",
-				"lodash.union": "~4.6.0",
-				"lodash.uniq": "~4.5.0",
-				"lodash.without": "~4.4.0",
-				"lru-cache": "^5.1.1",
-				"meant": "~1.0.1",
-				"mississippi": "^3.0.0",
-				"mkdirp": "^0.5.5",
-				"move-concurrently": "^1.0.1",
-				"node-gyp": "^5.1.0",
-				"nopt": "^4.0.3",
-				"normalize-package-data": "^2.5.0",
-				"npm-audit-report": "^1.3.3",
-				"npm-cache-filename": "~1.0.2",
-				"npm-install-checks": "^3.0.2",
-				"npm-lifecycle": "^3.1.5",
-				"npm-package-arg": "^6.1.1",
-				"npm-packlist": "^1.4.8",
-				"npm-pick-manifest": "^3.0.2",
-				"npm-profile": "^4.0.4",
-				"npm-registry-fetch": "^4.0.5",
-				"npm-user-validate": "~1.0.0",
-				"npmlog": "~4.1.2",
-				"once": "~1.4.0",
-				"opener": "^1.5.1",
-				"osenv": "^0.1.5",
-				"pacote": "^9.5.12",
-				"path-is-inside": "~1.0.2",
-				"promise-inflight": "~1.0.1",
-				"qrcode-terminal": "^0.12.0",
-				"query-string": "^6.8.2",
-				"qw": "~1.0.1",
-				"read": "~1.0.7",
-				"read-cmd-shim": "^1.0.5",
-				"read-installed": "~4.0.3",
-				"read-package-json": "^2.1.1",
-				"read-package-tree": "^5.3.1",
-				"readable-stream": "^3.6.0",
-				"readdir-scoped-modules": "^1.1.0",
-				"request": "^2.88.0",
-				"retry": "^0.12.0",
-				"rimraf": "^2.7.1",
-				"safe-buffer": "^5.1.2",
-				"semver": "^5.7.1",
-				"sha": "^3.0.0",
-				"slide": "~1.1.6",
-				"sorted-object": "~2.0.1",
-				"sorted-union-stream": "~2.1.3",
-				"ssri": "^6.0.1",
-				"stringify-package": "^1.0.1",
-				"tar": "^4.4.13",
-				"text-table": "~0.2.0",
-				"tiny-relative-date": "^1.3.0",
-				"uid-number": "0.0.6",
-				"umask": "~1.1.0",
-				"unique-filename": "^1.1.1",
-				"unpipe": "~1.0.0",
-				"update-notifier": "^2.5.0",
-				"uuid": "^3.3.3",
-				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "~3.0.0",
-				"which": "^1.3.1",
-				"worker-farm": "^1.7.0",
-				"write-file-atomic": "^2.4.3"
-			},
-			"dependencies": {
-				"JSONStream": {
-					"version": "1.3.5",
-					"bundled": true,
-					"requires": {
-						"jsonparse": "^1.2.0",
-						"through": ">=2.2.7 <3"
-					}
-				},
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"agent-base": {
-					"version": "4.3.0",
-					"bundled": true,
-					"requires": {
-						"es6-promisify": "^5.0.0"
-					}
-				},
-				"agentkeepalive": {
-					"version": "3.5.2",
-					"bundled": true,
-					"requires": {
-						"humanize-ms": "^1.2.1"
-					}
-				},
-				"ajv": {
-					"version": "5.5.2",
-					"bundled": true,
-					"requires": {
-						"co": "^4.6.0",
-						"fast-deep-equal": "^1.0.0",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.3.0"
-					}
-				},
-				"ansi-align": {
-					"version": "2.0.0",
-					"bundled": true,
-					"requires": {
-						"string-width": "^2.0.0"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"bundled": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"ansicolors": {
-					"version": "0.3.2",
-					"bundled": true
-				},
-				"ansistyles": {
-					"version": "0.1.3",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"archy": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"asap": {
-					"version": "2.0.6",
-					"bundled": true
-				},
-				"asn1": {
-					"version": "0.2.4",
-					"bundled": true,
-					"requires": {
-						"safer-buffer": "~2.1.0"
-					}
-				},
-				"assert-plus": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"bundled": true
-				},
-				"aws-sign2": {
-					"version": "0.7.0",
-					"bundled": true
-				},
-				"aws4": {
-					"version": "1.8.0",
-					"bundled": true
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "^0.14.3"
-					}
-				},
-				"bin-links": {
-					"version": "1.1.8",
-					"bundled": true,
-					"requires": {
-						"bluebird": "^3.5.3",
-						"cmd-shim": "^3.0.0",
-						"gentle-fs": "^2.3.0",
-						"graceful-fs": "^4.1.15",
-						"npm-normalize-package-bin": "^1.0.0",
-						"write-file-atomic": "^2.3.0"
-					}
-				},
-				"bluebird": {
-					"version": "3.5.5",
-					"bundled": true
-				},
-				"boxen": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"ansi-align": "^2.0.0",
-						"camelcase": "^4.0.0",
-						"chalk": "^2.0.1",
-						"cli-boxes": "^1.0.0",
-						"string-width": "^2.0.0",
-						"term-size": "^1.2.0",
-						"widest-line": "^2.0.0"
-					}
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-from": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"builtins": {
-					"version": "1.0.3",
-					"bundled": true
-				},
-				"byline": {
-					"version": "5.0.0",
-					"bundled": true
-				},
-				"byte-size": {
-					"version": "5.0.1",
-					"bundled": true
-				},
-				"cacache": {
-					"version": "12.0.3",
-					"bundled": true,
-					"requires": {
-						"bluebird": "^3.5.5",
-						"chownr": "^1.1.1",
-						"figgy-pudding": "^3.5.1",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.1.15",
-						"infer-owner": "^1.0.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.3",
-						"ssri": "^6.0.1",
-						"unique-filename": "^1.1.1",
-						"y18n": "^4.0.0"
-					}
-				},
-				"call-limit": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"bundled": true
-				},
-				"capture-stack-trace": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"bundled": true
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"bundled": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"chownr": {
-					"version": "1.1.4",
-					"bundled": true
-				},
-				"ci-info": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"cidr-regex": {
-					"version": "2.0.10",
-					"bundled": true,
-					"requires": {
-						"ip-regex": "^2.1.0"
-					}
-				},
-				"cli-boxes": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"cli-columns": {
-					"version": "3.1.2",
-					"bundled": true,
-					"requires": {
-						"string-width": "^2.0.0",
-						"strip-ansi": "^3.0.1"
-					}
-				},
-				"cli-table3": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"colors": "^1.1.2",
-						"object-assign": "^4.1.0",
-						"string-width": "^2.1.1"
-					}
-				},
-				"cliui": {
-					"version": "5.0.0",
-					"bundled": true,
-					"requires": {
-						"string-width": "^3.1.0",
-						"strip-ansi": "^5.2.0",
-						"wrap-ansi": "^5.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"bundled": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"bundled": true
-						},
-						"string-width": {
-							"version": "3.1.0",
-							"bundled": true,
-							"requires": {
-								"emoji-regex": "^7.0.1",
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"clone": {
-					"version": "1.0.4",
-					"bundled": true
-				},
-				"cmd-shim": {
-					"version": "3.0.3",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"mkdirp": "~0.5.0"
-					}
-				},
-				"co": {
-					"version": "4.6.0",
-					"bundled": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"color-convert": {
-					"version": "1.9.1",
-					"bundled": true,
-					"requires": {
-						"color-name": "^1.1.1"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"bundled": true
-				},
-				"colors": {
-					"version": "1.3.3",
-					"bundled": true,
-					"optional": true
-				},
-				"columnify": {
-					"version": "1.5.4",
-					"bundled": true,
-					"requires": {
-						"strip-ansi": "^3.0.0",
-						"wcwidth": "^1.0.0"
-					}
-				},
-				"combined-stream": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"delayed-stream": "~1.0.0"
-					}
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"concat-stream": {
-					"version": "1.6.2",
-					"bundled": true,
-					"requires": {
-						"buffer-from": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.2.2",
-						"typedarray": "^0.0.6"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"config-chain": {
-					"version": "1.1.12",
-					"bundled": true,
-					"requires": {
-						"ini": "^1.3.4",
-						"proto-list": "~1.2.1"
-					}
-				},
-				"configstore": {
-					"version": "3.1.2",
-					"bundled": true,
-					"requires": {
-						"dot-prop": "^4.1.0",
-						"graceful-fs": "^4.1.2",
-						"make-dir": "^1.0.0",
-						"unique-string": "^1.0.0",
-						"write-file-atomic": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
-					}
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"copy-concurrently": {
-					"version": "1.0.5",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.1.1",
-						"fs-write-stream-atomic": "^1.0.8",
-						"iferr": "^0.1.5",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.5.4",
-						"run-queue": "^1.0.0"
-					},
-					"dependencies": {
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true
-						},
-						"iferr": {
-							"version": "0.1.5",
-							"bundled": true
-						}
-					}
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"create-error-class": {
-					"version": "3.0.2",
-					"bundled": true,
-					"requires": {
-						"capture-stack-trace": "^1.0.0"
-					}
-				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"bundled": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					},
-					"dependencies": {
-						"lru-cache": {
-							"version": "4.1.5",
-							"bundled": true,
-							"requires": {
-								"pseudomap": "^1.0.2",
-								"yallist": "^2.1.2"
-							}
-						},
-						"yallist": {
-							"version": "2.1.2",
-							"bundled": true
-						}
-					}
-				},
-				"crypto-random-string": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"cyclist": {
-					"version": "0.2.2",
-					"bundled": true
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"bundled": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					}
-				},
-				"debug": {
-					"version": "3.1.0",
-					"bundled": true,
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"bundled": true
-						}
-					}
-				},
-				"debuglog": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"decamelize": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"decode-uri-component": {
-					"version": "0.2.0",
-					"bundled": true
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true
-				},
-				"defaults": {
-					"version": "1.0.3",
-					"bundled": true,
-					"requires": {
-						"clone": "^1.0.2"
-					}
-				},
-				"define-properties": {
-					"version": "1.1.3",
-					"bundled": true,
-					"requires": {
-						"object-keys": "^1.0.12"
-					}
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"detect-indent": {
-					"version": "5.0.0",
-					"bundled": true
-				},
-				"detect-newline": {
-					"version": "2.1.0",
-					"bundled": true
-				},
-				"dezalgo": {
-					"version": "1.0.3",
-					"bundled": true,
-					"requires": {
-						"asap": "^2.0.0",
-						"wrappy": "1"
-					}
-				},
-				"dot-prop": {
-					"version": "4.2.0",
-					"bundled": true,
-					"requires": {
-						"is-obj": "^1.0.0"
-					}
-				},
-				"dotenv": {
-					"version": "5.0.1",
-					"bundled": true
-				},
-				"duplexer3": {
-					"version": "0.1.4",
-					"bundled": true
-				},
-				"duplexify": {
-					"version": "3.6.0",
-					"bundled": true,
-					"requires": {
-						"end-of-stream": "^1.0.0",
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0",
-						"stream-shift": "^1.0.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"ecc-jsbn": {
-					"version": "0.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "~0.1.0",
-						"safer-buffer": "^2.1.0"
-					}
-				},
-				"editor": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"emoji-regex": {
-					"version": "7.0.3",
-					"bundled": true
-				},
-				"encoding": {
-					"version": "0.1.12",
-					"bundled": true,
-					"requires": {
-						"iconv-lite": "~0.4.13"
-					}
-				},
-				"end-of-stream": {
-					"version": "1.4.1",
-					"bundled": true,
-					"requires": {
-						"once": "^1.4.0"
-					}
-				},
-				"env-paths": {
-					"version": "2.2.0",
-					"bundled": true
-				},
-				"err-code": {
-					"version": "1.1.2",
-					"bundled": true
-				},
-				"errno": {
-					"version": "0.1.7",
-					"bundled": true,
-					"requires": {
-						"prr": "~1.0.1"
-					}
-				},
-				"es-abstract": {
-					"version": "1.12.0",
-					"bundled": true,
-					"requires": {
-						"es-to-primitive": "^1.1.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.1",
-						"is-callable": "^1.1.3",
-						"is-regex": "^1.0.4"
-					}
-				},
-				"es-to-primitive": {
-					"version": "1.2.0",
-					"bundled": true,
-					"requires": {
-						"is-callable": "^1.1.4",
-						"is-date-object": "^1.0.1",
-						"is-symbol": "^1.0.2"
-					}
-				},
-				"es6-promise": {
-					"version": "4.2.8",
-					"bundled": true
-				},
-				"es6-promisify": {
-					"version": "5.0.0",
-					"bundled": true,
-					"requires": {
-						"es6-promise": "^4.0.3"
-					}
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"bundled": true
-				},
-				"execa": {
-					"version": "0.7.0",
-					"bundled": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					},
-					"dependencies": {
-						"get-stream": {
-							"version": "3.0.0",
-							"bundled": true
-						}
-					}
-				},
-				"extend": {
-					"version": "3.0.2",
-					"bundled": true
-				},
-				"extsprintf": {
-					"version": "1.3.0",
-					"bundled": true
-				},
-				"fast-deep-equal": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"fast-json-stable-stringify": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"figgy-pudding": {
-					"version": "3.5.1",
-					"bundled": true
-				},
-				"find-npm-prefix": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"flush-write-stream": {
-					"version": "1.0.3",
-					"bundled": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.4"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"bundled": true
-				},
-				"form-data": {
-					"version": "2.3.2",
-					"bundled": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"from2": {
-					"version": "2.3.0",
-					"bundled": true,
-					"requires": {
-						"inherits": "^2.0.1",
-						"readable-stream": "^2.0.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"fs-minipass": {
-					"version": "1.2.7",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.6.0"
-					},
-					"dependencies": {
-						"minipass": {
-							"version": "2.9.0",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						}
-					}
-				},
-				"fs-vacuum": {
-					"version": "1.2.10",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"path-is-inside": "^1.0.1",
-						"rimraf": "^2.5.2"
-					}
-				},
-				"fs-write-stream-atomic": {
-					"version": "1.0.10",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"iferr": "^0.1.5",
-						"imurmurhash": "^0.1.4",
-						"readable-stream": "1 || 2"
-					},
-					"dependencies": {
-						"iferr": {
-							"version": "0.1.5",
-							"bundled": true
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"function-bind": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					},
-					"dependencies": {
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
-					}
-				},
-				"genfun": {
-					"version": "5.0.0",
-					"bundled": true
-				},
-				"gentle-fs": {
-					"version": "2.3.1",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.1.2",
-						"chownr": "^1.1.2",
-						"cmd-shim": "^3.0.3",
-						"fs-vacuum": "^1.2.10",
-						"graceful-fs": "^4.1.11",
-						"iferr": "^0.1.5",
-						"infer-owner": "^1.0.4",
-						"mkdirp": "^0.5.1",
-						"path-is-inside": "^1.0.2",
-						"read-cmd-shim": "^1.0.1",
-						"slide": "^1.1.6"
-					},
-					"dependencies": {
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true
-						},
-						"iferr": {
-							"version": "0.1.5",
-							"bundled": true
-						}
-					}
-				},
-				"get-caller-file": {
-					"version": "2.0.5",
-					"bundled": true
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"bundled": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"bundled": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.6",
-					"bundled": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"global-dirs": {
-					"version": "0.1.1",
-					"bundled": true,
-					"requires": {
-						"ini": "^1.3.4"
-					}
-				},
-				"got": {
-					"version": "6.7.1",
-					"bundled": true,
-					"requires": {
-						"create-error-class": "^3.0.0",
-						"duplexer3": "^0.1.4",
-						"get-stream": "^3.0.0",
-						"is-redirect": "^1.0.0",
-						"is-retry-allowed": "^1.0.0",
-						"is-stream": "^1.0.0",
-						"lowercase-keys": "^1.0.0",
-						"safe-buffer": "^5.0.1",
-						"timed-out": "^4.0.0",
-						"unzip-response": "^2.0.1",
-						"url-parse-lax": "^1.0.0"
-					},
-					"dependencies": {
-						"get-stream": {
-							"version": "3.0.0",
-							"bundled": true
-						}
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.4",
-					"bundled": true
-				},
-				"har-schema": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"har-validator": {
-					"version": "5.1.0",
-					"bundled": true,
-					"requires": {
-						"ajv": "^5.3.0",
-						"har-schema": "^2.0.0"
-					}
-				},
-				"has": {
-					"version": "1.0.3",
-					"bundled": true,
-					"requires": {
-						"function-bind": "^1.1.1"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"bundled": true
-				},
-				"has-symbols": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"hosted-git-info": {
-					"version": "2.8.8",
-					"bundled": true
-				},
-				"http-cache-semantics": {
-					"version": "3.8.1",
-					"bundled": true
-				},
-				"http-proxy-agent": {
-					"version": "2.1.0",
-					"bundled": true,
-					"requires": {
-						"agent-base": "4",
-						"debug": "3.1.0"
-					}
-				},
-				"http-signature": {
-					"version": "1.2.0",
-					"bundled": true,
-					"requires": {
-						"assert-plus": "^1.0.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
-					}
-				},
-				"https-proxy-agent": {
-					"version": "2.2.4",
-					"bundled": true,
-					"requires": {
-						"agent-base": "^4.3.0",
-						"debug": "^3.1.0"
-					}
-				},
-				"humanize-ms": {
-					"version": "1.2.1",
-					"bundled": true,
-					"requires": {
-						"ms": "^2.0.0"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.23",
-					"bundled": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"iferr": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"ignore-walk": {
-					"version": "3.0.3",
-					"bundled": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"import-lazy": {
-					"version": "2.1.0",
-					"bundled": true
-				},
-				"imurmurhash": {
-					"version": "0.1.4",
-					"bundled": true
-				},
-				"infer-owner": {
-					"version": "1.0.4",
-					"bundled": true
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true
-				},
-				"init-package-json": {
-					"version": "1.10.3",
-					"bundled": true,
-					"requires": {
-						"glob": "^7.1.1",
-						"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
-						"promzard": "^0.3.0",
-						"read": "~1.0.1",
-						"read-package-json": "1 || 2",
-						"semver": "2.x || 3.x || 4 || 5",
-						"validate-npm-package-license": "^3.0.1",
-						"validate-npm-package-name": "^3.0.0"
-					}
-				},
-				"ip": {
-					"version": "1.1.5",
-					"bundled": true
-				},
-				"ip-regex": {
-					"version": "2.1.0",
-					"bundled": true
-				},
-				"is-callable": {
-					"version": "1.1.4",
-					"bundled": true
-				},
-				"is-ci": {
-					"version": "1.2.1",
-					"bundled": true,
-					"requires": {
-						"ci-info": "^1.5.0"
-					},
-					"dependencies": {
-						"ci-info": {
-							"version": "1.6.0",
-							"bundled": true
-						}
-					}
-				},
-				"is-cidr": {
-					"version": "3.0.0",
-					"bundled": true,
-					"requires": {
-						"cidr-regex": "^2.0.10"
-					}
-				},
-				"is-date-object": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"is-installed-globally": {
-					"version": "0.1.0",
-					"bundled": true,
-					"requires": {
-						"global-dirs": "^0.1.0",
-						"is-path-inside": "^1.0.0"
-					}
-				},
-				"is-npm": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"is-obj": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"is-path-inside": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"path-is-inside": "^1.0.1"
-					}
-				},
-				"is-redirect": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"is-regex": {
-					"version": "1.0.4",
-					"bundled": true,
-					"requires": {
-						"has": "^1.0.1"
-					}
-				},
-				"is-retry-allowed": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"is-stream": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"is-symbol": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"has-symbols": "^1.0.0"
-					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"isexe": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"bundled": true
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"json-parse-better-errors": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"bundled": true
-				},
-				"json-schema-traverse": {
-					"version": "0.3.1",
-					"bundled": true
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"bundled": true
-				},
-				"jsonparse": {
-					"version": "1.3.1",
-					"bundled": true
-				},
-				"jsprim": {
-					"version": "1.4.1",
-					"bundled": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.3.0",
-						"json-schema": "0.2.3",
-						"verror": "1.10.0"
-					}
-				},
-				"latest-version": {
-					"version": "3.1.0",
-					"bundled": true,
-					"requires": {
-						"package-json": "^4.0.0"
-					}
-				},
-				"lazy-property": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"libcipm": {
-					"version": "4.0.8",
-					"bundled": true,
-					"requires": {
-						"bin-links": "^1.1.2",
-						"bluebird": "^3.5.1",
-						"figgy-pudding": "^3.5.1",
-						"find-npm-prefix": "^1.0.2",
-						"graceful-fs": "^4.1.11",
-						"ini": "^1.3.5",
-						"lock-verify": "^2.1.0",
-						"mkdirp": "^0.5.1",
-						"npm-lifecycle": "^3.0.0",
-						"npm-logical-tree": "^1.2.1",
-						"npm-package-arg": "^6.1.0",
-						"pacote": "^9.1.0",
-						"read-package-json": "^2.0.13",
-						"rimraf": "^2.6.2",
-						"worker-farm": "^1.6.0"
-					}
-				},
-				"libnpm": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"bin-links": "^1.1.2",
-						"bluebird": "^3.5.3",
-						"find-npm-prefix": "^1.0.2",
-						"libnpmaccess": "^3.0.2",
-						"libnpmconfig": "^1.2.1",
-						"libnpmhook": "^5.0.3",
-						"libnpmorg": "^1.0.1",
-						"libnpmpublish": "^1.1.2",
-						"libnpmsearch": "^2.0.2",
-						"libnpmteam": "^1.0.2",
-						"lock-verify": "^2.0.2",
-						"npm-lifecycle": "^3.0.0",
-						"npm-logical-tree": "^1.2.1",
-						"npm-package-arg": "^6.1.0",
-						"npm-profile": "^4.0.2",
-						"npm-registry-fetch": "^4.0.0",
-						"npmlog": "^4.1.2",
-						"pacote": "^9.5.3",
-						"read-package-json": "^2.0.13",
-						"stringify-package": "^1.0.0"
-					}
-				},
-				"libnpmaccess": {
-					"version": "3.0.2",
-					"bundled": true,
-					"requires": {
-						"aproba": "^2.0.0",
-						"get-stream": "^4.0.0",
-						"npm-package-arg": "^6.1.0",
-						"npm-registry-fetch": "^4.0.0"
-					}
-				},
-				"libnpmconfig": {
-					"version": "1.2.1",
-					"bundled": true,
-					"requires": {
-						"figgy-pudding": "^3.5.1",
-						"find-up": "^3.0.0",
-						"ini": "^1.3.5"
-					},
-					"dependencies": {
-						"find-up": {
-							"version": "3.0.0",
-							"bundled": true,
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"bundled": true,
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "2.2.0",
-							"bundled": true,
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "3.0.0",
-							"bundled": true,
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"p-try": {
-							"version": "2.2.0",
-							"bundled": true
-						}
-					}
-				},
-				"libnpmhook": {
-					"version": "5.0.3",
-					"bundled": true,
-					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.4.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
-					}
-				},
-				"libnpmorg": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.4.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
-					}
-				},
-				"libnpmpublish": {
-					"version": "1.1.2",
-					"bundled": true,
-					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.5.1",
-						"get-stream": "^4.0.0",
-						"lodash.clonedeep": "^4.5.0",
-						"normalize-package-data": "^2.4.0",
-						"npm-package-arg": "^6.1.0",
-						"npm-registry-fetch": "^4.0.0",
-						"semver": "^5.5.1",
-						"ssri": "^6.0.1"
-					}
-				},
-				"libnpmsearch": {
-					"version": "2.0.2",
-					"bundled": true,
-					"requires": {
-						"figgy-pudding": "^3.5.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
-					}
-				},
-				"libnpmteam": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"aproba": "^2.0.0",
-						"figgy-pudding": "^3.4.1",
-						"get-stream": "^4.0.0",
-						"npm-registry-fetch": "^4.0.0"
-					}
-				},
-				"libnpx": {
-					"version": "10.2.4",
-					"bundled": true,
-					"requires": {
-						"dotenv": "^5.0.1",
-						"npm-package-arg": "^6.0.0",
-						"rimraf": "^2.6.2",
-						"safe-buffer": "^5.1.0",
-						"update-notifier": "^2.3.0",
-						"which": "^1.3.0",
-						"y18n": "^4.0.0",
-						"yargs": "^14.2.3"
-					}
-				},
-				"lock-verify": {
-					"version": "2.1.0",
-					"bundled": true,
-					"requires": {
-						"npm-package-arg": "^6.1.0",
-						"semver": "^5.4.1"
-					}
-				},
-				"lockfile": {
-					"version": "1.0.4",
-					"bundled": true,
-					"requires": {
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"lodash._baseindexof": {
-					"version": "3.1.0",
-					"bundled": true
-				},
-				"lodash._baseuniq": {
-					"version": "4.6.0",
-					"bundled": true,
-					"requires": {
-						"lodash._createset": "~4.0.0",
-						"lodash._root": "~3.0.0"
-					}
-				},
-				"lodash._bindcallback": {
-					"version": "3.0.1",
-					"bundled": true
-				},
-				"lodash._cacheindexof": {
-					"version": "3.0.2",
-					"bundled": true
-				},
-				"lodash._createcache": {
-					"version": "3.1.2",
-					"bundled": true,
-					"requires": {
-						"lodash._getnative": "^3.0.0"
-					}
-				},
-				"lodash._createset": {
-					"version": "4.0.3",
-					"bundled": true
-				},
-				"lodash._getnative": {
-					"version": "3.9.1",
-					"bundled": true
-				},
-				"lodash._root": {
-					"version": "3.0.1",
-					"bundled": true
-				},
-				"lodash.clonedeep": {
-					"version": "4.5.0",
-					"bundled": true
-				},
-				"lodash.restparam": {
-					"version": "3.6.1",
-					"bundled": true
-				},
-				"lodash.union": {
-					"version": "4.6.0",
-					"bundled": true
-				},
-				"lodash.uniq": {
-					"version": "4.5.0",
-					"bundled": true
-				},
-				"lodash.without": {
-					"version": "4.4.0",
-					"bundled": true
-				},
-				"lowercase-keys": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"lru-cache": {
-					"version": "5.1.1",
-					"bundled": true,
-					"requires": {
-						"yallist": "^3.0.2"
-					}
-				},
-				"make-dir": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"make-fetch-happen": {
-					"version": "5.0.2",
-					"bundled": true,
-					"requires": {
-						"agentkeepalive": "^3.4.1",
-						"cacache": "^12.0.0",
-						"http-cache-semantics": "^3.8.1",
-						"http-proxy-agent": "^2.1.0",
-						"https-proxy-agent": "^2.2.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"node-fetch-npm": "^2.0.2",
-						"promise-retry": "^1.1.1",
-						"socks-proxy-agent": "^4.0.0",
-						"ssri": "^6.0.0"
-					}
-				},
-				"meant": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"mime-db": {
-					"version": "1.35.0",
-					"bundled": true
-				},
-				"mime-types": {
-					"version": "2.1.19",
-					"bundled": true,
-					"requires": {
-						"mime-db": "~1.35.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.9.0"
-					},
-					"dependencies": {
-						"minipass": {
-							"version": "2.9.0",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						}
-					}
-				},
-				"mississippi": {
-					"version": "3.0.0",
-					"bundled": true,
-					"requires": {
-						"concat-stream": "^1.5.0",
-						"duplexify": "^3.4.2",
-						"end-of-stream": "^1.1.0",
-						"flush-write-stream": "^1.0.0",
-						"from2": "^2.1.0",
-						"parallel-transform": "^1.1.0",
-						"pump": "^3.0.0",
-						"pumpify": "^1.3.3",
-						"stream-each": "^1.1.0",
-						"through2": "^2.0.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"bundled": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.5",
-							"bundled": true
-						}
-					}
-				},
-				"move-concurrently": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.1.1",
-						"copy-concurrently": "^1.0.0",
-						"fs-write-stream-atomic": "^1.0.8",
-						"mkdirp": "^0.5.1",
-						"rimraf": "^2.5.4",
-						"run-queue": "^1.0.3"
-					},
-					"dependencies": {
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"mute-stream": {
-					"version": "0.0.7",
-					"bundled": true
-				},
-				"node-fetch-npm": {
-					"version": "2.0.2",
-					"bundled": true,
-					"requires": {
-						"encoding": "^0.1.11",
-						"json-parse-better-errors": "^1.0.0",
-						"safe-buffer": "^5.1.1"
-					}
-				},
-				"node-gyp": {
-					"version": "5.1.0",
-					"bundled": true,
-					"requires": {
-						"env-paths": "^2.2.0",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.2.2",
-						"mkdirp": "^0.5.1",
-						"nopt": "^4.0.1",
-						"npmlog": "^4.1.2",
-						"request": "^2.88.0",
-						"rimraf": "^2.6.3",
-						"semver": "^5.7.1",
-						"tar": "^4.4.12",
-						"which": "^1.3.1"
-					}
-				},
-				"nopt": {
-					"version": "4.0.3",
-					"bundled": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"normalize-package-data": {
-					"version": "2.5.0",
-					"bundled": true,
-					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"resolve": "^1.10.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
-					},
-					"dependencies": {
-						"resolve": {
-							"version": "1.10.0",
-							"bundled": true,
-							"requires": {
-								"path-parse": "^1.0.6"
-							}
-						}
-					}
-				},
-				"npm-audit-report": {
-					"version": "1.3.3",
-					"bundled": true,
-					"requires": {
-						"cli-table3": "^0.5.0",
-						"console-control-strings": "^1.1.0"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.1.1",
-					"bundled": true,
-					"requires": {
-						"npm-normalize-package-bin": "^1.0.1"
-					}
-				},
-				"npm-cache-filename": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"npm-install-checks": {
-					"version": "3.0.2",
-					"bundled": true,
-					"requires": {
-						"semver": "^2.3.0 || 3.x || 4 || 5"
-					}
-				},
-				"npm-lifecycle": {
-					"version": "3.1.5",
-					"bundled": true,
-					"requires": {
-						"byline": "^5.0.0",
-						"graceful-fs": "^4.1.15",
-						"node-gyp": "^5.0.2",
-						"resolve-from": "^4.0.0",
-						"slide": "^1.1.6",
-						"uid-number": "0.0.6",
-						"umask": "^1.1.0",
-						"which": "^1.3.1"
-					}
-				},
-				"npm-logical-tree": {
-					"version": "1.2.1",
-					"bundled": true
-				},
-				"npm-normalize-package-bin": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"npm-package-arg": {
-					"version": "6.1.1",
-					"bundled": true,
-					"requires": {
-						"hosted-git-info": "^2.7.1",
-						"osenv": "^0.1.5",
-						"semver": "^5.6.0",
-						"validate-npm-package-name": "^3.0.0"
-					}
-				},
-				"npm-packlist": {
-					"version": "1.4.8",
-					"bundled": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1",
-						"npm-normalize-package-bin": "^1.0.1"
-					}
-				},
-				"npm-pick-manifest": {
-					"version": "3.0.2",
-					"bundled": true,
-					"requires": {
-						"figgy-pudding": "^3.5.1",
-						"npm-package-arg": "^6.0.0",
-						"semver": "^5.4.1"
-					}
-				},
-				"npm-profile": {
-					"version": "4.0.4",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.1.2 || 2",
-						"figgy-pudding": "^3.4.1",
-						"npm-registry-fetch": "^4.0.0"
-					}
-				},
-				"npm-registry-fetch": {
-					"version": "4.0.5",
-					"bundled": true,
-					"requires": {
-						"JSONStream": "^1.3.4",
-						"bluebird": "^3.5.1",
-						"figgy-pudding": "^3.4.1",
-						"lru-cache": "^5.1.1",
-						"make-fetch-happen": "^5.0.0",
-						"npm-package-arg": "^6.1.0",
-						"safe-buffer": "^5.2.0"
-					},
-					"dependencies": {
-						"safe-buffer": {
-							"version": "5.2.1",
-							"bundled": true
-						}
-					}
-				},
-				"npm-run-path": {
-					"version": "2.0.2",
-					"bundled": true,
-					"requires": {
-						"path-key": "^2.0.0"
-					}
-				},
-				"npm-user-validate": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"oauth-sign": {
-					"version": "0.9.0",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true
-				},
-				"object-keys": {
-					"version": "1.0.12",
-					"bundled": true
-				},
-				"object.getownpropertydescriptors": {
-					"version": "2.0.3",
-					"bundled": true,
-					"requires": {
-						"define-properties": "^1.1.2",
-						"es-abstract": "^1.5.1"
-					}
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"opener": {
-					"version": "1.5.1",
-					"bundled": true
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"p-finally": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"package-json": {
-					"version": "4.0.1",
-					"bundled": true,
-					"requires": {
-						"got": "^6.7.1",
-						"registry-auth-token": "^3.0.1",
-						"registry-url": "^3.0.3",
-						"semver": "^5.1.0"
-					}
-				},
-				"pacote": {
-					"version": "9.5.12",
-					"bundled": true,
-					"requires": {
-						"bluebird": "^3.5.3",
-						"cacache": "^12.0.2",
-						"chownr": "^1.1.2",
-						"figgy-pudding": "^3.5.1",
-						"get-stream": "^4.1.0",
-						"glob": "^7.1.3",
-						"infer-owner": "^1.0.4",
-						"lru-cache": "^5.1.1",
-						"make-fetch-happen": "^5.0.0",
-						"minimatch": "^3.0.4",
-						"minipass": "^2.3.5",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"normalize-package-data": "^2.4.0",
-						"npm-normalize-package-bin": "^1.0.0",
-						"npm-package-arg": "^6.1.0",
-						"npm-packlist": "^1.1.12",
-						"npm-pick-manifest": "^3.0.0",
-						"npm-registry-fetch": "^4.0.0",
-						"osenv": "^0.1.5",
-						"promise-inflight": "^1.0.1",
-						"promise-retry": "^1.1.1",
-						"protoduck": "^5.0.1",
-						"rimraf": "^2.6.2",
-						"safe-buffer": "^5.1.2",
-						"semver": "^5.6.0",
-						"ssri": "^6.0.1",
-						"tar": "^4.4.10",
-						"unique-filename": "^1.1.1",
-						"which": "^1.3.1"
-					},
-					"dependencies": {
-						"minipass": {
-							"version": "2.9.0",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						}
-					}
-				},
-				"parallel-transform": {
-					"version": "1.1.0",
-					"bundled": true,
-					"requires": {
-						"cyclist": "~0.2.2",
-						"inherits": "^2.0.3",
-						"readable-stream": "^2.1.5"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"bundled": true
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"path-is-inside": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"path-key": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"bundled": true
-				},
-				"performance-now": {
-					"version": "2.1.0",
-					"bundled": true
-				},
-				"pify": {
-					"version": "3.0.0",
-					"bundled": true
-				},
-				"prepend-http": {
-					"version": "1.0.4",
-					"bundled": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"promise-inflight": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"promise-retry": {
-					"version": "1.1.1",
-					"bundled": true,
-					"requires": {
-						"err-code": "^1.0.0",
-						"retry": "^0.10.0"
-					},
-					"dependencies": {
-						"retry": {
-							"version": "0.10.1",
-							"bundled": true
-						}
-					}
-				},
-				"promzard": {
-					"version": "0.3.0",
-					"bundled": true,
-					"requires": {
-						"read": "1"
-					}
-				},
-				"proto-list": {
-					"version": "1.2.4",
-					"bundled": true
-				},
-				"protoduck": {
-					"version": "5.0.1",
-					"bundled": true,
-					"requires": {
-						"genfun": "^5.0.0"
-					}
-				},
-				"prr": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"pseudomap": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"psl": {
-					"version": "1.1.29",
-					"bundled": true
-				},
-				"pump": {
-					"version": "3.0.0",
-					"bundled": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"pumpify": {
-					"version": "1.5.1",
-					"bundled": true,
-					"requires": {
-						"duplexify": "^3.6.0",
-						"inherits": "^2.0.3",
-						"pump": "^2.0.0"
-					},
-					"dependencies": {
-						"pump": {
-							"version": "2.0.1",
-							"bundled": true,
-							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
-							}
-						}
-					}
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"bundled": true
-				},
-				"qrcode-terminal": {
-					"version": "0.12.0",
-					"bundled": true
-				},
-				"qs": {
-					"version": "6.5.2",
-					"bundled": true
-				},
-				"query-string": {
-					"version": "6.8.2",
-					"bundled": true,
-					"requires": {
-						"decode-uri-component": "^0.2.0",
-						"split-on-first": "^1.0.0",
-						"strict-uri-encode": "^2.0.0"
-					}
-				},
-				"qw": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.5",
-							"bundled": true
-						}
-					}
-				},
-				"read": {
-					"version": "1.0.7",
-					"bundled": true,
-					"requires": {
-						"mute-stream": "~0.0.4"
-					}
-				},
-				"read-cmd-shim": {
-					"version": "1.0.5",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "^4.1.2"
-					}
-				},
-				"read-installed": {
-					"version": "4.0.3",
-					"bundled": true,
-					"requires": {
-						"debuglog": "^1.0.1",
-						"graceful-fs": "^4.1.2",
-						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0",
-						"semver": "2 || 3 || 4 || 5",
-						"slide": "~1.1.3",
-						"util-extend": "^1.0.1"
-					}
-				},
-				"read-package-json": {
-					"version": "2.1.1",
-					"bundled": true,
-					"requires": {
-						"glob": "^7.1.1",
-						"graceful-fs": "^4.1.2",
-						"json-parse-better-errors": "^1.0.1",
-						"normalize-package-data": "^2.0.0",
-						"npm-normalize-package-bin": "^1.0.0"
-					}
-				},
-				"read-package-tree": {
-					"version": "5.3.1",
-					"bundled": true,
-					"requires": {
-						"read-package-json": "^2.0.0",
-						"readdir-scoped-modules": "^1.0.0",
-						"util-promisify": "^2.1.0"
-					}
-				},
-				"readable-stream": {
-					"version": "3.6.0",
-					"bundled": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"readdir-scoped-modules": {
-					"version": "1.1.0",
-					"bundled": true,
-					"requires": {
-						"debuglog": "^1.0.1",
-						"dezalgo": "^1.0.0",
-						"graceful-fs": "^4.1.2",
-						"once": "^1.3.0"
-					}
-				},
-				"registry-auth-token": {
-					"version": "3.4.0",
-					"bundled": true,
-					"requires": {
-						"rc": "^1.1.6",
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"registry-url": {
-					"version": "3.1.0",
-					"bundled": true,
-					"requires": {
-						"rc": "^1.0.1"
-					}
-				},
-				"request": {
-					"version": "2.88.0",
-					"bundled": true,
-					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.0",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.4.3",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
-					}
-				},
-				"require-directory": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"require-main-filename": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"resolve-from": {
-					"version": "4.0.0",
-					"bundled": true
-				},
-				"retry": {
-					"version": "0.12.0",
-					"bundled": true
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"bundled": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"run-queue": {
-					"version": "1.0.3",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.1.1"
-					},
-					"dependencies": {
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true
-						}
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"bundled": true
-				},
-				"semver-diff": {
-					"version": "2.1.0",
-					"bundled": true,
-					"requires": {
-						"semver": "^5.0.3"
-					}
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"sha": {
-					"version": "3.0.0",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "^4.1.2"
-					}
-				},
-				"shebang-command": {
-					"version": "1.2.0",
-					"bundled": true,
-					"requires": {
-						"shebang-regex": "^1.0.0"
-					}
-				},
-				"shebang-regex": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true
-				},
-				"slide": {
-					"version": "1.1.6",
-					"bundled": true
-				},
-				"smart-buffer": {
-					"version": "4.1.0",
-					"bundled": true
-				},
-				"socks": {
-					"version": "2.3.3",
-					"bundled": true,
-					"requires": {
-						"ip": "1.1.5",
-						"smart-buffer": "^4.1.0"
-					}
-				},
-				"socks-proxy-agent": {
-					"version": "4.0.2",
-					"bundled": true,
-					"requires": {
-						"agent-base": "~4.2.1",
-						"socks": "~2.3.2"
-					},
-					"dependencies": {
-						"agent-base": {
-							"version": "4.2.1",
-							"bundled": true,
-							"requires": {
-								"es6-promisify": "^5.0.0"
-							}
-						}
-					}
-				},
-				"sorted-object": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"sorted-union-stream": {
-					"version": "2.1.3",
-					"bundled": true,
-					"requires": {
-						"from2": "^1.3.0",
-						"stream-iterate": "^1.1.0"
-					},
-					"dependencies": {
-						"from2": {
-							"version": "1.3.0",
-							"bundled": true,
-							"requires": {
-								"inherits": "~2.0.1",
-								"readable-stream": "~1.1.10"
-							}
-						},
-						"isarray": {
-							"version": "0.0.1",
-							"bundled": true
-						},
-						"readable-stream": {
-							"version": "1.1.14",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.1",
-								"isarray": "0.0.1",
-								"string_decoder": "~0.10.x"
-							}
-						},
-						"string_decoder": {
-							"version": "0.10.31",
-							"bundled": true
-						}
-					}
-				},
-				"spdx-correct": {
-					"version": "3.0.0",
-					"bundled": true,
-					"requires": {
-						"spdx-expression-parse": "^3.0.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-exceptions": {
-					"version": "2.1.0",
-					"bundled": true
-				},
-				"spdx-expression-parse": {
-					"version": "3.0.0",
-					"bundled": true,
-					"requires": {
-						"spdx-exceptions": "^2.1.0",
-						"spdx-license-ids": "^3.0.0"
-					}
-				},
-				"spdx-license-ids": {
-					"version": "3.0.5",
-					"bundled": true
-				},
-				"split-on-first": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"sshpk": {
-					"version": "1.14.2",
-					"bundled": true,
-					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jsbn": "~0.1.0",
-						"safer-buffer": "^2.0.2",
-						"tweetnacl": "~0.14.0"
-					}
-				},
-				"ssri": {
-					"version": "6.0.1",
-					"bundled": true,
-					"requires": {
-						"figgy-pudding": "^3.5.1"
-					}
-				},
-				"stream-each": {
-					"version": "1.2.2",
-					"bundled": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"stream-shift": "^1.0.0"
-					}
-				},
-				"stream-iterate": {
-					"version": "1.2.0",
-					"bundled": true,
-					"requires": {
-						"readable-stream": "^2.1.5",
-						"stream-shift": "^1.0.0"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"stream-shift": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"strict-uri-encode": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"bundled": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"bundled": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"bundled": true
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					},
-					"dependencies": {
-						"safe-buffer": {
-							"version": "5.2.0",
-							"bundled": true
-						}
-					}
-				},
-				"stringify-package": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-eof": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"supports-color": {
-					"version": "5.4.0",
-					"bundled": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"tar": {
-					"version": "4.4.13",
-					"bundled": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					},
-					"dependencies": {
-						"minipass": {
-							"version": "2.9.0",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						}
-					}
-				},
-				"term-size": {
-					"version": "1.2.0",
-					"bundled": true,
-					"requires": {
-						"execa": "^0.7.0"
-					}
-				},
-				"text-table": {
-					"version": "0.2.0",
-					"bundled": true
-				},
-				"through": {
-					"version": "2.3.8",
-					"bundled": true
-				},
-				"through2": {
-					"version": "2.0.3",
-					"bundled": true,
-					"requires": {
-						"readable-stream": "^2.1.5",
-						"xtend": "~4.0.1"
-					},
-					"dependencies": {
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						}
-					}
-				},
-				"timed-out": {
-					"version": "4.0.1",
-					"bundled": true
-				},
-				"tiny-relative-date": {
-					"version": "1.3.0",
-					"bundled": true
-				},
-				"tough-cookie": {
-					"version": "2.4.3",
-					"bundled": true,
-					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"bundled": true,
-					"optional": true
-				},
-				"typedarray": {
-					"version": "0.0.6",
-					"bundled": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"bundled": true
-				},
-				"umask": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"unique-filename": {
-					"version": "1.1.1",
-					"bundled": true,
-					"requires": {
-						"unique-slug": "^2.0.0"
-					}
-				},
-				"unique-slug": {
-					"version": "2.0.0",
-					"bundled": true,
-					"requires": {
-						"imurmurhash": "^0.1.4"
-					}
-				},
-				"unique-string": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"crypto-random-string": "^1.0.0"
-					}
-				},
-				"unpipe": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"unzip-response": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"update-notifier": {
-					"version": "2.5.0",
-					"bundled": true,
-					"requires": {
-						"boxen": "^1.2.1",
-						"chalk": "^2.0.1",
-						"configstore": "^3.0.0",
-						"import-lazy": "^2.1.0",
-						"is-ci": "^1.0.10",
-						"is-installed-globally": "^0.1.0",
-						"is-npm": "^1.0.0",
-						"latest-version": "^3.0.0",
-						"semver-diff": "^2.0.0",
-						"xdg-basedir": "^3.0.0"
-					}
-				},
-				"url-parse-lax": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"prepend-http": "^1.0.1"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"util-extend": {
-					"version": "1.0.3",
-					"bundled": true
-				},
-				"util-promisify": {
-					"version": "2.1.0",
-					"bundled": true,
-					"requires": {
-						"object.getownpropertydescriptors": "^2.0.3"
-					}
-				},
-				"uuid": {
-					"version": "3.3.3",
-					"bundled": true
-				},
-				"validate-npm-package-license": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"spdx-correct": "^3.0.0",
-						"spdx-expression-parse": "^3.0.0"
-					}
-				},
-				"validate-npm-package-name": {
-					"version": "3.0.0",
-					"bundled": true,
-					"requires": {
-						"builtins": "^1.0.3"
-					}
-				},
-				"verror": {
-					"version": "1.10.0",
-					"bundled": true,
-					"requires": {
-						"assert-plus": "^1.0.0",
-						"core-util-is": "1.0.2",
-						"extsprintf": "^1.2.0"
-					}
-				},
-				"wcwidth": {
-					"version": "1.0.1",
-					"bundled": true,
-					"requires": {
-						"defaults": "^1.0.3"
-					}
-				},
-				"which": {
-					"version": "1.3.1",
-					"bundled": true,
-					"requires": {
-						"isexe": "^2.0.0"
-					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"requires": {
-						"string-width": "^1.0.2"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						}
-					}
-				},
-				"widest-line": {
-					"version": "2.0.1",
-					"bundled": true,
-					"requires": {
-						"string-width": "^2.1.1"
-					}
-				},
-				"worker-farm": {
-					"version": "1.7.0",
-					"bundled": true,
-					"requires": {
-						"errno": "~0.1.7"
-					}
-				},
-				"wrap-ansi": {
-					"version": "5.1.0",
-					"bundled": true,
-					"requires": {
-						"ansi-styles": "^3.2.0",
-						"string-width": "^3.0.0",
-						"strip-ansi": "^5.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"bundled": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"bundled": true
-						},
-						"string-width": {
-							"version": "3.1.0",
-							"bundled": true,
-							"requires": {
-								"emoji-regex": "^7.0.1",
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"write-file-atomic": {
-					"version": "2.4.3",
-					"bundled": true,
-					"requires": {
-						"graceful-fs": "^4.1.11",
-						"imurmurhash": "^0.1.4",
-						"signal-exit": "^3.0.2"
-					}
-				},
-				"xdg-basedir": {
-					"version": "3.0.0",
-					"bundled": true
-				},
-				"xtend": {
-					"version": "4.0.1",
-					"bundled": true
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"bundled": true
-				},
-				"yallist": {
-					"version": "3.0.3",
-					"bundled": true
-				},
-				"yargs": {
-					"version": "14.2.3",
-					"bundled": true,
-					"requires": {
-						"cliui": "^5.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^3.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^15.0.1"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"bundled": true
-						},
-						"find-up": {
-							"version": "3.0.0",
-							"bundled": true,
-							"requires": {
-								"locate-path": "^3.0.0"
-							}
-						},
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"bundled": true
-						},
-						"locate-path": {
-							"version": "3.0.0",
-							"bundled": true,
-							"requires": {
-								"p-locate": "^3.0.0",
-								"path-exists": "^3.0.0"
-							}
-						},
-						"p-limit": {
-							"version": "2.3.0",
-							"bundled": true,
-							"requires": {
-								"p-try": "^2.0.0"
-							}
-						},
-						"p-locate": {
-							"version": "3.0.0",
-							"bundled": true,
-							"requires": {
-								"p-limit": "^2.0.0"
-							}
-						},
-						"p-try": {
-							"version": "2.2.0",
-							"bundled": true
-						},
-						"string-width": {
-							"version": "3.1.0",
-							"bundled": true,
-							"requires": {
-								"emoji-regex": "^7.0.1",
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"bundled": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						}
-					}
-				},
-				"yargs-parser": {
-					"version": "15.0.1",
-					"bundled": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					},
-					"dependencies": {
-						"camelcase": {
-							"version": "5.3.1",
-							"bundled": true
-						}
-					}
-				}
-			}
-		},
 		"npm-run-path": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3799,11 +860,31 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
+		"number-to-bn": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+			"integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+			"requires": {
+				"bn.js": "4.11.6",
+				"strip-hex-prefix": "1.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -3861,6 +942,11 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
+		"parse-headers": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+			"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+		},
 		"parsimmon": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.13.0.tgz",
@@ -3891,6 +977,11 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
+		"process": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3899,6 +990,24 @@
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
+			}
+		},
+		"query-string": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+			"requires": {
+				"decode-uri-component": "^0.2.0",
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"require-directory": {
@@ -3921,6 +1030,11 @@
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"semver": {
 			"version": "6.3.0",
@@ -3955,11 +1069,31 @@
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
+		"simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+		},
+		"simple-get": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+			"requires": {
+				"decompress-response": "^3.3.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
+		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -3986,6 +1120,14 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
+		"strip-hex-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+			"requires": {
+				"is-hex-prefixed": "1.0.0"
+			}
+		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -3997,6 +1139,11 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 			"dev": true
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"tslib": {
 			"version": "1.11.1",
@@ -4072,12 +1219,56 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
+		"url-set-query": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+			"integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+		},
 		"utf-8-validate": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
 			"integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
 			"requires": {
 				"node-gyp-build": "~3.7.0"
+			}
+		},
+		"utf8": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+		},
+		"web3-core-helpers": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
+			"integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
+			"requires": {
+				"underscore": "1.9.1",
+				"web3-eth-iban": "1.2.11",
+				"web3-utils": "1.2.11"
+			}
+		},
+		"web3-eth-iban": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
+			"integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"web3-utils": "1.2.11"
+			}
+		},
+		"web3-utils": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+			"integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"eth-lib": "0.2.8",
+				"ethereum-bloom-filters": "^1.0.6",
+				"ethjs-unit": "0.1.6",
+				"number-to-bn": "1.7.0",
+				"randombytes": "^2.1.0",
+				"underscore": "1.9.1",
+				"utf8": "3.0.0"
 			}
 		},
 		"which": {
@@ -4145,8 +1336,45 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xhr": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+			"requires": {
+				"global": "~4.3.0",
+				"is-function": "^1.0.1",
+				"parse-headers": "^2.0.0",
+				"xtend": "^4.0.0"
+			}
+		},
+		"xhr-request": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+			"integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+			"requires": {
+				"buffer-to-arraybuffer": "^0.0.5",
+				"object-assign": "^4.1.1",
+				"query-string": "^5.0.1",
+				"simple-get": "^2.7.0",
+				"timed-out": "^4.0.1",
+				"url-set-query": "^1.0.0",
+				"xhr": "^2.0.4"
+			}
+		},
+		"xhr-request-promise": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+			"integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+			"requires": {
+				"xhr-request": "^1.1.0"
+			}
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -4,6 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@nomiclabs/websocket": {
+			"version": "1.0.31",
+			"resolved": "https://registry.npmjs.org/@nomiclabs/websocket/-/websocket-1.0.31.tgz",
+			"integrity": "sha512-Tiub0/Rsm9CMkHwjlSP5uM0lr6m6BV87rUM8Rxvpmcs+/Cq75jNB/YSk2B3tCPCoCQ5uzW7sNaDyhKG6EwdYZw==",
+			"requires": {
+				"bufferutil": "^4.0.1",
+				"debug": "^2.2.0",
+				"es5-ext": "^0.10.50",
+				"typedarray-to-buffer": "^3.1.5",
+				"utf-8-validate": "^5.0.2",
+				"yaeti": "^0.0.6"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -92,6 +105,14 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"bufferutil": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
+			"integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+			"requires": {
+				"node-gyp-build": "~3.7.0"
 			}
 		},
 		"builtin-modules": {
@@ -384,11 +405,6 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
-		"eventemitter3": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
-		},
 		"execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -502,6 +518,11 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
+		},
+		"i": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+			"integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -662,11 +683,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-		},
 		"next-tick": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -677,6 +693,3096 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"node-gyp-build": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+			"integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+		},
+		"npm": {
+			"version": "6.14.7",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
+			"integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
+			"requires": {
+				"JSONStream": "^1.3.5",
+				"abbrev": "~1.1.1",
+				"ansicolors": "~0.3.2",
+				"ansistyles": "~0.1.3",
+				"aproba": "^2.0.0",
+				"archy": "~1.0.0",
+				"bin-links": "^1.1.8",
+				"bluebird": "^3.5.5",
+				"byte-size": "^5.0.1",
+				"cacache": "^12.0.3",
+				"call-limit": "^1.1.1",
+				"chownr": "^1.1.4",
+				"ci-info": "^2.0.0",
+				"cli-columns": "^3.1.2",
+				"cli-table3": "^0.5.1",
+				"cmd-shim": "^3.0.3",
+				"columnify": "~1.5.4",
+				"config-chain": "^1.1.12",
+				"debuglog": "*",
+				"detect-indent": "~5.0.0",
+				"detect-newline": "^2.1.0",
+				"dezalgo": "~1.0.3",
+				"editor": "~1.0.0",
+				"figgy-pudding": "^3.5.1",
+				"find-npm-prefix": "^1.0.2",
+				"fs-vacuum": "~1.2.10",
+				"fs-write-stream-atomic": "~1.0.10",
+				"gentle-fs": "^2.3.1",
+				"glob": "^7.1.6",
+				"graceful-fs": "^4.2.4",
+				"has-unicode": "~2.0.1",
+				"hosted-git-info": "^2.8.8",
+				"iferr": "^1.0.2",
+				"imurmurhash": "*",
+				"infer-owner": "^1.0.4",
+				"inflight": "~1.0.6",
+				"inherits": "^2.0.4",
+				"ini": "^1.3.5",
+				"init-package-json": "^1.10.3",
+				"is-cidr": "^3.0.0",
+				"json-parse-better-errors": "^1.0.2",
+				"lazy-property": "~1.0.0",
+				"libcipm": "^4.0.8",
+				"libnpm": "^3.0.1",
+				"libnpmaccess": "^3.0.2",
+				"libnpmhook": "^5.0.3",
+				"libnpmorg": "^1.0.1",
+				"libnpmsearch": "^2.0.2",
+				"libnpmteam": "^1.0.2",
+				"libnpx": "^10.2.4",
+				"lock-verify": "^2.1.0",
+				"lockfile": "^1.0.4",
+				"lodash._baseindexof": "*",
+				"lodash._baseuniq": "~4.6.0",
+				"lodash._bindcallback": "*",
+				"lodash._cacheindexof": "*",
+				"lodash._createcache": "*",
+				"lodash._getnative": "*",
+				"lodash.clonedeep": "~4.5.0",
+				"lodash.restparam": "*",
+				"lodash.union": "~4.6.0",
+				"lodash.uniq": "~4.5.0",
+				"lodash.without": "~4.4.0",
+				"lru-cache": "^5.1.1",
+				"meant": "~1.0.1",
+				"mississippi": "^3.0.0",
+				"mkdirp": "^0.5.5",
+				"move-concurrently": "^1.0.1",
+				"node-gyp": "^5.1.0",
+				"nopt": "^4.0.3",
+				"normalize-package-data": "^2.5.0",
+				"npm-audit-report": "^1.3.3",
+				"npm-cache-filename": "~1.0.2",
+				"npm-install-checks": "^3.0.2",
+				"npm-lifecycle": "^3.1.5",
+				"npm-package-arg": "^6.1.1",
+				"npm-packlist": "^1.4.8",
+				"npm-pick-manifest": "^3.0.2",
+				"npm-profile": "^4.0.4",
+				"npm-registry-fetch": "^4.0.5",
+				"npm-user-validate": "~1.0.0",
+				"npmlog": "~4.1.2",
+				"once": "~1.4.0",
+				"opener": "^1.5.1",
+				"osenv": "^0.1.5",
+				"pacote": "^9.5.12",
+				"path-is-inside": "~1.0.2",
+				"promise-inflight": "~1.0.1",
+				"qrcode-terminal": "^0.12.0",
+				"query-string": "^6.8.2",
+				"qw": "~1.0.1",
+				"read": "~1.0.7",
+				"read-cmd-shim": "^1.0.5",
+				"read-installed": "~4.0.3",
+				"read-package-json": "^2.1.1",
+				"read-package-tree": "^5.3.1",
+				"readable-stream": "^3.6.0",
+				"readdir-scoped-modules": "^1.1.0",
+				"request": "^2.88.0",
+				"retry": "^0.12.0",
+				"rimraf": "^2.7.1",
+				"safe-buffer": "^5.1.2",
+				"semver": "^5.7.1",
+				"sha": "^3.0.0",
+				"slide": "~1.1.6",
+				"sorted-object": "~2.0.1",
+				"sorted-union-stream": "~2.1.3",
+				"ssri": "^6.0.1",
+				"stringify-package": "^1.0.1",
+				"tar": "^4.4.13",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
+				"uid-number": "0.0.6",
+				"umask": "~1.1.0",
+				"unique-filename": "^1.1.1",
+				"unpipe": "~1.0.0",
+				"update-notifier": "^2.5.0",
+				"uuid": "^3.3.3",
+				"validate-npm-package-license": "^3.0.4",
+				"validate-npm-package-name": "~3.0.0",
+				"which": "^1.3.1",
+				"worker-farm": "^1.7.0",
+				"write-file-atomic": "^2.4.3"
+			},
+			"dependencies": {
+				"JSONStream": {
+					"version": "1.3.5",
+					"bundled": true,
+					"requires": {
+						"jsonparse": "^1.2.0",
+						"through": ">=2.2.7 <3"
+					}
+				},
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"agent-base": {
+					"version": "4.3.0",
+					"bundled": true,
+					"requires": {
+						"es6-promisify": "^5.0.0"
+					}
+				},
+				"agentkeepalive": {
+					"version": "3.5.2",
+					"bundled": true,
+					"requires": {
+						"humanize-ms": "^1.2.1"
+					}
+				},
+				"ajv": {
+					"version": "5.5.2",
+					"bundled": true,
+					"requires": {
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
+					}
+				},
+				"ansi-align": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "^2.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"bundled": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"ansicolors": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"ansistyles": {
+					"version": "0.1.3",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"requires": {
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"asap": {
+					"version": "2.0.6",
+					"bundled": true
+				},
+				"asn1": {
+					"version": "0.2.4",
+					"bundled": true,
+					"requires": {
+						"safer-buffer": "~2.1.0"
+					}
+				},
+				"assert-plus": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true
+				},
+				"aws-sign2": {
+					"version": "0.7.0",
+					"bundled": true
+				},
+				"aws4": {
+					"version": "1.8.0",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "^0.14.3"
+					}
+				},
+				"bin-links": {
+					"version": "1.1.8",
+					"bundled": true,
+					"requires": {
+						"bluebird": "^3.5.3",
+						"cmd-shim": "^3.0.0",
+						"gentle-fs": "^2.3.0",
+						"graceful-fs": "^4.1.15",
+						"npm-normalize-package-bin": "^1.0.0",
+						"write-file-atomic": "^2.3.0"
+					}
+				},
+				"bluebird": {
+					"version": "3.5.5",
+					"bundled": true
+				},
+				"boxen": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"ansi-align": "^2.0.0",
+						"camelcase": "^4.0.0",
+						"chalk": "^2.0.1",
+						"cli-boxes": "^1.0.0",
+						"string-width": "^2.0.0",
+						"term-size": "^1.2.0",
+						"widest-line": "^2.0.0"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-from": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"builtins": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"byline": {
+					"version": "5.0.0",
+					"bundled": true
+				},
+				"byte-size": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"cacache": {
+					"version": "12.0.3",
+					"bundled": true,
+					"requires": {
+						"bluebird": "^3.5.5",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.1.15",
+						"infer-owner": "^1.0.3",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.3",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
+						"y18n": "^4.0.0"
+					}
+				},
+				"call-limit": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"camelcase": {
+					"version": "4.1.0",
+					"bundled": true
+				},
+				"capture-stack-trace": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"chownr": {
+					"version": "1.1.4",
+					"bundled": true
+				},
+				"ci-info": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"cidr-regex": {
+					"version": "2.0.10",
+					"bundled": true,
+					"requires": {
+						"ip-regex": "^2.1.0"
+					}
+				},
+				"cli-boxes": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"cli-columns": {
+					"version": "3.1.2",
+					"bundled": true,
+					"requires": {
+						"string-width": "^2.0.0",
+						"strip-ansi": "^3.0.1"
+					}
+				},
+				"cli-table3": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"colors": "^1.1.2",
+						"object-assign": "^4.1.0",
+						"string-width": "^2.1.1"
+					}
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"clone": {
+					"version": "1.0.4",
+					"bundled": true
+				},
+				"cmd-shim": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"mkdirp": "~0.5.0"
+					}
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"color-convert": {
+					"version": "1.9.1",
+					"bundled": true,
+					"requires": {
+						"color-name": "^1.1.1"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"bundled": true
+				},
+				"colors": {
+					"version": "1.3.3",
+					"bundled": true,
+					"optional": true
+				},
+				"columnify": {
+					"version": "1.5.4",
+					"bundled": true,
+					"requires": {
+						"strip-ansi": "^3.0.0",
+						"wcwidth": "^1.0.0"
+					}
+				},
+				"combined-stream": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "~1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"concat-stream": {
+					"version": "1.6.2",
+					"bundled": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.2.2",
+						"typedarray": "^0.0.6"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"config-chain": {
+					"version": "1.1.12",
+					"bundled": true,
+					"requires": {
+						"ini": "^1.3.4",
+						"proto-list": "~1.2.1"
+					}
+				},
+				"configstore": {
+					"version": "3.1.2",
+					"bundled": true,
+					"requires": {
+						"dot-prop": "^4.1.0",
+						"graceful-fs": "^4.1.2",
+						"make-dir": "^1.0.0",
+						"unique-string": "^1.0.0",
+						"write-file-atomic": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"copy-concurrently": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"aproba": "^1.1.1",
+						"fs-write-stream-atomic": "^1.0.8",
+						"iferr": "^0.1.5",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.0"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true
+						},
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true
+						}
+					}
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"create-error-class": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"capture-stack-trace": "^1.0.0"
+					}
+				},
+				"cross-spawn": {
+					"version": "5.1.0",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "4.1.5",
+							"bundled": true,
+							"requires": {
+								"pseudomap": "^1.0.2",
+								"yallist": "^2.1.2"
+							}
+						},
+						"yallist": {
+							"version": "2.1.2",
+							"bundled": true
+						}
+					}
+				},
+				"crypto-random-string": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"cyclist": {
+					"version": "0.2.2",
+					"bundled": true
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"ms": "2.0.0"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"debuglog": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"decode-uri-component": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"deep-extend": {
+					"version": "0.6.0",
+					"bundled": true
+				},
+				"defaults": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"clone": "^1.0.2"
+					}
+				},
+				"define-properties": {
+					"version": "1.1.3",
+					"bundled": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"detect-indent": {
+					"version": "5.0.0",
+					"bundled": true
+				},
+				"detect-newline": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"dezalgo": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"asap": "^2.0.0",
+						"wrappy": "1"
+					}
+				},
+				"dot-prop": {
+					"version": "4.2.0",
+					"bundled": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"dotenv": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"duplexer3": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"duplexify": {
+					"version": "3.6.0",
+					"bundled": true,
+					"requires": {
+						"end-of-stream": "^1.0.0",
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0",
+						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"ecc-jsbn": {
+					"version": "0.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "~0.1.0",
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"editor": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"bundled": true
+				},
+				"encoding": {
+					"version": "0.1.12",
+					"bundled": true,
+					"requires": {
+						"iconv-lite": "~0.4.13"
+					}
+				},
+				"end-of-stream": {
+					"version": "1.4.1",
+					"bundled": true,
+					"requires": {
+						"once": "^1.4.0"
+					}
+				},
+				"env-paths": {
+					"version": "2.2.0",
+					"bundled": true
+				},
+				"err-code": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"errno": {
+					"version": "0.1.7",
+					"bundled": true,
+					"requires": {
+						"prr": "~1.0.1"
+					}
+				},
+				"es-abstract": {
+					"version": "1.12.0",
+					"bundled": true,
+					"requires": {
+						"es-to-primitive": "^1.1.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.1",
+						"is-callable": "^1.1.3",
+						"is-regex": "^1.0.4"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"es6-promise": {
+					"version": "4.2.8",
+					"bundled": true
+				},
+				"es6-promisify": {
+					"version": "5.0.0",
+					"bundled": true,
+					"requires": {
+						"es6-promise": "^4.0.3"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"bundled": true
+				},
+				"execa": {
+					"version": "0.7.0",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"extend": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"extsprintf": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"fast-deep-equal": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"figgy-pudding": {
+					"version": "3.5.1",
+					"bundled": true
+				},
+				"find-npm-prefix": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"flush-write-stream": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.4"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true
+				},
+				"form-data": {
+					"version": "2.3.2",
+					"bundled": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				},
+				"from2": {
+					"version": "2.3.0",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.1",
+						"readable-stream": "^2.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"fs-minipass": {
+					"version": "1.2.7",
+					"bundled": true,
+					"requires": {
+						"minipass": "^2.6.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
+					}
+				},
+				"fs-vacuum": {
+					"version": "1.2.10",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"path-is-inside": "^1.0.1",
+						"rimraf": "^2.5.2"
+					}
+				},
+				"fs-write-stream-atomic": {
+					"version": "1.0.10",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"iferr": "^0.1.5",
+						"imurmurhash": "^0.1.4",
+						"readable-stream": "1 || 2"
+					},
+					"dependencies": {
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"function-bind": {
+					"version": "1.1.1",
+					"bundled": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"requires": {
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"genfun": {
+					"version": "5.0.0",
+					"bundled": true
+				},
+				"gentle-fs": {
+					"version": "2.3.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "^1.1.2",
+						"chownr": "^1.1.2",
+						"cmd-shim": "^3.0.3",
+						"fs-vacuum": "^1.2.10",
+						"graceful-fs": "^4.1.11",
+						"iferr": "^0.1.5",
+						"infer-owner": "^1.0.4",
+						"mkdirp": "^0.5.1",
+						"path-is-inside": "^1.0.2",
+						"read-cmd-shim": "^1.0.1",
+						"slide": "^1.1.6"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true
+						},
+						"iferr": {
+							"version": "0.1.5",
+							"bundled": true
+						}
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"bundled": true
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"bundled": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.6",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"global-dirs": {
+					"version": "0.1.1",
+					"bundled": true,
+					"requires": {
+						"ini": "^1.3.4"
+					}
+				},
+				"got": {
+					"version": "6.7.1",
+					"bundled": true,
+					"requires": {
+						"create-error-class": "^3.0.0",
+						"duplexer3": "^0.1.4",
+						"get-stream": "^3.0.0",
+						"is-redirect": "^1.0.0",
+						"is-retry-allowed": "^1.0.0",
+						"is-stream": "^1.0.0",
+						"lowercase-keys": "^1.0.0",
+						"safe-buffer": "^5.0.1",
+						"timed-out": "^4.0.0",
+						"unzip-response": "^2.0.1",
+						"url-parse-lax": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.4",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"har-validator": {
+					"version": "5.1.0",
+					"bundled": true,
+					"requires": {
+						"ajv": "^5.3.0",
+						"har-schema": "^2.0.0"
+					}
+				},
+				"has": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"function-bind": "^1.1.1"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"has-symbols": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"hosted-git-info": {
+					"version": "2.8.8",
+					"bundled": true
+				},
+				"http-cache-semantics": {
+					"version": "3.8.1",
+					"bundled": true
+				},
+				"http-proxy-agent": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"agent-base": "4",
+						"debug": "3.1.0"
+					}
+				},
+				"http-signature": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.7.0"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "2.2.4",
+					"bundled": true,
+					"requires": {
+						"agent-base": "^4.3.0",
+						"debug": "^3.1.0"
+					}
+				},
+				"humanize-ms": {
+					"version": "1.2.1",
+					"bundled": true,
+					"requires": {
+						"ms": "^2.0.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.4.23",
+					"bundled": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"iferr": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"ignore-walk": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"minimatch": "^3.0.4"
+					}
+				},
+				"import-lazy": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"infer-owner": {
+					"version": "1.0.4",
+					"bundled": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true
+				},
+				"init-package-json": {
+					"version": "1.10.3",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.1.1",
+						"npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+						"promzard": "^0.3.0",
+						"read": "~1.0.1",
+						"read-package-json": "1 || 2",
+						"semver": "2.x || 3.x || 4 || 5",
+						"validate-npm-package-license": "^3.0.1",
+						"validate-npm-package-name": "^3.0.0"
+					}
+				},
+				"ip": {
+					"version": "1.1.5",
+					"bundled": true
+				},
+				"ip-regex": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"is-callable": {
+					"version": "1.1.4",
+					"bundled": true
+				},
+				"is-ci": {
+					"version": "1.2.1",
+					"bundled": true,
+					"requires": {
+						"ci-info": "^1.5.0"
+					},
+					"dependencies": {
+						"ci-info": {
+							"version": "1.6.0",
+							"bundled": true
+						}
+					}
+				},
+				"is-cidr": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"cidr-regex": "^2.0.10"
+					}
+				},
+				"is-date-object": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"is-installed-globally": {
+					"version": "0.1.0",
+					"bundled": true,
+					"requires": {
+						"global-dirs": "^0.1.0",
+						"is-path-inside": "^1.0.0"
+					}
+				},
+				"is-npm": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-obj": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"is-path-inside": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"path-is-inside": "^1.0.1"
+					}
+				},
+				"is-redirect": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"is-regex": {
+					"version": "1.0.4",
+					"bundled": true,
+					"requires": {
+						"has": "^1.0.1"
+					}
+				},
+				"is-retry-allowed": {
+					"version": "1.2.0",
+					"bundled": true
+				},
+				"is-stream": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"is-symbol": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"has-symbols": "^1.0.0"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"json-parse-better-errors": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true
+				},
+				"json-schema-traverse": {
+					"version": "0.3.1",
+					"bundled": true
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"jsonparse": {
+					"version": "1.3.1",
+					"bundled": true
+				},
+				"jsprim": {
+					"version": "1.4.1",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.2.3",
+						"verror": "1.10.0"
+					}
+				},
+				"latest-version": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"package-json": "^4.0.0"
+					}
+				},
+				"lazy-property": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"libcipm": {
+					"version": "4.0.8",
+					"bundled": true,
+					"requires": {
+						"bin-links": "^1.1.2",
+						"bluebird": "^3.5.1",
+						"figgy-pudding": "^3.5.1",
+						"find-npm-prefix": "^1.0.2",
+						"graceful-fs": "^4.1.11",
+						"ini": "^1.3.5",
+						"lock-verify": "^2.1.0",
+						"mkdirp": "^0.5.1",
+						"npm-lifecycle": "^3.0.0",
+						"npm-logical-tree": "^1.2.1",
+						"npm-package-arg": "^6.1.0",
+						"pacote": "^9.1.0",
+						"read-package-json": "^2.0.13",
+						"rimraf": "^2.6.2",
+						"worker-farm": "^1.6.0"
+					}
+				},
+				"libnpm": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"bin-links": "^1.1.2",
+						"bluebird": "^3.5.3",
+						"find-npm-prefix": "^1.0.2",
+						"libnpmaccess": "^3.0.2",
+						"libnpmconfig": "^1.2.1",
+						"libnpmhook": "^5.0.3",
+						"libnpmorg": "^1.0.1",
+						"libnpmpublish": "^1.1.2",
+						"libnpmsearch": "^2.0.2",
+						"libnpmteam": "^1.0.2",
+						"lock-verify": "^2.0.2",
+						"npm-lifecycle": "^3.0.0",
+						"npm-logical-tree": "^1.2.1",
+						"npm-package-arg": "^6.1.0",
+						"npm-profile": "^4.0.2",
+						"npm-registry-fetch": "^4.0.0",
+						"npmlog": "^4.1.2",
+						"pacote": "^9.5.3",
+						"read-package-json": "^2.0.13",
+						"stringify-package": "^1.0.0"
+					}
+				},
+				"libnpmaccess": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"get-stream": "^4.0.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmconfig": {
+					"version": "1.2.1",
+					"bundled": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"find-up": "^3.0.0",
+						"ini": "^1.3.5"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "2.2.0",
+							"bundled": true,
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"p-try": {
+							"version": "2.2.0",
+							"bundled": true
+						}
+					}
+				},
+				"libnpmhook": {
+					"version": "5.0.3",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmorg": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmpublish": {
+					"version": "1.1.2",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"lodash.clonedeep": "^4.5.0",
+						"normalize-package-data": "^2.4.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^4.0.0",
+						"semver": "^5.5.1",
+						"ssri": "^6.0.1"
+					}
+				},
+				"libnpmsearch": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpmteam": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"libnpx": {
+					"version": "10.2.4",
+					"bundled": true,
+					"requires": {
+						"dotenv": "^5.0.1",
+						"npm-package-arg": "^6.0.0",
+						"rimraf": "^2.6.2",
+						"safe-buffer": "^5.1.0",
+						"update-notifier": "^2.3.0",
+						"which": "^1.3.0",
+						"y18n": "^4.0.0",
+						"yargs": "^14.2.3"
+					}
+				},
+				"lock-verify": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"npm-package-arg": "^6.1.0",
+						"semver": "^5.4.1"
+					}
+				},
+				"lockfile": {
+					"version": "1.0.4",
+					"bundled": true,
+					"requires": {
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"lodash._baseindexof": {
+					"version": "3.1.0",
+					"bundled": true
+				},
+				"lodash._baseuniq": {
+					"version": "4.6.0",
+					"bundled": true,
+					"requires": {
+						"lodash._createset": "~4.0.0",
+						"lodash._root": "~3.0.0"
+					}
+				},
+				"lodash._bindcallback": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"lodash._cacheindexof": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"lodash._createcache": {
+					"version": "3.1.2",
+					"bundled": true,
+					"requires": {
+						"lodash._getnative": "^3.0.0"
+					}
+				},
+				"lodash._createset": {
+					"version": "4.0.3",
+					"bundled": true
+				},
+				"lodash._getnative": {
+					"version": "3.9.1",
+					"bundled": true
+				},
+				"lodash._root": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"lodash.clonedeep": {
+					"version": "4.5.0",
+					"bundled": true
+				},
+				"lodash.restparam": {
+					"version": "3.6.1",
+					"bundled": true
+				},
+				"lodash.union": {
+					"version": "4.6.0",
+					"bundled": true
+				},
+				"lodash.uniq": {
+					"version": "4.5.0",
+					"bundled": true
+				},
+				"lodash.without": {
+					"version": "4.4.0",
+					"bundled": true
+				},
+				"lowercase-keys": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"bundled": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"make-dir": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"pify": "^3.0.0"
+					}
+				},
+				"make-fetch-happen": {
+					"version": "5.0.2",
+					"bundled": true,
+					"requires": {
+						"agentkeepalive": "^3.4.1",
+						"cacache": "^12.0.0",
+						"http-cache-semantics": "^3.8.1",
+						"http-proxy-agent": "^2.1.0",
+						"https-proxy-agent": "^2.2.3",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
+						"node-fetch-npm": "^2.0.2",
+						"promise-retry": "^1.1.1",
+						"socks-proxy-agent": "^4.0.0",
+						"ssri": "^6.0.0"
+					}
+				},
+				"meant": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"mime-db": {
+					"version": "1.35.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.19",
+					"bundled": true,
+					"requires": {
+						"mime-db": "~1.35.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minizlib": {
+					"version": "1.3.3",
+					"bundled": true,
+					"requires": {
+						"minipass": "^2.9.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
+					}
+				},
+				"mississippi": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"concat-stream": "^1.5.0",
+						"duplexify": "^3.4.2",
+						"end-of-stream": "^1.1.0",
+						"flush-write-stream": "^1.0.0",
+						"from2": "^2.1.0",
+						"parallel-transform": "^1.1.0",
+						"pump": "^3.0.0",
+						"pumpify": "^1.3.3",
+						"stream-each": "^1.1.0",
+						"through2": "^2.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.5",
+					"bundled": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.5",
+							"bundled": true
+						}
+					}
+				},
+				"move-concurrently": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"aproba": "^1.1.1",
+						"copy-concurrently": "^1.0.0",
+						"fs-write-stream-atomic": "^1.0.8",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.5.4",
+						"run-queue": "^1.0.3"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true
+						}
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"bundled": true
+				},
+				"node-fetch-npm": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"encoding": "^0.1.11",
+						"json-parse-better-errors": "^1.0.0",
+						"safe-buffer": "^5.1.1"
+					}
+				},
+				"node-gyp": {
+					"version": "5.1.0",
+					"bundled": true,
+					"requires": {
+						"env-paths": "^2.2.0",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.2.2",
+						"mkdirp": "^0.5.1",
+						"nopt": "^4.0.1",
+						"npmlog": "^4.1.2",
+						"request": "^2.88.0",
+						"rimraf": "^2.6.3",
+						"semver": "^5.7.1",
+						"tar": "^4.4.12",
+						"which": "^1.3.1"
+					}
+				},
+				"nopt": {
+					"version": "4.0.3",
+					"bundled": true,
+					"requires": {
+						"abbrev": "1",
+						"osenv": "^0.1.4"
+					}
+				},
+				"normalize-package-data": {
+					"version": "2.5.0",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^2.1.4",
+						"resolve": "^1.10.0",
+						"semver": "2 || 3 || 4 || 5",
+						"validate-npm-package-license": "^3.0.1"
+					},
+					"dependencies": {
+						"resolve": {
+							"version": "1.10.0",
+							"bundled": true,
+							"requires": {
+								"path-parse": "^1.0.6"
+							}
+						}
+					}
+				},
+				"npm-audit-report": {
+					"version": "1.3.3",
+					"bundled": true,
+					"requires": {
+						"cli-table3": "^0.5.0",
+						"console-control-strings": "^1.1.0"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.1.1",
+					"bundled": true,
+					"requires": {
+						"npm-normalize-package-bin": "^1.0.1"
+					}
+				},
+				"npm-cache-filename": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"npm-install-checks": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"semver": "^2.3.0 || 3.x || 4 || 5"
+					}
+				},
+				"npm-lifecycle": {
+					"version": "3.1.5",
+					"bundled": true,
+					"requires": {
+						"byline": "^5.0.0",
+						"graceful-fs": "^4.1.15",
+						"node-gyp": "^5.0.2",
+						"resolve-from": "^4.0.0",
+						"slide": "^1.1.6",
+						"uid-number": "0.0.6",
+						"umask": "^1.1.0",
+						"which": "^1.3.1"
+					}
+				},
+				"npm-logical-tree": {
+					"version": "1.2.1",
+					"bundled": true
+				},
+				"npm-normalize-package-bin": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"npm-package-arg": {
+					"version": "6.1.1",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^2.7.1",
+						"osenv": "^0.1.5",
+						"semver": "^5.6.0",
+						"validate-npm-package-name": "^3.0.0"
+					}
+				},
+				"npm-packlist": {
+					"version": "1.4.8",
+					"bundled": true,
+					"requires": {
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1",
+						"npm-normalize-package-bin": "^1.0.1"
+					}
+				},
+				"npm-pick-manifest": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"npm-package-arg": "^6.0.0",
+						"semver": "^5.4.1"
+					}
+				},
+				"npm-profile": {
+					"version": "4.0.4",
+					"bundled": true,
+					"requires": {
+						"aproba": "^1.1.2 || 2",
+						"figgy-pudding": "^3.4.1",
+						"npm-registry-fetch": "^4.0.0"
+					}
+				},
+				"npm-registry-fetch": {
+					"version": "4.0.5",
+					"bundled": true,
+					"requires": {
+						"JSONStream": "^1.3.4",
+						"bluebird": "^3.5.1",
+						"figgy-pudding": "^3.4.1",
+						"lru-cache": "^5.1.1",
+						"make-fetch-happen": "^5.0.0",
+						"npm-package-arg": "^6.1.0",
+						"safe-buffer": "^5.2.0"
+					},
+					"dependencies": {
+						"safe-buffer": {
+							"version": "5.2.1",
+							"bundled": true
+						}
+					}
+				},
+				"npm-run-path": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"path-key": "^2.0.0"
+					}
+				},
+				"npm-user-validate": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"oauth-sign": {
+					"version": "0.9.0",
+					"bundled": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"object-keys": {
+					"version": "1.0.12",
+					"bundled": true
+				},
+				"object.getownpropertydescriptors": {
+					"version": "2.0.3",
+					"bundled": true,
+					"requires": {
+						"define-properties": "^1.1.2",
+						"es-abstract": "^1.5.1"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"opener": {
+					"version": "1.5.1",
+					"bundled": true
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"requires": {
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
+					}
+				},
+				"p-finally": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"package-json": {
+					"version": "4.0.1",
+					"bundled": true,
+					"requires": {
+						"got": "^6.7.1",
+						"registry-auth-token": "^3.0.1",
+						"registry-url": "^3.0.3",
+						"semver": "^5.1.0"
+					}
+				},
+				"pacote": {
+					"version": "9.5.12",
+					"bundled": true,
+					"requires": {
+						"bluebird": "^3.5.3",
+						"cacache": "^12.0.2",
+						"chownr": "^1.1.2",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.1.0",
+						"glob": "^7.1.3",
+						"infer-owner": "^1.0.4",
+						"lru-cache": "^5.1.1",
+						"make-fetch-happen": "^5.0.0",
+						"minimatch": "^3.0.4",
+						"minipass": "^2.3.5",
+						"mississippi": "^3.0.0",
+						"mkdirp": "^0.5.1",
+						"normalize-package-data": "^2.4.0",
+						"npm-normalize-package-bin": "^1.0.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-packlist": "^1.1.12",
+						"npm-pick-manifest": "^3.0.0",
+						"npm-registry-fetch": "^4.0.0",
+						"osenv": "^0.1.5",
+						"promise-inflight": "^1.0.1",
+						"promise-retry": "^1.1.1",
+						"protoduck": "^5.0.1",
+						"rimraf": "^2.6.2",
+						"safe-buffer": "^5.1.2",
+						"semver": "^5.6.0",
+						"ssri": "^6.0.1",
+						"tar": "^4.4.10",
+						"unique-filename": "^1.1.1",
+						"which": "^1.3.1"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
+					}
+				},
+				"parallel-transform": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"cyclist": "~0.2.2",
+						"inherits": "^2.0.3",
+						"readable-stream": "^2.1.5"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"path-is-inside": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"path-key": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
+					"bundled": true
+				},
+				"performance-now": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"pify": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"prepend-http": {
+					"version": "1.0.4",
+					"bundled": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"promise-inflight": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"promise-retry": {
+					"version": "1.1.1",
+					"bundled": true,
+					"requires": {
+						"err-code": "^1.0.0",
+						"retry": "^0.10.0"
+					},
+					"dependencies": {
+						"retry": {
+							"version": "0.10.1",
+							"bundled": true
+						}
+					}
+				},
+				"promzard": {
+					"version": "0.3.0",
+					"bundled": true,
+					"requires": {
+						"read": "1"
+					}
+				},
+				"proto-list": {
+					"version": "1.2.4",
+					"bundled": true
+				},
+				"protoduck": {
+					"version": "5.0.1",
+					"bundled": true,
+					"requires": {
+						"genfun": "^5.0.0"
+					}
+				},
+				"prr": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"pseudomap": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"psl": {
+					"version": "1.1.29",
+					"bundled": true
+				},
+				"pump": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"pumpify": {
+					"version": "1.5.1",
+					"bundled": true,
+					"requires": {
+						"duplexify": "^3.6.0",
+						"inherits": "^2.0.3",
+						"pump": "^2.0.0"
+					},
+					"dependencies": {
+						"pump": {
+							"version": "2.0.1",
+							"bundled": true,
+							"requires": {
+								"end-of-stream": "^1.1.0",
+								"once": "^1.3.1"
+							}
+						}
+					}
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true
+				},
+				"qrcode-terminal": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"qs": {
+					"version": "6.5.2",
+					"bundled": true
+				},
+				"query-string": {
+					"version": "6.8.2",
+					"bundled": true,
+					"requires": {
+						"decode-uri-component": "^0.2.0",
+						"split-on-first": "^1.0.0",
+						"strict-uri-encode": "^2.0.0"
+					}
+				},
+				"qw": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"rc": {
+					"version": "1.2.8",
+					"bundled": true,
+					"requires": {
+						"deep-extend": "^0.6.0",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.5",
+							"bundled": true
+						}
+					}
+				},
+				"read": {
+					"version": "1.0.7",
+					"bundled": true,
+					"requires": {
+						"mute-stream": "~0.0.4"
+					}
+				},
+				"read-cmd-shim": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2"
+					}
+				},
+				"read-installed": {
+					"version": "4.0.3",
+					"bundled": true,
+					"requires": {
+						"debuglog": "^1.0.1",
+						"graceful-fs": "^4.1.2",
+						"read-package-json": "^2.0.0",
+						"readdir-scoped-modules": "^1.0.0",
+						"semver": "2 || 3 || 4 || 5",
+						"slide": "~1.1.3",
+						"util-extend": "^1.0.1"
+					}
+				},
+				"read-package-json": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.1.1",
+						"graceful-fs": "^4.1.2",
+						"json-parse-better-errors": "^1.0.1",
+						"normalize-package-data": "^2.0.0",
+						"npm-normalize-package-bin": "^1.0.0"
+					}
+				},
+				"read-package-tree": {
+					"version": "5.3.1",
+					"bundled": true,
+					"requires": {
+						"read-package-json": "^2.0.0",
+						"readdir-scoped-modules": "^1.0.0",
+						"util-promisify": "^2.1.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"bundled": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"readdir-scoped-modules": {
+					"version": "1.1.0",
+					"bundled": true,
+					"requires": {
+						"debuglog": "^1.0.1",
+						"dezalgo": "^1.0.0",
+						"graceful-fs": "^4.1.2",
+						"once": "^1.3.0"
+					}
+				},
+				"registry-auth-token": {
+					"version": "3.4.0",
+					"bundled": true,
+					"requires": {
+						"rc": "^1.1.6",
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"registry-url": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"rc": "^1.0.1"
+					}
+				},
+				"request": {
+					"version": "2.88.0",
+					"bundled": true,
+					"requires": {
+						"aws-sign2": "~0.7.0",
+						"aws4": "^1.8.0",
+						"caseless": "~0.12.0",
+						"combined-stream": "~1.0.6",
+						"extend": "~3.0.2",
+						"forever-agent": "~0.6.1",
+						"form-data": "~2.3.2",
+						"har-validator": "~5.1.0",
+						"http-signature": "~1.2.0",
+						"is-typedarray": "~1.0.0",
+						"isstream": "~0.1.2",
+						"json-stringify-safe": "~5.0.1",
+						"mime-types": "~2.1.19",
+						"oauth-sign": "~0.9.0",
+						"performance-now": "^2.1.0",
+						"qs": "~6.5.2",
+						"safe-buffer": "^5.1.2",
+						"tough-cookie": "~2.4.3",
+						"tunnel-agent": "^0.6.0",
+						"uuid": "^3.3.2"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"retry": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"bundled": true,
+					"requires": {
+						"glob": "^7.1.3"
+					}
+				},
+				"run-queue": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"aproba": "^1.1.1"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true
+						}
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"bundled": true
+				},
+				"semver-diff": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"semver": "^5.0.3"
+					}
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"sha": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.2"
+					}
+				},
+				"shebang-command": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "^1.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"slide": {
+					"version": "1.1.6",
+					"bundled": true
+				},
+				"smart-buffer": {
+					"version": "4.1.0",
+					"bundled": true
+				},
+				"socks": {
+					"version": "2.3.3",
+					"bundled": true,
+					"requires": {
+						"ip": "1.1.5",
+						"smart-buffer": "^4.1.0"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "4.0.2",
+					"bundled": true,
+					"requires": {
+						"agent-base": "~4.2.1",
+						"socks": "~2.3.2"
+					},
+					"dependencies": {
+						"agent-base": {
+							"version": "4.2.1",
+							"bundled": true,
+							"requires": {
+								"es6-promisify": "^5.0.0"
+							}
+						}
+					}
+				},
+				"sorted-object": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"sorted-union-stream": {
+					"version": "2.1.3",
+					"bundled": true,
+					"requires": {
+						"from2": "^1.3.0",
+						"stream-iterate": "^1.1.0"
+					},
+					"dependencies": {
+						"from2": {
+							"version": "1.3.0",
+							"bundled": true,
+							"requires": {
+								"inherits": "~2.0.1",
+								"readable-stream": "~1.1.10"
+							}
+						},
+						"isarray": {
+							"version": "0.0.1",
+							"bundled": true
+						},
+						"readable-stream": {
+							"version": "1.1.14",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.1",
+								"isarray": "0.0.1",
+								"string_decoder": "~0.10.x"
+							}
+						},
+						"string_decoder": {
+							"version": "0.10.31",
+							"bundled": true
+						}
+					}
+				},
+				"spdx-correct": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.1.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.5",
+					"bundled": true
+				},
+				"split-on-first": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"sshpk": {
+					"version": "1.14.2",
+					"bundled": true,
+					"requires": {
+						"asn1": "~0.2.3",
+						"assert-plus": "^1.0.0",
+						"bcrypt-pbkdf": "^1.0.0",
+						"dashdash": "^1.12.0",
+						"ecc-jsbn": "~0.1.1",
+						"getpass": "^0.1.1",
+						"jsbn": "~0.1.0",
+						"safer-buffer": "^2.0.2",
+						"tweetnacl": "~0.14.0"
+					}
+				},
+				"ssri": {
+					"version": "6.0.1",
+					"bundled": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1"
+					}
+				},
+				"stream-each": {
+					"version": "1.2.2",
+					"bundled": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"stream-shift": "^1.0.0"
+					}
+				},
+				"stream-iterate": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"readable-stream": "^2.1.5",
+						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"stream-shift": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"strict-uri-encode": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"bundled": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "3.0.0",
+							"bundled": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"strip-ansi": {
+							"version": "4.0.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^3.0.0"
+							}
+						}
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					},
+					"dependencies": {
+						"safe-buffer": {
+							"version": "5.2.0",
+							"bundled": true
+						}
+					}
+				},
+				"stringify-package": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-eof": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"bundled": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"tar": {
+					"version": "4.4.13",
+					"bundled": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.3"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						}
+					}
+				},
+				"term-size": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"execa": "^0.7.0"
+					}
+				},
+				"text-table": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"through": {
+					"version": "2.3.8",
+					"bundled": true
+				},
+				"through2": {
+					"version": "2.0.3",
+					"bundled": true,
+					"requires": {
+						"readable-stream": "^2.1.5",
+						"xtend": "~4.0.1"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
+					}
+				},
+				"timed-out": {
+					"version": "4.0.1",
+					"bundled": true
+				},
+				"tiny-relative-date": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"bundled": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "^5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"optional": true
+				},
+				"typedarray": {
+					"version": "0.0.6",
+					"bundled": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true
+				},
+				"umask": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"unique-filename": {
+					"version": "1.1.1",
+					"bundled": true,
+					"requires": {
+						"unique-slug": "^2.0.0"
+					}
+				},
+				"unique-slug": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"unique-string": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"crypto-random-string": "^1.0.0"
+					}
+				},
+				"unpipe": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"unzip-response": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"update-notifier": {
+					"version": "2.5.0",
+					"bundled": true,
+					"requires": {
+						"boxen": "^1.2.1",
+						"chalk": "^2.0.1",
+						"configstore": "^3.0.0",
+						"import-lazy": "^2.1.0",
+						"is-ci": "^1.0.10",
+						"is-installed-globally": "^0.1.0",
+						"is-npm": "^1.0.0",
+						"latest-version": "^3.0.0",
+						"semver-diff": "^2.0.0",
+						"xdg-basedir": "^3.0.0"
+					}
+				},
+				"url-parse-lax": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"prepend-http": "^1.0.1"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"util-extend": {
+					"version": "1.0.3",
+					"bundled": true
+				},
+				"util-promisify": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"object.getownpropertydescriptors": "^2.0.3"
+					}
+				},
+				"uuid": {
+					"version": "3.3.3",
+					"bundled": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					}
+				},
+				"validate-npm-package-name": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"builtins": "^1.0.3"
+					}
+				},
+				"verror": {
+					"version": "1.10.0",
+					"bundled": true,
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"core-util-is": "1.0.2",
+						"extsprintf": "^1.2.0"
+					}
+				},
+				"wcwidth": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"defaults": "^1.0.3"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"bundled": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"requires": {
+						"string-width": "^1.0.2"
+					},
+					"dependencies": {
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						}
+					}
+				},
+				"widest-line": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"string-width": "^2.1.1"
+					}
+				},
+				"worker-farm": {
+					"version": "1.7.0",
+					"bundled": true,
+					"requires": {
+						"errno": "~0.1.7"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"write-file-atomic": {
+					"version": "2.4.3",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"xdg-basedir": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"xtend": {
+					"version": "4.0.1",
+					"bundled": true
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"bundled": true
+				},
+				"yargs": {
+					"version": "14.2.3",
+					"bundled": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^15.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"bundled": true
+						},
+						"find-up": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "2.3.0",
+							"bundled": true,
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"bundled": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"p-try": {
+							"version": "2.2.0",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"bundled": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "15.0.1",
+					"bundled": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					},
+					"dependencies": {
+						"camelcase": {
+							"version": "5.3.1",
+							"bundled": true
+						}
+					}
+				}
+			}
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -966,16 +4072,12 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
-		"websocket": {
-			"version": "1.0.31",
-			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
-			"integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+		"utf-8-validate": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+			"integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
 			"requires": {
-				"debug": "^2.2.0",
-				"es5-ext": "^0.10.50",
-				"nan": "^2.14.0",
-				"typedarray-to-buffer": "^3.1.5",
-				"yaeti": "^0.0.6"
+				"node-gyp-build": "~3.7.0"
 			}
 		},
 		"which": {

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -14,10 +14,12 @@
   "types": "types/index.d.ts",
   "main": "lib/index.js",
   "dependencies": {
+    "@nomiclabs/websocket": "^1.0.31",
     "eventemitter3": "4.0.4",
+    "i": "^0.3.6",
+    "npm": "^6.14.7",
     "underscore": "1.9.1",
-    "web3-core-helpers": "1.2.11",
-    "websocket": "^1.0.31"
+    "web3-core-helpers": "1.2.11"
   },
   "devDependencies": {
     "dtslint": "^3.4.1",

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -14,10 +14,8 @@
   "types": "types/index.d.ts",
   "main": "lib/index.js",
   "dependencies": {
-    "@nomiclabs/websocket": "^1.0.31",
+    "@chainsafe/websocket": "^1.0.31",
     "eventemitter3": "4.0.4",
-    "i": "^0.3.6",
-    "npm": "^6.14.7",
     "underscore": "1.9.1",
     "web3-core-helpers": "1.2.11"
   },

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -25,7 +25,7 @@
 var EventEmitter = require('eventemitter3');
 var helpers = require('./helpers.js');
 var errors = require('web3-core-helpers').errors;
-var Ws = require('@nomiclabs/websocket').w3cwebsocket;
+var Ws = require('@chainsafe/websocket').w3cwebsocket;
 
 /**
  * @param {string} url

--- a/packages/web3-providers-ws/src/index.js
+++ b/packages/web3-providers-ws/src/index.js
@@ -25,7 +25,7 @@
 var EventEmitter = require('eventemitter3');
 var helpers = require('./helpers.js');
 var errors = require('web3-core-helpers').errors;
-var Ws = require('websocket').w3cwebsocket;
+var Ws = require('@nomiclabs/websocket').w3cwebsocket;
 
 /**
  * @param {string} url


### PR DESCRIPTION
## Description

Please include a summary of the changes and be sure to follow our [Contribution Guidelines](../CONTRIBUTIONS.md).

See #3685 for full details.

This PR switches the websocket library to a temporary fork that removes the need to compile with node-gyp :confetti_ball:. The temporary fork is being maintained by [Nomic Labs](https://nomiclabs.io/) as a part of a larger effort to eradicate `node-gyp` from ethereum. 

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->
Fixes #3685 

### Install stats (via github):
**This PR**: 106.935s
**Current master**: 146.577s
**Difference**: ~40s  :eyes: 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
