### PR TITLE
Fix Web3 provider typings

### DIFF
--- a/packages/web3-providers-http/types/index.d.ts
+++ b/packages/web3-providers-http/types/index.d.ts
@@ -43,7 +43,7 @@ export interface HttpProviderOptions {
     keepAlive?: boolean;
 }
 
-export class HttpProvider extends HttpProviderBase {
+export default class HttpProvider extends HttpProviderBase {
     host: string;
 
     withCredentials: boolean;

--- a/packages/web3-providers-http/types/tests/web3-provider-http-tests.ts
+++ b/packages/web3-providers-http/types/tests/web3-provider-http-tests.ts
@@ -22,8 +22,8 @@
 
 import * as http from 'http';
 import * as https from 'https';
-import { HttpProvider } from 'web3-providers';
 import { JsonRpcResponse } from 'web3-core-helpers';
+import HttpProvider from 'web3-providers-http';
 
 const httpProvider = new HttpProvider('http://localhost:8545', {
     timeout: 20000,

--- a/packages/web3-providers-http/types/tsconfig.json
+++ b/packages/web3-providers-http/types/tsconfig.json
@@ -11,7 +11,7 @@
         "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
-            "web3-providers": ["."]
+            "web3-providers-http": ["."]
         }
     }
 }

--- a/packages/web3-providers-ipc/types/index.d.ts
+++ b/packages/web3-providers-ipc/types/index.d.ts
@@ -22,4 +22,4 @@
 
 import { IpcProviderBase } from 'web3-core-helpers';
 
-export class IpcProvider extends IpcProviderBase { }
+export default class IpcProvider extends IpcProviderBase { }

--- a/packages/web3-providers-ipc/types/tests/web3-provider-ipc-tests.ts
+++ b/packages/web3-providers-ipc/types/tests/web3-provider-ipc-tests.ts
@@ -21,8 +21,8 @@
  */
 
 import * as net from 'net';
-import { IpcProvider } from 'web3-providers';
 import { JsonRpcResponse } from 'web3-core-helpers';
+import IpcProvider from 'web3-providers-ipc';
 
 const ipcProvider = new IpcProvider(
     '/Users/myuser/Library/Ethereum/geth.ipc',

--- a/packages/web3-providers-ipc/types/tsconfig.json
+++ b/packages/web3-providers-ipc/types/tsconfig.json
@@ -11,7 +11,7 @@
         "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
-            "web3-providers": ["."]
+            "web3-providers-ipc": ["."]
         }
     }
 }

--- a/packages/web3-providers-ws/types/index.d.ts
+++ b/packages/web3-providers-ws/types/index.d.ts
@@ -22,4 +22,4 @@
 
 import { WebsocketProviderBase } from 'web3-core-helpers';
 
-export class WebsocketProvider extends WebsocketProviderBase { }
+export default class WebsocketProvider extends WebsocketProviderBase { }

--- a/packages/web3-providers-ws/types/tests/web3-provider-ws-tests.ts
+++ b/packages/web3-providers-ws/types/tests/web3-provider-ws-tests.ts
@@ -21,7 +21,7 @@
  */
 
 import { WebsocketProviderOptions, JsonRpcResponse } from 'web3-core-helpers';
-import { WebsocketProvider } from 'web3-providers';
+import WebsocketProvider from 'web3-providers-ws';
 
 const options: WebsocketProviderOptions = {
     timeout: 30000,

--- a/packages/web3-providers-ws/types/tsconfig.json
+++ b/packages/web3-providers-ws/types/tsconfig.json
@@ -11,7 +11,7 @@
         "allowSyntheticDefaultImports": false,
         "baseUrl": ".",
         "paths": {
-            "web3-providers": ["."]
+            "web3-providers-ws": ["."]
         }
     }
 }


### PR DESCRIPTION
## Description

This pull request fixes the typings of the `web3-provider-*` packages. The modules use the default (`module.exports =`) export instead of a named export. The typing tests were only passing because the configuration aliased to the deprecated `web3-providers` module. This means the provider modules could not be used as intended in TypeScript because the named export does not exist and caused a runtime error and the default export was not typed.

## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
