### PR TITLE
Wyatt/v1.3.2 timeout fix

### DIFF
--- a/test/eth.ens.js
+++ b/test/eth.ens.js
@@ -148,7 +148,7 @@ describe('ens', function () {
         });
 
         it('should set the owner record for a name', async function () {
-            this.timeout(10000);
+            this.timeout(12000);
             const signature = 'setOwner(bytes32,address)';
 
             prepareProviderForSetter(


### PR DESCRIPTION
## Description

Bumping the timeout by 2 seconds for [this test](https://github.com/ChainSafe/web3.js/blob/1.x/test/eth.ens.js#L151)

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
