### PR TITLE
Add 3.x to build triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,14 @@ on:
     push:
         branches:
             - "1.x"
+            - "3.x"
         tags:
             - v1*
+            - v3*
     pull_request:
         branches:
             - "1.x"
+            - "3.x"
         types: [opened, reopened, synchronize]
 jobs:
     lint:


### PR DESCRIPTION
Update Github workflow to run tests on pushes and PRs to `3.x`

### Note

I'm not sure if this change needs to be applied to `1.x` as most changes to `1.x` will need to be merged into `3.x`, and I'm not sure if the tests will run with current settings