### PR TITLE
Bump websocket version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,7 @@ Released with 1.0.0-beta.37 code base.
 - Modernized web3-core to use newer es syntax (#3652)
 - Bumped `web3-providers-ipc` `oboe` version to 2.1.5 (#3661)
 - Bump lodash from 4.17.15 to 4.17.19
+- Bump websocket version which removes node-gyp from web3.js (#3865)
 
 ### Fixed
 

--- a/packages/web3-providers-ws/package-lock.json
+++ b/packages/web3-providers-ws/package-lock.json
@@ -84,6 +84,11 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"bn.js": {
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -92,6 +97,24 @@
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+		},
+		"buffer-to-arraybuffer": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
+			"integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
+		},
+		"bufferutil": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
+			"integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+			"requires": {
+				"node-gyp-build": "~3.7.0"
 			}
 		},
 		"builtin-modules": {
@@ -231,11 +254,29 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"decompress-response": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"requires": {
+				"mimic-response": "^1.0.0"
+			}
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 			"dev": true
+		},
+		"dom-walk": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+			"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 		},
 		"dts-critic": {
 			"version": "3.0.1",
@@ -322,6 +363,20 @@
 				}
 			}
 		},
+		"elliptic": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"requires": {
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -384,10 +439,44 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"eth-lib": {
+			"version": "0.2.8",
+			"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+			"integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+			"requires": {
+				"bn.js": "^4.11.6",
+				"elliptic": "^6.4.0",
+				"xhr-request-promise": "^0.1.2"
+			}
+		},
+		"ethereum-bloom-filters": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
+			"integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
+			"requires": {
+				"js-sha3": "^0.8.0"
+			}
+		},
+		"ethjs-unit": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
+			"integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
+			"requires": {
+				"bn.js": "4.11.6",
+				"number-to-bn": "1.7.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
+			}
+		},
 		"eventemitter3": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+			"integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
 		},
 		"execa": {
 			"version": "1.0.0",
@@ -413,9 +502,9 @@
 			},
 			"dependencies": {
 				"type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+					"integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
 				}
 			}
 		},
@@ -474,6 +563,15 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"global": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+			"integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+			"requires": {
+				"min-document": "^2.19.0",
+				"process": "~0.5.1"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -503,6 +601,25 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -516,8 +633,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"invert-kv": {
 			"version": "2.0.0",
@@ -530,6 +646,16 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 			"dev": true
+		},
+		"is-function": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+		},
+		"is-hex-prefixed": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+			"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -547,6 +673,11 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true
+		},
+		"js-sha3": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -633,6 +764,29 @@
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
 		},
+		"mimic-response": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+		},
+		"min-document": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+			"integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+			"requires": {
+				"dom-walk": "^0.1.0"
+			}
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -662,11 +816,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
-		},
 		"next-tick": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -677,6 +826,11 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"node-gyp-build": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+			"integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -693,11 +847,31 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
+		"number-to-bn": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
+			"integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
+			"requires": {
+				"bn.js": "4.11.6",
+				"strip-hex-prefix": "1.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.6",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
+				}
+			}
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -755,6 +929,11 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
 		},
+		"parse-headers": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+			"integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
+		},
 		"parsimmon": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/parsimmon/-/parsimmon-1.13.0.tgz",
@@ -785,6 +964,11 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
+		"process": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+			"integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
+		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -793,6 +977,24 @@
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
+			}
+		},
+		"query-string": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+			"requires": {
+				"decode-uri-component": "^0.2.0",
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"requires": {
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"require-directory": {
@@ -815,6 +1017,11 @@
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"semver": {
 			"version": "6.3.0",
@@ -849,11 +1056,31 @@
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
+		"simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+		},
+		"simple-get": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+			"requires": {
+				"decompress-response": "^3.3.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
+		},
+		"strict-uri-encode": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
 		"string-width": {
 			"version": "2.1.1",
@@ -880,6 +1107,14 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
+		"strip-hex-prefix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+			"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+			"requires": {
+				"is-hex-prefixed": "1.0.0"
+			}
+		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -891,6 +1126,11 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
 			"dev": true
+		},
+		"timed-out": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
 		},
 		"tslib": {
 			"version": "1.11.1",
@@ -966,15 +1206,68 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
-		"websocket": {
-			"version": "1.0.31",
-			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
-			"integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+		"url-set-query": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
+			"integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk="
+		},
+		"utf-8-validate": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+			"integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
 			"requires": {
+				"node-gyp-build": "~3.7.0"
+			}
+		},
+		"utf8": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+		},
+		"web3-core-helpers": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
+			"integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
+			"requires": {
+				"underscore": "1.9.1",
+				"web3-eth-iban": "1.2.11",
+				"web3-utils": "1.2.11"
+			}
+		},
+		"web3-eth-iban": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
+			"integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"web3-utils": "1.2.11"
+			}
+		},
+		"web3-utils": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
+			"integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+			"requires": {
+				"bn.js": "^4.11.9",
+				"eth-lib": "0.2.8",
+				"ethereum-bloom-filters": "^1.0.6",
+				"ethjs-unit": "0.1.6",
+				"number-to-bn": "1.7.0",
+				"randombytes": "^2.1.0",
+				"underscore": "1.9.1",
+				"utf8": "3.0.0"
+			}
+		},
+		"websocket": {
+			"version": "1.0.32",
+			"resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
+			"integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
+			"requires": {
+				"bufferutil": "^4.0.1",
 				"debug": "^2.2.0",
 				"es5-ext": "^0.10.50",
-				"nan": "^2.14.0",
 				"typedarray-to-buffer": "^3.1.5",
+				"utf-8-validate": "^5.0.2",
 				"yaeti": "^0.0.6"
 			}
 		},
@@ -1043,8 +1336,45 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xhr": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+			"integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
+			"requires": {
+				"global": "~4.3.0",
+				"is-function": "^1.0.1",
+				"parse-headers": "^2.0.0",
+				"xtend": "^4.0.0"
+			}
+		},
+		"xhr-request": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
+			"integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
+			"requires": {
+				"buffer-to-arraybuffer": "^0.0.5",
+				"object-assign": "^4.1.1",
+				"query-string": "^5.0.1",
+				"simple-get": "^2.7.0",
+				"timed-out": "^4.0.1",
+				"url-set-query": "^1.0.0",
+				"xhr": "^2.0.4"
+			}
+		},
+		"xhr-request-promise": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
+			"integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
+			"requires": {
+				"xhr-request": "^1.1.0"
+			}
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -17,7 +17,7 @@
     "eventemitter3": "4.0.4",
     "underscore": "1.9.1",
     "web3-core-helpers": "1.2.11",
-    "websocket": "^1.0.31"
+    "websocket": "^1.0.32"
   },
   "devDependencies": {
     "dtslint": "^3.4.1",


### PR DESCRIPTION
## Description

This supersedes #3686 and addresses a major change to the websocket library that removes node-gyp. 

Upon merge, web3.js no longer requires node-gyp, and therefore has increased install times. 

Roughly speaking, ~40s speed increase.
 
<!--
Optional if an issue is fixed:
Fixes #(issue)
-->
Closes #3685 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
