### PR TITLE
Prevent ABI objects from being mutated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,3 +310,4 @@ Released with 1.0.0-beta.37 code base.
 - Fixed decoding bytes and string parameters for logs emitted with solc 0.4.x (#3724, #3738)
 - Grammar changes to inputAddressFormatter error message
 - Fixed vulnerable dependencies
+- Fixed mutation of inputs to encoding and decoding functions (#3748)

--- a/packages/web3-eth-abi/src/index.js
+++ b/packages/web3-eth-abi/src/index.js
@@ -155,7 +155,7 @@ ABICoder.prototype.mapTypes = function (types) {
         // recognize former type. Solidity docs say `Function` is a bytes24
         // encoding the contract address followed by the function selector hash.
         if (typeof type === 'object' && type.type === 'function'){
-            type.type = "bytes24";
+            type = Object.assign({}, type, { type: "bytes24" });
         }
         if (self.isSimplifiedStructFormat(type)) {
             var structName = Object.keys(type)[0];

--- a/test/abi.decodeParameter.js
+++ b/test/abi.decodeParameter.js
@@ -638,3 +638,18 @@ describe('lib/solidity/coder', function () {
                         '737472696e670000000000000000000000000000000000000000000000000000'})
     });
 });
+
+describe('/lib/solidity/coder', function() {
+    describe('decodeParam', function () {
+        it('should not alter inputs', function () {
+            const t = {
+                type: "function",
+                name: "f",
+                internalType: "function () external"
+            };
+            const copyOfT = Object.assign({}, t);
+            coder.decodeParameter(t, '063e4f349a9e91c6575aedab0e70087fab642ecac04062260000000000000000'); //must not alter t!
+            assert.deepEqual(t, copyOfT);
+        });
+    });
+});


### PR DESCRIPTION
## Description

Fixes #3748.  Prevents ABI parameter objects from being changed when used as inputs to encoding/decoding functions.  Does this by replacing `t.type = "bytes24"` with `t = Object.assign({}, t, { type: "bytes24" })`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.