### PR TITLE
Fix types for unsubscribe

### DIFF
--- a/packages/web3-core-subscriptions/types/index.d.ts
+++ b/packages/web3-core-subscriptions/types/index.d.ts
@@ -28,9 +28,7 @@ export class Subscription<T> {
 
     subscribe(callback?: (error: Error, result: T) => void): Subscription<T>;
 
-    unsubscribe(
-        callback?: (error: Error, result: boolean) => void
-    ): Promise<undefined | boolean>;
+    unsubscribe(callback?: (error: Error, result: boolean) => void): void;
 
     on(type: 'data', handler: (data: T) => void): Subscription<T>;
 

--- a/packages/web3-core-subscriptions/types/tests/subscriptions.tests.ts
+++ b/packages/web3-core-subscriptions/types/tests/subscriptions.tests.ts
@@ -75,7 +75,7 @@ subscription.lastBlock;
 // $ExpectType Subscription<unknown>
 subscription.subscribe(() => {});
 
-// $ExpectType Promise<boolean | undefined>
+// $ExpectType void
 subscription.unsubscribe(() => {});
 
 // $ExpectType Subscription<unknown>


### PR DESCRIPTION
## Description

Fix types for unsubscribe.

```js
Subscription.prototype.unsubscribe = function(callback) {
    this.options.requestManager.removeSubscription(this.id, callback);
    this.id = null;
    this.lastBlock = null;
    this.removeAllListeners();
};
```

This function always return void.

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
