### PR TITLE
Solve unhandled rejection if the error event handler of a transaction throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,7 @@ Released with 1.0.0-beta.37 code base.
 ## [1.3.1]
 
 ### Changed
+
 - bump utils 0.10.0^ -> 0.12.0 (#3733)
 
 ### Removed
@@ -299,5 +300,6 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
+- Fix possible unhandled promise rejection when sending a transaction (#3708)
 - Fixed decoding bytes and string parameters for logs emitted with solc 0.4.x (#3724, #3738)
 - Grammar changes to inputAddressFormatter error message

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -725,12 +725,12 @@ Method.prototype.buildCall = function () {
                             txOptions.common = method.defaultCommon;
                         }
 
-                        return method.accounts.signTransaction(txOptions, wallet.privateKey)
+                        method.accounts.signTransaction(txOptions, wallet.privateKey)
                             .then(sendSignedTx)
                             .catch(function (err) {
                                 if (_.isFunction(defer.eventEmitter.listeners) && defer.eventEmitter.listeners('error').length) {
                                     try {
-                                    defer.eventEmitter.emit('error', err);
+                                        defer.eventEmitter.emit('error', err);
                                     } catch (err) {
                                         // Ignore userland error prevent it to bubble up within web3.
                                     }
@@ -740,6 +740,7 @@ Method.prototype.buildCall = function () {
                                 }
                                 defer.reject(err);
                             });
+                        return;
                     }
 
                     // ETH_SIGN

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -729,7 +729,11 @@ Method.prototype.buildCall = function () {
                             .then(sendSignedTx)
                             .catch(function (err) {
                                 if (_.isFunction(defer.eventEmitter.listeners) && defer.eventEmitter.listeners('error').length) {
+                                    try {
                                     defer.eventEmitter.emit('error', err);
+                                    } catch (err) {
+                                        // Ignore userland error prevent it to bubble up within web3.
+                                    }
                                     defer.eventEmitter.removeAllListeners();
                                     defer.eventEmitter.catch(function () {
                                     });


### PR DESCRIPTION
## Description

Since the event handlers are run synchronously, if an `error` event handler throws in userland, the error will return to the lib and keep the `sendRequest` promise chain broken, rising an unhandled promise rejection error. See #3708 for a detailed explanation of the error and how to reproduce.

Fixes #3708

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.