### PR TITLE
Feature/improve xml request error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,7 @@ Released with 1.0.0-beta.37 code base.
 - Add missing subscription.on('connected') TS type definition (#3319)
 - Add missing bignumber.js dependency for TS types (#3386)
 - Upgrade swarm-js to 0.1.40 to remove npm vulnerability warning (#3399)
+- Fixed misleading error thrown on XMLHTTP request error
 - Upgrade devDeps to resolve security warnings (#3464)
   - dtslint 0.4.2 => 3.4.1
   - definitelytyped-header-parser 1.0.1 => 3.9.0

--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -44,6 +44,9 @@ module.exports = {
         var message = !!result && !!result.error && !!result.error.message ? result.error.message : 'Invalid JSON RPC response: ' + JSON.stringify(result);
         return new Error(message);
     },
+    RequestFailed: function (){
+        return new Error('HTTP request failed');
+    },
     ConnectionTimeout: function (ms){
         return new Error('CONNECTION TIMEOUT: timeout of ' + ms + ' ms achived');
     },

--- a/packages/web3-providers-http/src/index.js
+++ b/packages/web3-providers-http/src/index.js
@@ -97,7 +97,7 @@ HttpProvider.prototype.send = function (payload, callback) {
     var request = this._prepareRequest();
 
     request.onreadystatechange = function() {
-        if (request.readyState === 4 && request.timeout !== 1) {
+        if (request.readyState === 4 && request.timeout !== 1 && (request.status >= 200 && request.status < 300)) {
             var result = request.responseText;
             var error = null;
 
@@ -110,6 +110,10 @@ HttpProvider.prototype.send = function (payload, callback) {
             _this.connected = true;
             callback(error, result);
         }
+    };
+
+    request.onerror = function() {
+        callback(errors.RequestFailed());
     };
 
     request.ontimeout = function() {

--- a/packages/web3-providers-http/src/index.js
+++ b/packages/web3-providers-http/src/index.js
@@ -125,7 +125,7 @@ HttpProvider.prototype.send = function (payload, callback) {
         request.send(JSON.stringify(payload));
     } catch(error) {
         this.connected = false;
-        callback(errors.InvalidConnection(this.host));
+        callback(errors.InvalidConnection(this.host, { code: 'ECONNREFUSED', reason: 'ECONNREFUSED' }));
     }
 };
 

--- a/packages/web3-providers-http/src/index.js
+++ b/packages/web3-providers-http/src/index.js
@@ -112,9 +112,15 @@ HttpProvider.prototype.send = function (payload, callback) {
         }
     };
 
-    request.onerror = function() {
-        callback(errors.RequestFailed());
-    };
+	//since XHR2._onHttpRequestError swallows the initial request error, we need to get it from the underlying request
+	request.addEventListener('loadstart', function() {
+		var clientRequest = request._request;
+		if (clientRequest) {
+			clientRequest.on('error', function (error) {
+				callback(error || errors.RequestFailed());
+			});
+		}		
+	});
 
     request.ontimeout = function() {
         _this.connected = false;

--- a/test/helpers/FakeXHR2.js
+++ b/test/helpers/FakeXHR2.js
@@ -5,6 +5,7 @@ var assert = chai.assert;
 var FakeXHR2 = function () {
     this.responseText = undefined;
     this.readyState = 4;
+    this.status = 200;
     this.onreadystatechange = null;
     this.async = true;
     this.agents = {};

--- a/test/helpers/FakeXHR2.js
+++ b/test/helpers/FakeXHR2.js
@@ -39,4 +39,8 @@ FakeXHR2.prototype.send = function (payload) {
     }
 };
 
+FakeXHR2.prototype.addEventListener = function(eventType, callback) {
+	callback();
+}
+
 module.exports = {XMLHttpRequest: FakeXHR2};


### PR DESCRIPTION
## Description

Adds explicit handling for XMLHttpRequest errors.

When an XMLHttpRequest fails, instead of throwing `Error: Invalid JSON RPC response: ""` throw `Error: HTTP request failed` with error code and other details.

Fixes #3425.

Details: HttpProvider uses `xhr2-cookies` for Node HTTP requests. This package catches and propagates HTTP errors but swallows the actual error. In other words, we know that something wrong happened but we don't know what exactly, see https://github.com/souldreamer/xhr2-cookies/issues/9. I'm accessing a private variable that references the underlying ClientRequest to get the error information and pass it upstream.

BTW, "xhr2-cookies" is not maintained anymore, the last commit was done 3 years ago. I think it would be safer to update to something else, maybe "node-xhr2" which has the same API.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. _This is an internal fix so no documentation changes should be necessary._
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success. _TBH I had a few unrelated tests failing, but they were failing before my changes, see #3946._
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code. _Not applicable_
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
