### PR TITLE
Rename close event to disconnect

### DIFF
--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -137,6 +137,7 @@ RequestManager.prototype.setProvider = function (provider, net) {
                 _this.provider.emit('end', event);
             }
         };
+        // TODO: Remove close once the standard allows it
         this.provider.on('close', disconnect);
         this.provider.on('disconnect', disconnect);
 

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -122,7 +122,7 @@ RequestManager.prototype.setProvider = function (provider, net) {
         });
 
         // notify all subscriptions about bad close conditions
-        this.provider.on('disconnect', function close(event) {
+        const disconnect = function disconnect(event) {
             if (!_this._isCleanCloseEvent(event) || _this._isIpcCloseError(event)) {
                 _this.subscriptions.forEach(function (subscription) {
                     subscription.callback(errors.ConnectionCloseError(event));
@@ -136,7 +136,9 @@ RequestManager.prototype.setProvider = function (provider, net) {
             if (_this.provider && _this.provider.emit) {
                 _this.provider.emit('end', event);
             }
-        });
+        };
+        this.provider.on('close', disconnect);
+        this.provider.on('disconnect', disconnect);
 
         // TODO add end, timeout??
     }

--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -122,7 +122,7 @@ RequestManager.prototype.setProvider = function (provider, net) {
         });
 
         // notify all subscriptions about bad close conditions
-        this.provider.on('close', function close(event) {
+        this.provider.on('disconnect', function close(event) {
             if (!_this._isCleanCloseEvent(event) || _this._isIpcCloseError(event)) {
                 _this.subscriptions.forEach(function (subscription) {
                     subscription.callback(errors.ConnectionCloseError(event));
@@ -257,7 +257,7 @@ RequestManager.prototype.removeSubscription = function (id, callback) {
  * Should be called to reset the subscriptions
  *
  * @method reset
- * 
+ *
  * @returns {boolean}
  */
 RequestManager.prototype.clearSubscriptions = function (keepIsSyncing) {
@@ -310,12 +310,12 @@ RequestManager.prototype._isIpcCloseError = function (event) {
 
 /**
  * The jsonrpc result callback for RequestManager.send
- * 
+ *
  * @method _jsonrpcResultCallback
- * 
+ *
  * @param {Function} callback the callback to use
  * @param {Object} payload the jsonrpc payload
- * 
+ *
  * @returns {Function} return callback of form (err, result)
  *
  */

--- a/scripts/e2e.ganache.core.sh
+++ b/scripts/e2e.ganache.core.sh
@@ -11,6 +11,7 @@ set -o errexit
 # Install ganache-core
 git clone https://github.com/trufflesuite/ganache-core
 cd ganache-core
+git checkout tags/v2.13.0
 
 # Install via registry and verify
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"

--- a/test/3_givenProvider-ganache.js
+++ b/test/3_givenProvider-ganache.js
@@ -30,7 +30,10 @@ describe('web.providers.givenProvider (ganache)', function(){
         assert.equal(1, web3.currentProvider.listenerCount('data'))
         assert.equal(1, web3.currentProvider.listenerCount('connect'))
         assert.equal(1, web3.currentProvider.listenerCount('error'))
-        assert.equal(1, web3.currentProvider.listenerCount('disconnect'))
+        // TODO: Remove close once the standard allows it
+        assert(
+            web3.currentProvider.listenerCount("disconnect") === 1 || web3.currentProvider.listenerCount("close") === 1
+        );
     });
 
     it('deploys a contract', async function(){

--- a/test/3_givenProvider-ganache.js
+++ b/test/3_givenProvider-ganache.js
@@ -30,7 +30,7 @@ describe('web.providers.givenProvider (ganache)', function(){
         assert.equal(1, web3.currentProvider.listenerCount('data'))
         assert.equal(1, web3.currentProvider.listenerCount('connect'))
         assert.equal(1, web3.currentProvider.listenerCount('error'))
-        assert.equal(1, web3.currentProvider.listenerCount('close'))
+        assert.equal(1, web3.currentProvider.listenerCount('disconnect'))
     });
 
     it('deploys a contract', async function(){

--- a/test/eth.subscribe.ganache.js
+++ b/test/eth.subscribe.ganache.js
@@ -242,12 +242,12 @@ describe('subscription connect/reconnect', function () {
                 .once('data', async function () {
                     await pify(server.close)();
                 })
-                .on('error', function (err) {
-                    counter++;
-                    assert(err.message.includes('CONNECTION ERROR'));
-                    assert(err.message.includes('close code `1006`'));
-                    assert(err.message.includes('Connection dropped by remote peer.'));
-                });
+
+            web3.eth.currentProvider.on('close', function (err) {
+                counter++;
+                assert(err.reason.includes('Connection dropped by remote peer.'));
+                assert(err.code === 1006);
+            });
 
             // Make sure error handler doesn't fire twice
             await waitSeconds(2);

--- a/test/websocket.ganache.js
+++ b/test/websocket.ganache.js
@@ -43,9 +43,9 @@ describe('WebsocketProvider (ganache)', function () {
         await web3.eth.getBlockNumber();
 
         await new Promise(async function(resolve){
-            web3.currentProvider.once('error', function(err){
-                assert(err.message.includes('Connection dropped by remote peer.'))
-                assert(err.message.includes('1006'));
+            web3.currentProvider.on('close', function (err) {
+                assert(err.reason.includes('Connection dropped by remote peer.'));
+                assert(err.code === 1006);
                 resolve();
             });
 
@@ -64,9 +64,9 @@ describe('WebsocketProvider (ganache)', function () {
         await web3.eth.getBlockNumber();
 
         await new Promise(async function(resolve){
-            web3.currentProvider.once('error', function(err){
-                assert(err.message.includes('1012'));
-                assert(err.message.includes('restart'));
+            web3.currentProvider.on('close', function (err) {
+                assert(err.reason.includes('restart'));
+                assert(err.code === 1012);
                 resolve();
             });
 
@@ -106,9 +106,9 @@ describe('WebsocketProvider (ganache)', function () {
         await web3.eth.getBlockNumber();
 
         await new Promise(async function(resolve){
-            web3.currentProvider.once('end', function(event){
-                assert.equal(event.type, 'close');
-                assert.equal(event.wasClean, false);
+            web3.currentProvider.on('close', function (err) {
+                assert.equal(err.type, 'close');
+                assert.equal(err.wasClean, false);
                 resolve();
             });
 
@@ -127,9 +127,9 @@ describe('WebsocketProvider (ganache)', function () {
         await web3.eth.getBlockNumber();
 
         await new Promise(async function(resolve){
-            web3.currentProvider.once('end', function(event){
-                assert.equal(event.type, 'close');
-                assert.equal(event.wasClean, true);
+            web3.currentProvider.on('close', function (err) {
+                assert.equal(err.type, 'close');
+                assert.equal(err.wasClean, true);
                 resolve();
             });
 


### PR DESCRIPTION
Fixes #3699 

We will need to make sure that the close event is still added for old providers. Either by comparing versions or by registering both, which would lead to the same warning Metamask users experience right now for newer providers.

