### PR TITLE
switch to wokring version of geth-dev-assistant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2276,6 +2276,18 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@chainsafe/geth-dev-assistant": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/@chainsafe/geth-dev-assistant/-/geth-dev-assistant-0.1.5.tgz",
+            "integrity": "sha512-9q5SuFSU+RAcxutg3Fs6Sz1BH120Lg2rWGJON29VVLmzyKzGJbTu9760OT9Gvv1x1pOiyZBduQ3C62SQpCTv+Q==",
+            "dev": true,
+            "requires": {
+                "colors": "^1.3.3",
+                "node-emoji": "^1.10.0",
+                "web3": "^1.2.9",
+                "yargs": "^13.2.2"
+            }
+        },
         "@ensdomains/ens": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.4.0.tgz",
@@ -2323,9 +2335,9 @@
             }
         },
         "@ethersproject/address": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.1.tgz",
-            "integrity": "sha512-kfQtXpBP2pI2TfoRRAYv8grHGiYw8U0c1KbMsC58/W33TIBy7gFSf/oAzOd94lNzdIUenKU0OuSzrHQfVcDDDA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.2.tgz",
+            "integrity": "sha512-+rz26RKj7ujGfQynys4V9VJRbR+wpC6eL8F22q3raWMH3152Ha31GwJPWzxE/bEA+43M/zTNVwY0R53gn53L2Q==",
             "dev": true,
             "requires": {
                 "@ethersproject/bignumber": "^5.0.0",
@@ -2337,39 +2349,38 @@
             }
         },
         "@ethersproject/bignumber": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.2.tgz",
-            "integrity": "sha512-fy27wYrrgXCHSG1Y8WMrcZQC8L28X2+yRHvSMr/dXAS0BDqIjcT+QdiVAynbIzShALklZdMkKHBe0qA45nLNEQ==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.5.tgz",
+            "integrity": "sha512-24ln7PV0g8ZzjcVZiLW9Wod0i+XCmK6zKkAaxw5enraTIT1p7gVOcSXFSzNQ9WYAwtiFQPvvA+TIO2oEITZNJA==",
             "dev": true,
             "requires": {
                 "@ethersproject/bytes": "^5.0.0",
                 "@ethersproject/logger": "^5.0.0",
-                "@ethersproject/properties": "^5.0.0",
                 "bn.js": "^4.4.0"
             }
         },
         "@ethersproject/bytes": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.1.tgz",
-            "integrity": "sha512-Y198536UW9Jb9RBXuqmCsCa9mYJUsxJn+5aGr2XjNMpLBc6vEn/44GHnbQXYgRCzh4rnWtJ9bTgSwDjme9Hgnw==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.3.tgz",
+            "integrity": "sha512-AyPMAlY+Amaw4Zfp8OAivm1xYPI8mqiUYmEnSUk1CnS2NrQGHEMmFJFiOJdS3gDDpgSOFhWIjZwxKq2VZpqNTA==",
             "dev": true,
             "requires": {
                 "@ethersproject/logger": "^5.0.0"
             }
         },
         "@ethersproject/constants": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.1.tgz",
-            "integrity": "sha512-Xec07hFCPN4wfC3WDiRay7KipkApl2msiKTrBHCuAwNMOM8M92+mlQp8tgfEL51DPwCZkmdk1f02kArc6caVSw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.2.tgz",
+            "integrity": "sha512-nNoVlNP6bgpog7pQ2EyD1xjlaXcy1Cl4kK5v1KoskHj58EtB6TK8M8AFGi3GgHTdMldfT4eN3OsoQ/CdOTVNFA==",
             "dev": true,
             "requires": {
                 "@ethersproject/bignumber": "^5.0.0"
             }
         },
         "@ethersproject/hash": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.1.tgz",
-            "integrity": "sha512-1ByUXYvkszrSSks07xctBtZfpFnIVmftxWlAAnguxh6Q65vKECd/EPi5uI5xVOvnrYMH9Vb8MK1SofPX/6fArQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.2.tgz",
+            "integrity": "sha512-dWGvNwmVRX2bxoQQ3ciMw46Vzl1nqfL+5R8+2ZxsRXD3Cjgw1dL2mdjJF7xMMWPvPdrlhKXWSK0gb8VLwHZ8Cw==",
             "dev": true,
             "requires": {
                 "@ethersproject/bytes": "^5.0.0",
@@ -2379,9 +2390,9 @@
             }
         },
         "@ethersproject/keccak256": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.1.tgz",
-            "integrity": "sha512-AtFm/4qHRQUvZcG3WYmaT7zV79dz72+N01w0XphcIBaD/7UZXyW85Uf08sirVlckHmh9fvc4UDWyHiroKsBT6Q==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.2.tgz",
+            "integrity": "sha512-MbroXutc0gPNYIrUjS4Aw0lDuXabdzI7+l7elRWr1G6G+W0v00e/3gbikWkCReGtt2Jnt4lQSgnflhDwQGcIhA==",
             "dev": true,
             "requires": {
                 "@ethersproject/bytes": "^5.0.0",
@@ -2397,24 +2408,24 @@
             }
         },
         "@ethersproject/logger": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.2.tgz",
-            "integrity": "sha512-NQe3O1/Nwkcp6bto6hsTvrcCeR/cOGK+RhOMn0Zi2FND6gdWsf1g+5ie8gQ1REqDX4MTGP/Y131dZas985ls/g==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.4.tgz",
+            "integrity": "sha512-alA2LiAy1LdQ/L1SA9ajUC7MvGAEQLsICEfKK4erX5qhkXE1LwLSPIzobtOWFsMHf2yrXGKBLnnpuVHprI3sAw==",
             "dev": true
         },
         "@ethersproject/properties": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.1.tgz",
-            "integrity": "sha512-b3VZ/NpYIf64/hFXeWNxVCbY1xoMPIYM3n6Qnu6Ayr3bLt1olFPQfAaaRB0aOsLz7tMtmkT3DrA1KG/IrOgBRw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.2.tgz",
+            "integrity": "sha512-FxAisPGAOACQjMJzewl9OJG6lsGCPTm5vpUMtfeoxzAlAb2lv+kHzQPUh9h4jfAILzE8AR1jgXMzRmlhwyra1Q==",
             "dev": true,
             "requires": {
                 "@ethersproject/logger": "^5.0.0"
             }
         },
         "@ethersproject/rlp": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.1.tgz",
-            "integrity": "sha512-3F8XE1zS4w8w4xiK1hMtFuVs6UnhQlmrEHLT85GanqK8vG5wGi81IQmkukL9tQIu2a5jykoO46ibja+6N1fpFg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.2.tgz",
+            "integrity": "sha512-oE0M5jqQ67fi2SuMcrpoewOpEuoXaD8M9JeR9md1bXRMvDYgKXUtDHs22oevpEOdnO2DPIRabp6MVHa4aDuWmw==",
             "dev": true,
             "requires": {
                 "@ethersproject/bytes": "^5.0.0",
@@ -2422,9 +2433,9 @@
             }
         },
         "@ethersproject/signing-key": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.2.tgz",
-            "integrity": "sha512-kgpCdtgoLoKXJTwJPw3ggRW7EO93YCQ98zY8hBpIb4OK3FxFCR3UUjlrGEwjMnLHDjFrxpKCeJagGWf477RyMQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.3.tgz",
+            "integrity": "sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==",
             "dev": true,
             "requires": {
                 "@ethersproject/bytes": "^5.0.0",
@@ -2451,9 +2462,9 @@
             }
         },
         "@ethersproject/strings": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.1.tgz",
-            "integrity": "sha512-N8LxdHGBT7GZdogkEOV5xKXYTz5PNHuNzcxLNPYfH3kpvWSyXshZBgAz8YE1a8sMZagGj+Ic6d3mHijdCTSkGA==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.2.tgz",
+            "integrity": "sha512-oNa+xvSqsFU96ndzog0IBTtsRFGOqGpzrXJ7shXLBT7juVeSEyZA/sYs0DMZB5mJ9FEjHdZKxR/rTyBY91vuXg==",
             "dev": true,
             "requires": {
                 "@ethersproject/bytes": "^5.0.0",
@@ -2462,9 +2473,9 @@
             }
         },
         "@ethersproject/transactions": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.1.tgz",
-            "integrity": "sha512-IGc6/5hri3PrqR/ZCj89osDiq3Lt0CSrycn6vlRl8SjpBKYDdcT+Ru5xkeC7YcsnqcdBmTL+jyR3SLudU+x2Kw==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.2.tgz",
+            "integrity": "sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==",
             "dev": true,
             "requires": {
                 "@ethersproject/address": "^5.0.0",
@@ -5544,6 +5555,12 @@
             "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
             "dev": true
         },
+        "bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true
+        },
         "bn.js": {
             "version": "4.11.9",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
@@ -6038,9 +6055,9 @@
             },
             "dependencies": {
                 "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
                     "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
@@ -6331,9 +6348,9 @@
                     }
                 },
                 "multicodec": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.3.tgz",
-                    "integrity": "sha512-8G4JKbHWSe/39Xx2uiI+/b/S6mGgimzwEN4TOCokFUIfofg1T8eHny88ht9eWImD2dng+EEQRsApXxA5ubhU4g==",
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+                    "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
                     "dev": true,
                     "requires": {
                         "buffer": "^5.6.0",
@@ -8401,13 +8418,16 @@
             }
         },
         "eth-lib": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-            "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+            "version": "0.1.29",
+            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+            "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
+                "nano-json-stream-parser": "^0.1.2",
+                "servify": "^0.1.12",
+                "ws": "^3.0.0",
                 "xhr-request-promise": "^0.1.2"
             }
         },
@@ -10379,181 +10399,6 @@
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
             "dev": true
-        },
-        "geth-dev-assistant": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/geth-dev-assistant/-/geth-dev-assistant-0.1.5.tgz",
-            "integrity": "sha512-k77vdAd67SypzyGiUuCCVgtb1HfBQS2q9UQnG6452jWLyHJ3xHmeb+QlJU71qgToqVhSTvAOqdVLzqLH/i5UtA==",
-            "dev": true,
-            "requires": {
-                "colors": "^1.3.3",
-                "node-emoji": "^1.10.0",
-                "web3": "^1.2.9",
-                "yargs": "^13.2.2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
-                },
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^3.1.0",
-                        "strip-ansi": "^5.2.0",
-                        "wrap-ansi": "^5.1.0"
-                    }
-                },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
-                "get-caller-file": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-                    "dev": true,
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-                    "dev": true
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
-                },
-                "require-main-filename": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-                    "dev": true
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^4.1.0"
-                    }
-                },
-                "which-module": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-                    "dev": true
-                },
-                "wrap-ansi": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.0",
-                        "string-width": "^3.0.0",
-                        "strip-ansi": "^5.0.0"
-                    }
-                },
-                "y18n": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-                    "dev": true
-                },
-                "yargs": {
-                    "version": "13.3.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-                    "dev": true,
-                    "requires": {
-                        "cliui": "^5.0.0",
-                        "find-up": "^3.0.0",
-                        "get-caller-file": "^2.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^2.0.0",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^3.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^4.0.0",
-                        "yargs-parser": "^13.1.2"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "13.1.2",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
-                    }
-                }
-            }
         },
         "getpass": {
             "version": "0.1.7",
@@ -13861,9 +13706,9 @@
             }
         },
         "mock-fs": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.11.0.tgz",
-            "integrity": "sha512-Yp4o3/ZA15wsXqJTT+R+9w2AYIkD1i80Lds47wDbuUhOvQvm+O2EfjFZSz0pMgZZSPHRhGxgcd2+GL4+jZMtdw==",
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.12.0.tgz",
+            "integrity": "sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==",
             "dev": true
         },
         "modify-values": {
@@ -17439,12 +17284,6 @@
                 "xhr-request": "^1.0.1"
             },
             "dependencies": {
-                "bluebird": {
-                    "version": "3.7.2",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-                    "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-                    "dev": true
-                },
                 "buffer": {
                     "version": "5.6.0",
                     "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
@@ -17453,20 +17292,6 @@
                     "requires": {
                         "base64-js": "^1.0.2",
                         "ieee754": "^1.1.4"
-                    }
-                },
-                "eth-lib": {
-                    "version": "0.1.29",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
-                    "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
-                    "dev": true,
-                    "requires": {
-                        "bn.js": "^4.11.6",
-                        "elliptic": "^6.4.0",
-                        "nano-json-stream-parser": "^0.1.2",
-                        "servify": "^0.1.12",
-                        "ws": "^3.0.0",
-                        "xhr-request-promise": "^0.1.2"
                     }
                 },
                 "got": {
@@ -18714,30 +18539,24 @@
             }
         },
         "web3": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.9.tgz",
-            "integrity": "sha512-Mo5aBRm0JrcNpN/g4VOrDzudymfOnHRC3s2VarhYxRA8aWgF5rnhQ0ziySaugpic1gksbXPe105pUWyRqw8HUA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.11.tgz",
+            "integrity": "sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==",
             "dev": true,
             "requires": {
-                "web3-bzz": "1.2.9",
-                "web3-core": "1.2.9",
-                "web3-eth": "1.2.9",
-                "web3-eth-personal": "1.2.9",
-                "web3-net": "1.2.9",
-                "web3-shh": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-bzz": "1.2.11",
+                "web3-core": "1.2.11",
+                "web3-eth": "1.2.11",
+                "web3-eth-personal": "1.2.11",
+                "web3-net": "1.2.11",
+                "web3-shh": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -18746,13 +18565,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -18764,50 +18583,36 @@
             }
         },
         "web3-bzz": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.9.tgz",
-            "integrity": "sha512-ogVQr9jHodu9HobARtvUSmWG22cv2EUQzlPeejGWZ7j5h20HX40EDuWyomGY5VclIj5DdLY76Tmq88RTf/6nxA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.11.tgz",
+            "integrity": "sha512-XGpWUEElGypBjeFyUhTkiPXFbDVD6Nr/S5jznE3t8cWUA0FxRf1n3n/NuIZeb0H9RkN2Ctd/jNma/k8XGa3YKg==",
             "dev": true,
             "requires": {
-                "@types/node": "^10.12.18",
+                "@types/node": "^12.12.6",
                 "got": "9.6.0",
                 "swarm-js": "^0.1.40",
                 "underscore": "1.9.1"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "10.17.26",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
-                    "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw==",
-                    "dev": true
-                }
             }
         },
         "web3-core": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.9.tgz",
-            "integrity": "sha512-fSYv21IP658Ty2wAuU9iqmW7V+75DOYMVZsDH/c14jcF/1VXnedOcxzxSj3vArsCvXZNe6XC5/wAuGZyQwR9RA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
+            "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
             "dev": true,
             "requires": {
-                "@types/bn.js": "^4.11.4",
-                "@types/node": "^12.6.1",
+                "@types/bn.js": "^4.11.5",
+                "@types/node": "^12.12.6",
                 "bignumber.js": "^9.0.0",
-                "web3-core-helpers": "1.2.9",
-                "web3-core-method": "1.2.9",
-                "web3-core-requestmanager": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-core-helpers": "1.2.11",
+                "web3-core-method": "1.2.11",
+                "web3-core-requestmanager": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -18816,13 +18621,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -18834,26 +18639,20 @@
             }
         },
         "web3-core-helpers": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.9.tgz",
-            "integrity": "sha512-t0WAG3orLCE3lqi77ZoSRNFok3VQWZXTniZigDQjyOJYMAX7BU3F3js8HKbjVnAxlX3tiKoDxI0KBk9F3AxYuw==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
+            "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
             "dev": true,
             "requires": {
                 "underscore": "1.9.1",
-                "web3-eth-iban": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-eth-iban": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -18862,13 +18661,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -18880,29 +18679,23 @@
             }
         },
         "web3-core-method": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.9.tgz",
-            "integrity": "sha512-bjsIoqP3gs7A/gP8+QeLUCyOKJ8bopteCSNbCX36Pxk6TYfYWNuC6hP+2GzUuqdP3xaZNe+XEElQFUNpR3oyAg==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
+            "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
             "dev": true,
             "requires": {
                 "@ethersproject/transactions": "^5.0.0-beta.135",
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.9",
-                "web3-core-promievent": "1.2.9",
-                "web3-core-subscriptions": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-core-helpers": "1.2.11",
+                "web3-core-promievent": "1.2.11",
+                "web3-core-subscriptions": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -18911,13 +18704,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -18929,85 +18722,63 @@
             }
         },
         "web3-core-promievent": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.9.tgz",
-            "integrity": "sha512-0eAUA2zjgXTleSrnc1wdoKQPPIHU6KHf4fAscu4W9kKrR+mqP1KsjYrxY9wUyjNnXxfQ+5M29ipvbiaK8OqdOw==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
+            "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
             "dev": true,
             "requires": {
-                "eventemitter3": "3.1.2"
-            },
-            "dependencies": {
-                "eventemitter3": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-                    "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-                    "dev": true
-                }
+                "eventemitter3": "4.0.4"
             }
         },
         "web3-core-requestmanager": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.9.tgz",
-            "integrity": "sha512-1PwKV2m46ALUnIN5VPPgjOj8yMLJhhqZYvYJE34hTN5SErOkwhzx5zScvo5MN7v7KyQGFnpVCZKKGCiEnDmtFA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
+            "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
             "dev": true,
             "requires": {
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.9",
-                "web3-providers-http": "1.2.9",
-                "web3-providers-ipc": "1.2.9",
-                "web3-providers-ws": "1.2.9"
+                "web3-core-helpers": "1.2.11",
+                "web3-providers-http": "1.2.11",
+                "web3-providers-ipc": "1.2.11",
+                "web3-providers-ws": "1.2.11"
             }
         },
         "web3-core-subscriptions": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.9.tgz",
-            "integrity": "sha512-Y48TvXPSPxEM33OmXjGVDMzTd0j8X0t2+sDw66haeBS8eYnrEzasWuBZZXDq0zNUsqyxItgBGDn+cszkgEnFqg==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
+            "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
             "dev": true,
             "requires": {
-                "eventemitter3": "3.1.2",
+                "eventemitter3": "4.0.4",
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.9"
-            },
-            "dependencies": {
-                "eventemitter3": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-                    "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-                    "dev": true
-                }
+                "web3-core-helpers": "1.2.11"
             }
         },
         "web3-eth": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.9.tgz",
-            "integrity": "sha512-sIKO4iE9FEBa/CYUd6GdPd7GXt/wISqxUd8PlIld6+hvMJj02lgO7Z7p5T9mZIJcIZJGvZX81ogx8oJ9yif+Ag==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
+            "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
             "dev": true,
             "requires": {
                 "underscore": "1.9.1",
-                "web3-core": "1.2.9",
-                "web3-core-helpers": "1.2.9",
-                "web3-core-method": "1.2.9",
-                "web3-core-subscriptions": "1.2.9",
-                "web3-eth-abi": "1.2.9",
-                "web3-eth-accounts": "1.2.9",
-                "web3-eth-contract": "1.2.9",
-                "web3-eth-ens": "1.2.9",
-                "web3-eth-iban": "1.2.9",
-                "web3-eth-personal": "1.2.9",
-                "web3-net": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-core": "1.2.11",
+                "web3-core-helpers": "1.2.11",
+                "web3-core-method": "1.2.11",
+                "web3-core-subscriptions": "1.2.11",
+                "web3-eth-abi": "1.2.11",
+                "web3-eth-accounts": "1.2.11",
+                "web3-eth-contract": "1.2.11",
+                "web3-eth-ens": "1.2.11",
+                "web3-eth-iban": "1.2.11",
+                "web3-eth-personal": "1.2.11",
+                "web3-net": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -19016,13 +18787,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -19034,26 +18805,20 @@
             }
         },
         "web3-eth-abi": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.9.tgz",
-            "integrity": "sha512-3YwUYbh/DMfDbhMWEebAdjSd5bj3ZQieOjLzWFHU23CaLEqT34sUix1lba+hgUH/EN6A7bKAuKOhR3p0OvTn7Q==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
+            "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
             "dev": true,
             "requires": {
                 "@ethersproject/abi": "5.0.0-beta.153",
                 "underscore": "1.9.1",
-                "web3-utils": "1.2.9"
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -19062,13 +18827,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -19080,88 +18845,28 @@
             }
         },
         "web3-eth-accounts": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.9.tgz",
-            "integrity": "sha512-jkbDCZoA1qv53mFcRHCinoCsgg8WH+M0YUO1awxmqWXRmCRws1wW0TsuSQ14UThih5Dxolgl+e+aGWxG58LMwg==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
+            "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
             "dev": true,
             "requires": {
                 "crypto-browserify": "3.12.0",
-                "eth-lib": "^0.2.8",
+                "eth-lib": "0.2.8",
                 "ethereumjs-common": "^1.3.2",
                 "ethereumjs-tx": "^2.1.1",
                 "scrypt-js": "^3.0.1",
                 "underscore": "1.9.1",
                 "uuid": "3.3.2",
-                "web3-core": "1.2.9",
-                "web3-core-helpers": "1.2.9",
-                "web3-core-method": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-core": "1.2.11",
+                "web3-core-helpers": "1.2.11",
+                "web3-core-method": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
-                "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
-                    "dev": true,
-                    "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
-                        "ethereum-bloom-filters": "^1.0.6",
-                        "ethjs-unit": "0.1.6",
-                        "number-to-bn": "1.7.0",
-                        "randombytes": "^2.1.0",
-                        "underscore": "1.9.1",
-                        "utf8": "3.0.0"
-                    },
-                    "dependencies": {
-                        "eth-lib": {
-                            "version": "0.2.7",
-                            "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                            "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-                            "dev": true,
-                            "requires": {
-                                "bn.js": "^4.11.6",
-                                "elliptic": "^6.4.0",
-                                "xhr-request-promise": "^0.1.2"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "web3-eth-contract": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.9.tgz",
-            "integrity": "sha512-PYMvJf7EG/HyssUZa+pXrc8IB06K/YFfWYyW4R7ed3sab+9wWUys1TlWxBCBuiBXOokSAyM6H6P6/cKEx8FT8Q==",
-            "dev": true,
-            "requires": {
-                "@types/bn.js": "^4.11.4",
-                "underscore": "1.9.1",
-                "web3-core": "1.2.9",
-                "web3-core-helpers": "1.2.9",
-                "web3-core-method": "1.2.9",
-                "web3-core-promievent": "1.2.9",
-                "web3-core-subscriptions": "1.2.9",
-                "web3-eth-abi": "1.2.9",
-                "web3-utils": "1.2.9"
-            },
-            "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -19170,13 +18875,59 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
+                        "ethereum-bloom-filters": "^1.0.6",
+                        "ethjs-unit": "0.1.6",
+                        "number-to-bn": "1.7.0",
+                        "randombytes": "^2.1.0",
+                        "underscore": "1.9.1",
+                        "utf8": "3.0.0"
+                    }
+                }
+            }
+        },
+        "web3-eth-contract": {
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
+            "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
+            "dev": true,
+            "requires": {
+                "@types/bn.js": "^4.11.5",
+                "underscore": "1.9.1",
+                "web3-core": "1.2.11",
+                "web3-core-helpers": "1.2.11",
+                "web3-core-method": "1.2.11",
+                "web3-core-promievent": "1.2.11",
+                "web3-core-subscriptions": "1.2.11",
+                "web3-eth-abi": "1.2.11",
+                "web3-utils": "1.2.11"
+            },
+            "dependencies": {
+                "eth-lib": {
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.6",
+                        "elliptic": "^6.4.0",
+                        "xhr-request-promise": "^0.1.2"
+                    }
+                },
+                "web3-utils": {
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+                    "dev": true,
+                    "requires": {
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -19188,32 +18939,26 @@
             }
         },
         "web3-eth-ens": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.9.tgz",
-            "integrity": "sha512-kG4+ZRgZ8I1WYyOBGI8QVRHfUSbbJjvJAGA1AF/NOW7JXQ+x7gBGeJw6taDWJhSshMoEKWcsgvsiuoG4870YxQ==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
+            "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
             "dev": true,
             "requires": {
                 "content-hash": "^2.5.2",
                 "eth-ens-namehash": "2.0.8",
                 "underscore": "1.9.1",
-                "web3-core": "1.2.9",
-                "web3-core-helpers": "1.2.9",
-                "web3-core-promievent": "1.2.9",
-                "web3-eth-abi": "1.2.9",
-                "web3-eth-contract": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-core": "1.2.11",
+                "web3-core-helpers": "1.2.11",
+                "web3-core-promievent": "1.2.11",
+                "web3-eth-abi": "1.2.11",
+                "web3-eth-contract": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -19222,13 +18967,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -19240,25 +18985,19 @@
             }
         },
         "web3-eth-iban": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.9.tgz",
-            "integrity": "sha512-RtdVvJE0pyg9dHLy0GzDiqgnLnssSzfz/JYguhC1wsj9+Gnq1M6Diy3NixACWUAp6ty/zafyOaZnNQ+JuH9TjQ==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
+            "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "web3-utils": "1.2.9"
+                "bn.js": "^4.11.9",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -19267,13 +19006,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -19285,29 +19024,23 @@
             }
         },
         "web3-eth-personal": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.9.tgz",
-            "integrity": "sha512-cFiNrktxZ1C/rIdJFzQTvFn3/0zcsR3a+Jf8Y3KxeQDHszQtosjLWptP7bsUmDwEh4hzh0Cy3KpOxlYBWB8bJQ==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
+            "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
             "dev": true,
             "requires": {
-                "@types/node": "^12.6.1",
-                "web3-core": "1.2.9",
-                "web3-core-helpers": "1.2.9",
-                "web3-core-method": "1.2.9",
-                "web3-net": "1.2.9",
-                "web3-utils": "1.2.9"
+                "@types/node": "^12.12.6",
+                "web3-core": "1.2.11",
+                "web3-core-helpers": "1.2.11",
+                "web3-core-method": "1.2.11",
+                "web3-net": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -19316,13 +19049,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -19334,26 +19067,20 @@
             }
         },
         "web3-net": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.9.tgz",
-            "integrity": "sha512-d2mTn8jPlg+SI2hTj2b32Qan6DmtU9ap/IUlJTeQbZQSkTLf0u9suW8Vjwyr4poJYXTurdSshE7OZsPNn30/ZA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
+            "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
             "dev": true,
             "requires": {
-                "web3-core": "1.2.9",
-                "web3-core-method": "1.2.9",
-                "web3-utils": "1.2.9"
+                "web3-core": "1.2.11",
+                "web3-core-method": "1.2.11",
+                "web3-utils": "1.2.11"
             },
             "dependencies": {
-                "bn.js": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-                    "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-                    "dev": true
-                },
                 "eth-lib": {
-                    "version": "0.2.7",
-                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-                    "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                    "version": "0.2.8",
+                    "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+                    "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
                     "dev": true,
                     "requires": {
                         "bn.js": "^4.11.6",
@@ -19362,13 +19089,13 @@
                     }
                 },
                 "web3-utils": {
-                    "version": "1.2.9",
-                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
-                    "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
+                    "version": "1.2.11",
+                    "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+                    "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
                     "dev": true,
                     "requires": {
-                        "bn.js": "4.11.8",
-                        "eth-lib": "0.2.7",
+                        "bn.js": "^4.11.9",
+                        "eth-lib": "0.2.8",
                         "ethereum-bloom-filters": "^1.0.6",
                         "ethjs-unit": "0.1.6",
                         "number-to-bn": "1.7.0",
@@ -19380,48 +19107,48 @@
             }
         },
         "web3-providers-http": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.9.tgz",
-            "integrity": "sha512-F956tCIj60Ttr0UvEHWFIhx+be3He8msoPzyA44/kfzzYoMAsCFRn5cf0zQG6al0znE75g6HlWVSN6s3yAh51A==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
+            "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
             "dev": true,
             "requires": {
-                "web3-core-helpers": "1.2.9",
+                "web3-core-helpers": "1.2.11",
                 "xhr2-cookies": "1.1.0"
             }
         },
         "web3-providers-ipc": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.9.tgz",
-            "integrity": "sha512-NQ8QnBleoHA2qTJlqoWu7EJAD/FR5uimf7Ielzk4Z2z+m+6UAuJdJMSuQNj+Umhz9L/Ys6vpS1vHx9NizFl+aQ==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
+            "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
             "dev": true,
             "requires": {
                 "oboe": "2.1.4",
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.9"
+                "web3-core-helpers": "1.2.11"
             }
         },
         "web3-providers-ws": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.9.tgz",
-            "integrity": "sha512-6+UpvINeI//dglZoAKStUXqxDOXJy6Iitv2z3dbgInG4zb8tkYl/VBDL80UjUg3ZvzWG0g7EKY2nRPEpON2TFA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
+            "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
             "dev": true,
             "requires": {
-                "eventemitter3": "^4.0.0",
+                "eventemitter3": "4.0.4",
                 "underscore": "1.9.1",
-                "web3-core-helpers": "1.2.9",
+                "web3-core-helpers": "1.2.11",
                 "websocket": "^1.0.31"
             }
         },
         "web3-shh": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.9.tgz",
-            "integrity": "sha512-PWa8b/EaxaMinFaxy6cV0i0EOi2M7a/ST+9k9nhyhCjVa2vzXuNoBNo2IUOmeZ0WP2UQB8ByJ2+p4htlJaDOjA==",
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.11.tgz",
+            "integrity": "sha512-B3OrO3oG1L+bv3E1sTwCx66injW1A8hhwpknDUbV+sw3fehFazA06z9SGXUefuFI1kVs4q2vRi0n4oCcI4dZDg==",
             "dev": true,
             "requires": {
-                "web3-core": "1.2.9",
-                "web3-core-method": "1.2.9",
-                "web3-core-subscriptions": "1.2.9",
-                "web3-net": "1.2.9"
+                "web3-core": "1.2.11",
+                "web3-core-method": "1.2.11",
+                "web3-core-subscriptions": "1.2.11",
+                "web3-net": "1.2.11"
             }
         },
         "web3-utils": {
@@ -20126,6 +19853,171 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
             "dev": true
+        },
+        "yargs": {
+            "version": "13.3.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+            "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+            "dev": true,
+            "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+                    "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "get-caller-file": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+                    "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+                    "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+                    "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+                    "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+                    "dev": true
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
+                }
+            }
         },
         "yargs-unparser": {
             "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "@babel/plugin-transform-runtime": "^7.10.4",
         "@babel/preset-env": "^7.10.4",
         "@babel/runtime": "^7.10.4",
+        "@chainsafe/geth-dev-assistant": "^0.1.5",
         "@ensdomains/ens": "^0.4.0",
         "@ensdomains/resolver": "^0.2.4",
         "@types/bignumber.js": "^4.0.2",
@@ -115,7 +116,6 @@
         "ethers": "4.0.33",
         "ethjs-signer": "^0.1.1",
         "ganache-cli": "^6.7.0",
-        "geth-dev-assistant": "^0.1.5",
         "jshint": "^2.10.2",
         "karma": "^5.1.0",
         "karma-browserify": "^7.0.0",
@@ -134,5 +134,6 @@
         "wait-port": "^0.2.6",
         "webpack": "^4.43.0",
         "webpack-cli": "^3.3.12"
-    }
+    },
+    "dependencies": {}
 }


### PR DESCRIPTION
## Description

This supersedes #3690 as it uses an updated version of `geth-dev-assistant` that is able to use the latest docker version of go-ethereum rather than a tagged version.

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->
Closes #3687 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
