### PR TITLE
Contract leak fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,3 +349,7 @@ Released with 1.0.0-beta.37 code base.
 
 - Add `ETH2Core` class export to `index.d.ts` for `web3-eth2-core` (#3878)
 - Deprecation of bzz warning (#3872)
+
+### Fixed
+
+- Fixed memory leak in web3-eth contracts (#3042)

--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -309,8 +309,8 @@ var Eth = function Eth() {
         // instances. This will update the currentProvider for
         // the contract instances
         var _this = this;
-        var setProvider = self.setProvider;
         self.setProvider = function() {
+          // use setProvider reference from above
           setProvider.apply(self, arguments);
           core.packageInit(_this, [self]);
         };
@@ -658,4 +658,3 @@ core.addProviders(Eth);
 
 
 module.exports = Eth;
-


### PR DESCRIPTION
## Description

Removes `setProvider` variable inside `Contract` constructor. This solves the memory leak when creating contract objects using `new web3.eth.Contract(...)`. This fix is tested [here](https://github.com/JChanceHud/web3-contract-leak).

Fixes #3042 
<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
