### PR TITLE
Fix typo in web3-utils.rst

### DIFF
--- a/docs/web3-utils.rst
+++ b/docs/web3-utils.rst
@@ -1043,7 +1043,7 @@ toWei
 
 Converts any `ether value <http://ethdocs.org/en/latest/ether.html>`_ value into `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na>`_.
 
-.. note:: "wei" are the smallest ethere unit, and you should always make calculations in wei and convert only for display reasons.
+.. note:: "wei" are the smallest ethereum unit, and you should always make calculations in wei and convert only for display reasons.
 
 ----------
 Parameters
@@ -1117,7 +1117,7 @@ fromWei
 
 Converts any `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na>`_ value into a `ether value <http://ethdocs.org/en/latest/ether.html>`_.
 
-.. note:: "wei" are the smallest ethere unit, and you should always make calculations in wei and convert only for display reasons.
+.. note:: "wei" are the smallest ethereum unit, and you should always make calculations in wei and convert only for display reasons.
 
 ----------
 Parameters

--- a/docs/web3-utils.rst
+++ b/docs/web3-utils.rst
@@ -1117,7 +1117,7 @@ fromWei
 
 Converts any `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na>`_ value into a `ether value <http://ethdocs.org/en/latest/ether.html>`_.
 
-.. note:: "wei" are the smallest ethereum unit, and you should always make calculations in wei and convert only for display reasons.
+.. note:: "wei" are the smallest ether unit, and you should always make calculations in wei and convert only for display reasons.
 
 ----------
 Parameters

--- a/docs/web3-utils.rst
+++ b/docs/web3-utils.rst
@@ -1043,7 +1043,7 @@ toWei
 
 Converts any `ether value <http://ethdocs.org/en/latest/ether.html>`_ value into `wei <http://ethereum.stackexchange.com/questions/253/the-ether-denominations-are-called-finney-szabo-and-wei-what-who-are-these-na>`_.
 
-.. note:: "wei" are the smallest ethereum unit, and you should always make calculations in wei and convert only for display reasons.
+.. note:: "wei" are the smallest ether unit, and you should always make calculations in wei and convert only for display reasons.
 
 ----------
 Parameters
@@ -1391,4 +1391,3 @@ Example
 
     web3.utils.toTwosComplement('-0x1');
     > "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-


### PR DESCRIPTION
## Description

Fixes typos ("ethere unit") in web3-utils documentation.

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

Fix typos. "ethere unit" => "ether unit" 