### PR TITLE
Pin geth docker version to v1.9.18

### DIFF
--- a/scripts/e2e.geth.automine.sh
+++ b/scripts/e2e.geth.automine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --period 2 --accounts 1 --tag 'stable'
+geth-dev-assistant --period 2 --accounts 1 --tag 'v1.9.18'
 
 # Test
 GETH_AUTOMINE=true nyc --no-clean --silent _mocha -- \

--- a/scripts/e2e.geth.instamine.sh
+++ b/scripts/e2e.geth.instamine.sh
@@ -24,7 +24,7 @@ echo " "
 # Launch client w/ two unlocked accounts.
 # + accounts[0] default geth unlocked bal = ~infinity
 # + accounts[1] unlocked, bal=50 eth, signing password = 'left-hand-of-darkness'
-geth-dev-assistant --accounts 1 --tag 'stable'
+geth-dev-assistant --accounts 1 --tag 'v1.9.18'
 
 # Test
 GETH_INSTAMINE=true nyc --no-clean --silent _mocha -- \


### PR DESCRIPTION
## Description

Currently ci is failing in trying to set up a geth instance for the e2e tests.

This PR tests pinning the geth version for geth-dev-assistant to 1.9.18 to see if the issue is something in the latest [1.9.19](https://github.com/ethereum/go-ethereum/releases/tag/v1.9.19) release.

```
E2E: geth insta-mining (requires docker) 
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
> Pulling ethereum/client-go:stable
> ⚠️  Launching ethereum/client-go:stable as a background process. ⚠️ 
> ⚠️  Run docker stop geth-client when you are finished testing.   ⚠️
> Waiting for geth to launch... (10 sec maximum).
> Timed out while waiting for geth to launch.
  + Use --sleep <sec> to increase the wait time.
  + Use --interactive to see any errors geth may be throwing.

geth-client
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! web3.js@ test:e2e:geth:insta: `./scripts/e2e.geth.instamine.sh`
npm ERR! Exit status 1
```

## Type of change=

- [x] ci fix