### PR TITLE
Update ganache-core repo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,6 +376,10 @@ Released with 1.0.0-beta.37 code base.
 
 ## [3.0.0]
 
+### Changed
+
+- Update `e2e.ganahce.core.sh` to point to ChainSafe's fork of `ganache-core`
+
 ### Removed
 
 - removed bzz and shh api

--- a/scripts/e2e.ganache.core.sh
+++ b/scripts/e2e.ganache.core.sh
@@ -9,9 +9,9 @@
 set -o errexit
 
 # Install ganache-core
-git clone https://github.com/trufflesuite/ganache-core
+git clone https://github.com/ChainSafe/ganache-core
 cd ganache-core
-git checkout tags/v2.13.0
+git checkout 2.13.2-overflow-fix
 
 # Install via registry and verify
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"


### PR DESCRIPTION
Updates URL for `e2e.ganache.core.sh` to ChainSafe's fork of the repo to fix tests