### PR TITLE
Deprecate 0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# WARNING: 2.X IS NO LONGER BEING MAINTAINED AND WILL BE DEPRECATED FROM NPM
+
 # Ethereum JavaScript API
 
 [![Join the chat at https://gitter.im/ethereum/web3.js](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ethereum/web3.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/depricated.sh
+++ b/depricated.sh
@@ -1,0 +1,9 @@
+
+#!/bin/bash
+
+set -e 
+
+RED='\033[0;31m'
+
+
+printf "${RED}@@@@@@@@@@@@@@@@@@@@@\nWARNING THE 2.x web3.js BRANCH IS NOW DEPRECATED!\n@@@@@@@@@@@@@@@@@@@@@\n"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "scripts": {
+    "preinstall": "./deprecated.sh",
+    "postinstall": "./deprecated.sh",
     "build": "gulp",
     "watch": "gulp watch",
     "lint": "jshint *.js lib",


### PR DESCRIPTION
Metamask was the last user of the 0.20.7 branch, although we haven't updated it, as of today MM dropped support for web3.js in their latest build, we can finally deprecate it.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
