### PR TITLE
Bug fix for older versions of Safari 

### DIFF
--- a/packages/web3-core-requestmanager/src/index.js
+++ b/packages/web3-core-requestmanager/src/index.js
@@ -126,9 +126,9 @@ RequestManager.prototype.setProvider = function (provider, net) {
         });
 
         // notify all subscriptions about the error condition
-        this.provider.on('error', function error(error) {
+        this.provider.on('error', function error(e) {
             _this.subscriptions.forEach(function (subscription) {
-                subscription.callback(error);
+                subscription.callback(e);
             });
         });
 


### PR DESCRIPTION
Mangling named functions in strict mode can cause syntax errors in older versions of Safari

## Description

A bug that breaks everything on iOS <= 10 and Mac OS X <= 10.11:
```SyntaxError "Cannot declare a parameter named 'error' as it shadows the name of a strict mode function."```

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
