### PR TITLE
web3-eth types refactor and doc block refresh

### DIFF
--- a/packages/web3-eth/src/index.ts
+++ b/packages/web3-eth/src/index.ts
@@ -15,18 +15,7 @@ import {
 import {
     Web3EthOptions,
     EthTransaction,
-    EthCallTransaction,
     BlockIdentifier,
-    Web3EthResult,
-    EthSyncingResult,
-    EthBooleanResult,
-    EthAccountsResult,
-    EthBlockResult,
-    EthTransactionResult,
-    EthTransactionReceiptResult,
-    EthStringArrayResult,
-    EthCompiledSolidityResult,
-    EthLogResult,
     EthFilter,
     BlockTags,
     RpcStringResult,
@@ -38,6 +27,10 @@ import {
     RpcBlockResult,
     RpcTransactionResult,
     RpcTransactionReceiptResult,
+    RpcStringArrayResult,
+    RpcCompiledSolidityResult,
+    RpcLogResult,
+    EthCallTransaction,
 } from '../types';
 
 export default class Web3Eth {
@@ -963,9 +956,6 @@ export default class Web3Eth {
                         value: transaction.value
                             ? toHex(transaction.value)
                             : undefined,
-                        nonce: transaction.nonce
-                            ? toHex(transaction.nonce)
-                            : undefined,
                     },
                 ],
                 callOptions,
@@ -1306,7 +1296,13 @@ export default class Web3Eth {
                 ...response,
                 result: formatRpcResultArray(
                     response.result,
-                    ['blockNumber', 'cumulativeGasUsed', 'gasUsed'],
+                    [
+                        'transactionIndex',
+                        'blockNumber',
+                        'cumulativeGasUsed',
+                        'gasUsed',
+                        'status',
+                    ],
                     callOptions?.returnType || this._defaultReturnType
                 ),
             };
@@ -1328,7 +1324,7 @@ export default class Web3Eth {
         blockHash: PrefixedHexString,
         uncleIndex: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthBlockResult | SubscriptionResponse> {
+    ): Promise<RpcBlockResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1380,7 +1376,7 @@ export default class Web3Eth {
         blockIdentifier: BlockIdentifier,
         uncleIndex: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthBlockResult | SubscriptionResponse> {
+    ): Promise<RpcBlockResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1428,7 +1424,7 @@ export default class Web3Eth {
      */
     async getCompilers(
         callOptions?: CallOptions
-    ): Promise<EthStringArrayResult | SubscriptionResponse> {
+    ): Promise<RpcStringArrayResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_getCompilers',
@@ -1454,7 +1450,7 @@ export default class Web3Eth {
     async compileSolidity(
         sourceCode: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<EthCompiledSolidityResult | SubscriptionResponse> {
+    ): Promise<RpcCompiledSolidityResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1482,7 +1478,7 @@ export default class Web3Eth {
     async compileLLL(
         sourceCode: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1508,7 +1504,7 @@ export default class Web3Eth {
     async compileSerpent(
         sourceCode: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1540,7 +1536,7 @@ export default class Web3Eth {
     async newFilter(
         filter: EthFilter,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1586,7 +1582,7 @@ export default class Web3Eth {
      */
     async newBlockFilter(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_newBlockFilter',
@@ -1618,7 +1614,7 @@ export default class Web3Eth {
      */
     async newPendingTransactionFilter(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_newPendingTransactionFilter',
@@ -1654,7 +1650,7 @@ export default class Web3Eth {
     async uninstallFilter(
         filterId: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthBooleanResult | SubscriptionResponse> {
+    ): Promise<RpcBooleanResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1681,7 +1677,7 @@ export default class Web3Eth {
     async getFilterChanges(
         filterId: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthLogResult | SubscriptionResponse> {
+    ): Promise<RpcLogResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1717,7 +1713,7 @@ export default class Web3Eth {
     async getFilterLogs(
         filterId: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthLogResult | SubscriptionResponse> {
+    ): Promise<RpcLogResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1752,7 +1748,7 @@ export default class Web3Eth {
     async getLogs(
         filter: EthFilter,
         callOptions?: CallOptions
-    ): Promise<EthLogResult | SubscriptionResponse> {
+    ): Promise<RpcLogResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1799,7 +1795,7 @@ export default class Web3Eth {
      */
     async getWork(
         callOptions?: CallOptions
-    ): Promise<EthStringArrayResult | SubscriptionResponse> {
+    ): Promise<RpcStringArrayResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_getWork',
@@ -1829,7 +1825,7 @@ export default class Web3Eth {
         powHash: PrefixedHexString,
         digest: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<EthBooleanResult | SubscriptionResponse> {
+    ): Promise<RpcBooleanResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1861,7 +1857,7 @@ export default class Web3Eth {
         hashRate: ValidTypes,
         clientId: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthBooleanResult | SubscriptionResponse> {
+    ): Promise<RpcBooleanResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,

--- a/packages/web3-eth/src/index.ts
+++ b/packages/web3-eth/src/index.ts
@@ -29,6 +29,15 @@ import {
     EthLogResult,
     EthFilter,
     BlockTags,
+    RpcStringResult,
+    RpcPrefixedHexStringResult,
+    RpcValidTypeResult,
+    RpcBooleanResult,
+    RpcSyncingResult,
+    RpcAccountsResult,
+    RpcBlockResult,
+    RpcTransactionResult,
+    RpcTransactionReceiptResult,
 } from '../types';
 
 export default class Web3Eth {
@@ -86,7 +95,7 @@ export default class Web3Eth {
      */
     async getClientVersion(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'web3_clientVersion',
@@ -101,7 +110,6 @@ export default class Web3Eth {
         }
     }
 
-    // TODO Discuss input format
     /**
      * Returns Keccak-256 (not the standardized SHA3-256) of the given data
      * @param {string} data Data to convert into SHA3 hash
@@ -113,7 +121,7 @@ export default class Web3Eth {
     async getSha3(
         data: string,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -137,7 +145,7 @@ export default class Web3Eth {
      */
     async getNetworkVersion(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'net_version',
@@ -169,7 +177,7 @@ export default class Web3Eth {
      */
     async getNetworkListening(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcBooleanResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'net_listening',
@@ -193,7 +201,7 @@ export default class Web3Eth {
      */
     async getNetworkPeerCount(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'net_peerCount',
@@ -225,7 +233,7 @@ export default class Web3Eth {
      */
     async getProtocolVersion(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_protocolVersion',
@@ -257,7 +265,7 @@ export default class Web3Eth {
      */
     async getSyncing(
         callOptions?: CallOptions
-    ): Promise<EthSyncingResult | SubscriptionResponse> {
+    ): Promise<RpcSyncingResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_syncing',
@@ -270,12 +278,14 @@ export default class Web3Eth {
             const response = await this._send(...requestParameters);
             return {
                 ...response,
-                result: formatRpcResultArray(
-                    // @ts-ignore
-                    response.result,
-                    ['startingBlock', 'currentBlock', 'highestBlock'],
-                    this._defaultReturnType
-                ),
+                result:
+                    typeof response.result === 'boolean'
+                        ? response.result
+                        : formatRpcResultArray(
+                              response.result,
+                              ['startingBlock', 'currentBlock', 'highestBlock'],
+                              this._defaultReturnType
+                          ),
             };
         } catch (error) {
             throw Error(`Error getting syncing status: ${error.message}`);
@@ -291,7 +301,7 @@ export default class Web3Eth {
      */
     async getCoinbase(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_coinbase',
@@ -315,7 +325,7 @@ export default class Web3Eth {
      */
     async getMining(
         callOptions?: CallOptions
-    ): Promise<EthBooleanResult | SubscriptionResponse> {
+    ): Promise<RpcBooleanResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_mining',
@@ -339,7 +349,7 @@ export default class Web3Eth {
      */
     async getHashRate(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_hashrate',
@@ -371,7 +381,7 @@ export default class Web3Eth {
      */
     async getGasPrice(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_gasPrice',
@@ -403,7 +413,7 @@ export default class Web3Eth {
      */
     async getAccounts(
         callOptions?: CallOptions
-    ): Promise<EthAccountsResult | SubscriptionResponse> {
+    ): Promise<RpcAccountsResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_accounts',
@@ -427,7 +437,7 @@ export default class Web3Eth {
      */
     async getBlockNumber(
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [string, [], CallOptions | undefined] = [
                 'eth_blockNumber',
@@ -463,7 +473,7 @@ export default class Web3Eth {
         address: PrefixedHexString,
         blockIdentifier: BlockIdentifier,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -510,7 +520,7 @@ export default class Web3Eth {
         storagePosition: ValidTypes,
         blockIdentifier: BlockIdentifier,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -522,16 +532,9 @@ export default class Web3Eth {
                 callOptions,
             ];
 
-            if (callOptions?.subscribe)
-                return await this._subscribe(...requestParameters);
-            const response = await this._send(...requestParameters);
-            return {
-                ...response,
-                result: formatOutput(
-                    response.result,
-                    callOptions?.returnType || this._defaultReturnType
-                ),
-            };
+            return callOptions?.subscribe
+                ? await this._subscribe(...requestParameters)
+                : await this._send(...requestParameters);
         } catch (error) {
             throw Error(`Error getting storage value: ${error.message}`);
         }
@@ -550,7 +553,7 @@ export default class Web3Eth {
         address: PrefixedHexString,
         blockIdentifier: BlockIdentifier,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -577,7 +580,6 @@ export default class Web3Eth {
         }
     }
 
-    // TODO Discuss input format
     /**
      * Returns the number of transactions in a block from a block matching the given block hash
      * @param {string} blockHash Hash of block to query transaction count of
@@ -589,7 +591,7 @@ export default class Web3Eth {
     async getBlockTransactionCountByHash(
         blockHash: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -629,7 +631,7 @@ export default class Web3Eth {
     async getBlockTransactionCountByNumber(
         blockIdentifier: BlockIdentifier,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -658,7 +660,6 @@ export default class Web3Eth {
         }
     }
 
-    // TODO Discuss input format
     /**
      * Returns the number of uncles in a block from a block matching the given block hash
      * @param {string} blockHash Hash of block to query
@@ -670,7 +671,7 @@ export default class Web3Eth {
     async getUncleCountByBlockHash(
         blockHash: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -706,7 +707,7 @@ export default class Web3Eth {
     async getUncleCountByBlockNumber(
         blockIdentifier: BlockIdentifier,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -748,7 +749,7 @@ export default class Web3Eth {
         address: PrefixedHexString,
         blockIdentifier: BlockIdentifier,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -763,7 +764,6 @@ export default class Web3Eth {
         }
     }
 
-    // TODO Discuss input format
     /**
      * Calculates an Ethereum specific signature
      * @param {string} address Address to use to sign {data}
@@ -777,7 +777,7 @@ export default class Web3Eth {
         address: PrefixedHexString,
         message: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -810,7 +810,7 @@ export default class Web3Eth {
     async signTransaction(
         transaction: EthTransaction,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -863,7 +863,7 @@ export default class Web3Eth {
     async sendTransaction(
         transaction: EthTransaction,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -909,7 +909,7 @@ export default class Web3Eth {
     async sendRawTransaction(
         rawTransaction: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcPrefixedHexStringResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -924,7 +924,7 @@ export default class Web3Eth {
         }
     }
 
-    // TODO Discuss formatting result type
+    // TODO Discuss formatting result
     /**
      * Executes a new message call immediately without creating a transaction on the block chain
      * @param {object} transaction Ethereum transaction
@@ -943,7 +943,7 @@ export default class Web3Eth {
     async call(
         transaction: EthCallTransaction,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcResponse | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -996,7 +996,7 @@ export default class Web3Eth {
     async estimateGas(
         transaction: EthTransaction,
         callOptions?: CallOptions
-    ): Promise<Web3EthResult | SubscriptionResponse> {
+    ): Promise<RpcValidTypeResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1052,7 +1052,7 @@ export default class Web3Eth {
         blockHash: PrefixedHexString,
         returnFullTxs: boolean,
         callOptions?: CallOptions
-    ): Promise<EthBlockResult | SubscriptionResponse> {
+    ): Promise<RpcBlockResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1098,7 +1098,7 @@ export default class Web3Eth {
         blockIdentifier: BlockIdentifier,
         returnFullTxs: boolean,
         callOptions?: CallOptions
-    ): Promise<EthBlockResult | SubscriptionResponse> {
+    ): Promise<RpcBlockResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1146,7 +1146,7 @@ export default class Web3Eth {
     async getTransactionByHash(
         txHash: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<EthTransactionResult | SubscriptionResponse> {
+    ): Promise<RpcTransactionResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1191,7 +1191,7 @@ export default class Web3Eth {
         blockHash: PrefixedHexString,
         transactionIndex: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthTransactionResult | SubscriptionResponse> {
+    ): Promise<RpcTransactionResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1242,7 +1242,7 @@ export default class Web3Eth {
         blockIdentifier: BlockIdentifier,
         transactionIndex: ValidTypes,
         callOptions?: CallOptions
-    ): Promise<EthTransactionResult | SubscriptionResponse> {
+    ): Promise<RpcTransactionResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,
@@ -1291,7 +1291,7 @@ export default class Web3Eth {
     async getTransactionReceipt(
         txHash: PrefixedHexString,
         callOptions?: CallOptions
-    ): Promise<EthTransactionReceiptResult | SubscriptionResponse> {
+    ): Promise<RpcTransactionReceiptResult | SubscriptionResponse> {
         try {
             const requestParameters: [
                 string,

--- a/packages/web3-eth/src/index.ts
+++ b/packages/web3-eth/src/index.ts
@@ -81,9 +81,13 @@ export default class Web3Eth {
 
     /**
      * Returns the current client version
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Client version
      */
     async getClientVersion(
@@ -106,9 +110,13 @@ export default class Web3Eth {
     /**
      * Returns Keccak-256 (not the standardized SHA3-256) of the given data
      * @param {string} data Data to convert into SHA3 hash
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} SHA3 hash of {data}
      */
     async getSha3(
@@ -131,9 +139,13 @@ export default class Web3Eth {
 
     /**
      * Returns the current network version
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Current network version
      */
     async getNetworkVersion(
@@ -163,9 +175,13 @@ export default class Web3Eth {
 
     /**
      * Returns true if client is actively listening for network connections
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} true if currently listening, otherwise false
      */
     async getNetworkListening(
@@ -187,9 +203,13 @@ export default class Web3Eth {
 
     /**
      * Returns number of peers currently connected to the client
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} true if currently listening, otherwise false
      */
     async getNetworkPeerCount(
@@ -219,9 +239,13 @@ export default class Web3Eth {
 
     /**
      * Returns the current ethereum protocol version
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} The current ethereum protocol version
      */
     async getProtocolVersion(
@@ -251,9 +275,13 @@ export default class Web3Eth {
 
     /**
      * Returns an object with data about the sync status or false when not syncing
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Object with sync status data or false when not syncing
      */
     async getSyncing(
@@ -287,9 +315,13 @@ export default class Web3Eth {
 
     /**
      * Returns the client's coinbase address
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} The current coinbase address
      */
     async getCoinbase(
@@ -311,9 +343,13 @@ export default class Web3Eth {
 
     /**
      * Returns true if client is actively mining new blocks
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} true if the client is mining, otherwise false
      */
     async getMining(
@@ -335,9 +371,13 @@ export default class Web3Eth {
 
     /**
      * Returns the number of hashes per second that the node is mining with
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Number of hashes per second
      */
     async getHashRate(
@@ -367,9 +407,13 @@ export default class Web3Eth {
 
     /**
      * Returns the current price per gas in wei
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing current gas price in wei
      */
     async getGasPrice(
@@ -399,9 +443,13 @@ export default class Web3Eth {
 
     /**
      * Returns a list of addresses owned by client.
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Array of addresses owned by the client
      */
     async getAccounts(
@@ -423,9 +471,13 @@ export default class Web3Eth {
 
     /**
      * Returns the number of most recent block
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing current block number client is on
      */
     async getBlockNumber(
@@ -457,9 +509,13 @@ export default class Web3Eth {
      * Returns the balance of the account of given address
      * @param {string} address Address to get balance of
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing current balance in wei
      */
     async getBalance(
@@ -503,9 +559,13 @@ export default class Web3Eth {
      * @param {string} address Address of storage to query
      * @param {string} storagePosition Hex string representing position in storage to retrieve
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing value at {storagePosition}
      */
     async getStorageAt(
@@ -537,9 +597,13 @@ export default class Web3Eth {
      * Returns the number of transactions sent from an address
      * @param {string} address Address to get transaction count of
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing number of transactions sent by {address}
      */
     async getTransactionCount(
@@ -576,9 +640,13 @@ export default class Web3Eth {
     /**
      * Returns the number of transactions in a block from a block matching the given block hash
      * @param {string} blockHash Hash of block to query transaction count of
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing number of transactions in block
      */
     async getBlockTransactionCountByHash(
@@ -616,9 +684,13 @@ export default class Web3Eth {
     /**
      * Returns the number of transactions in a block from a block matching the given block number
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing number of transactions in block
      */
     async getBlockTransactionCountByNumber(
@@ -656,9 +728,13 @@ export default class Web3Eth {
     /**
      * Returns the number of uncles in a block from a block matching the given block hash
      * @param {string} blockHash Hash of block to query
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing number of uncles in block
      */
     async getUncleCountByBlockHash(
@@ -692,9 +768,13 @@ export default class Web3Eth {
     /**
      * Returns the number of uncles in a block from a block matching the given block number
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing number of uncles in block
      */
     async getUncleCountByBlockNumber(
@@ -733,9 +813,13 @@ export default class Web3Eth {
      * Returns code at a given address
      * @param {string} address Address to get code at
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing the code at {address}
      */
     async getCode(
@@ -761,9 +845,13 @@ export default class Web3Eth {
      * Calculates an Ethereum specific signature
      * @param {string} address Address to use to sign {data}
      * @param {string} message Message to sign
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing signed message
      */
     async sign(
@@ -795,9 +883,13 @@ export default class Web3Eth {
      * @param {string} transaction.value Hex string representing number of Wei to send to {to}
      * @param {string} transaction.data Hex string representing compiled code of a contract or the hash of the invoked method signature and encoded parameters
      * @param {string} transaction.nonce Can be used to overwrite pending transactions that use the same nonce
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing signed message
      */
     async signTransaction(
@@ -848,9 +940,13 @@ export default class Web3Eth {
      * @param {string} transaction.value Hex string representing number of Wei to send to {to}
      * @param {string} transaction.data Hex string representing compiled code of a contract or the hash of the invoked method signature and encoded parameters
      * @param {string} transaction.nonce Can be used to overwrite pending transactions that use the same nonce
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Transaction hash or zero hash if the transaction is not yet available
      */
     async sendTransaction(
@@ -894,9 +990,13 @@ export default class Web3Eth {
     /**
      * Submits a previously signed transaction object to the network
      * @param {string} rawTransaction Hex string representing previously signed transaction
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Transaction hash or zero hash if the transaction is not yet available
      */
     async sendRawTransaction(
@@ -928,9 +1028,13 @@ export default class Web3Eth {
      * @param {string} transaction.value Hex string representing number of Wei to send to {to}
      * @param {string} transaction.data Hash of the method signature and encoded parameters
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing return value of executed contract
      */
     async call(
@@ -978,9 +1082,13 @@ export default class Web3Eth {
      * @param {string} transaction.value Hex string representing number of Wei to send to {to} (optional)
      * @param {string} transaction.data Hash of the method signature and encoded parameters (optional)
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Hex string representing estimated amount of gas to be used
      */
     async estimateGas(
@@ -1033,9 +1141,13 @@ export default class Web3Eth {
      * Returns information about a block by hash
      * @param {string} blockHash Hash of block to get information for
      * @param {boolean} returnFullTxs If true it returns the full transaction objects, if false returns only the hashes of the transactions
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A block object or null when no block was found
      */
     async getBlockByHash(
@@ -1079,9 +1191,13 @@ export default class Web3Eth {
      * Returns information about a block by number
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
      * @param {boolean} returnFullTxs If true it returns the full transaction objects, if false returns only the hashes of the transactions
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A block object or null when no block was found
      */
     async getBlockByNumber(
@@ -1128,9 +1244,13 @@ export default class Web3Eth {
     /**
      * Returns the information about a transaction requested by transaction hash
      * @param {string} txHash Hash of transaction to retrieve
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A transaction object or {null} when no transaction was found
      */
     async getTransactionByHash(
@@ -1172,9 +1292,13 @@ export default class Web3Eth {
      * Returns information about a transaction by block hash and transaction index position
      * @param {string} blockHash Hash of block to get transactions of
      * @param {string} transactionIndex Hex string representing index of transaction to return
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A transaction object or {null} when no transaction was found
      */
     async getTransactionByBlockHashAndIndex(
@@ -1223,9 +1347,13 @@ export default class Web3Eth {
      * Returns information about a transaction by block number and transaction index position
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
      * @param {string} transactionIndex Hex string representing index of transaction to return
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A transaction object or {null} when no transaction was found
      */
     async getTransactionByBlockNumberAndIndex(
@@ -1273,9 +1401,13 @@ export default class Web3Eth {
     /**
      * Returns the receipt of a transaction by transaction hash
      * @param {string} txHash Hash of transaction to get receipt of
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A transaction object or {null} when no receipt was found
      */
     async getTransactionReceipt(
@@ -1315,9 +1447,13 @@ export default class Web3Eth {
      * Returns information about a uncle of a block by hash and uncle index position
      * @param {string} blockHash Hash of block to get uncles of
      * @param {string} uncleIndex Index of uncle to retrieve
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A block object or null when no block was found
      */
     async getUncleByBlockHashAndIndex(
@@ -1367,9 +1503,13 @@ export default class Web3Eth {
      * Returns information about a uncle of a block by number and uncle index position
      * @param {string|number} blockIdentifier Integer or hex string representing block number, or "latest", "earliest", "pending"
      * @param {string} uncleIndex Index of uncle to retrieve
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A block object or null when no block was found
      */
     async getUncleByBlockNumberAndIndex(
@@ -1417,9 +1557,13 @@ export default class Web3Eth {
 
     /**
      * Returns a list of available compilers in the client
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} A list of available compilers
      */
     async getCompilers(
@@ -1442,9 +1586,13 @@ export default class Web3Eth {
     /**
      * Returns compiled solidity code
      * @param {string} sourceCode Solidity code to be compiled
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} compiled {sourceCode}
      */
     async compileSolidity(
@@ -1470,9 +1618,13 @@ export default class Web3Eth {
     /**
      * Returns compiled LLL code
      * @param {string} sourceCode LLL code to be compiled
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} compiled {sourceCode}
      */
     async compileLLL(
@@ -1496,9 +1648,13 @@ export default class Web3Eth {
     /**
      * Returns compiled serpent code
      * @param {string} sourceCode Serpent code to be compiled
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} compiled {sourceCode}
      */
     async compileSerpent(
@@ -1528,9 +1684,13 @@ export default class Web3Eth {
      * @param {string|number} filter.toBlock End filter at integer block number or "latest", "earliest", "pending"
      * @param {string|string[]} filter.address: Contract address or list of addresses from which logs should originate
      * @param {string[]} filter.topics Topics to use for filtering (optional)
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Filter id
      */
     async newFilter(
@@ -1575,9 +1735,13 @@ export default class Web3Eth {
 
     /**
      * Creates a filter in the node, to notify when a new block arrives
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Filter id
      */
     async newBlockFilter(
@@ -1607,9 +1771,13 @@ export default class Web3Eth {
 
     /**
      * Creates a filter in the node, to notify when new pending transactions arrive
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Filter id
      */
     async newPendingTransactionFilter(
@@ -1642,9 +1810,13 @@ export default class Web3Eth {
     /**
      * Uninstalls a filter with given id. Should always be called when watch is no longer needed
      * @param {string} filterId Id of filter to uninstall from node
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Returns true if filter was successfully uninstalled, otherwise false
      */
     async uninstallFilter(
@@ -1669,9 +1841,13 @@ export default class Web3Eth {
     /**
      * Polling method for a filter, which returns an array of logs which occurred since last poll
      * @param {string} filterid Id of filter to retrieve changes from
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Array of log objects, or an empty array if nothing has changed since last poll
      */
     async getFilterChanges(
@@ -1705,9 +1881,13 @@ export default class Web3Eth {
     /**
      * Returns an array of all logs matching filter with given id
      * @param {string} filterid Id of filter to retrieve
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Array of log objects, or an empty array if nothing has changed since last poll
      */
     async getFilterLogs(
@@ -1740,9 +1920,13 @@ export default class Web3Eth {
     // TODO Formatting output could be intensive since {response} is an array of results
     /**
      * Returns an array of all logs matching a given filter object
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Array of log objects, or an empty array if nothing has changed since last poll
      */
     async getLogs(
@@ -1788,9 +1972,13 @@ export default class Web3Eth {
 
     /**
      * Returns the hash of the current block, the seedHash, and the boundary condition to be met (“target”)
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Array of work info (in order: current block header pow-hash, seed hash used for the DAG, and boundary condition (“target”), 2^256 / difficulty)
      */
     async getWork(
@@ -1815,9 +2003,13 @@ export default class Web3Eth {
      * @param {string} nonce Hex string representing found nonce (64 bits)
      * @param {string} powHash Hex string representing POW hash (256 bits)
      * @param {string} digest Hex string representing mix digest (256 bits)
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Returns true if the provided solution is valid, otherwise false
      */
     async submitWork(
@@ -1848,9 +2040,13 @@ export default class Web3Eth {
      * Used for submitting mining hashrate
      * @param {string} hashRate Hex string representing desired hash rate (32 bytes)
      * @param {string} clientId Hex string representing ID identifying the client
-     * @param {object} rpcOptions RPC options
-     * @param {number} rpcOptions.id ID used to identify request
-     * @param {string} rpcOptions.jsonrpc JSON RPC version
+     * @param {object} callOptions
+     * @param {object} callOptions.providerCallOptions Varies based on provider type (e.g. HttpOptions)
+     * @param {object} callOptions.rpcOptions
+     * @param {number} callOptions.rpcOptions.id (Optional) Id to pass along with RPC request. Gets returned by RPC node
+     * @param {string} callOptions.rpcOptions.jsonrpc (Optional) Version of JSON RPC version
+     * @param {string} callOptions.returnType (Optional) Desired return type of formattable outputs
+     * @param {boolean} callOptions.subscribe (Optional) If true, returns Node.js EventEmitter and polls
      * @returns {Promise} Returns true if the provided solution is valid, otherwise false
      */
     async submitHashRate(

--- a/packages/web3-eth/test/unit/testConfig.ts
+++ b/packages/web3-eth/test/unit/testConfig.ts
@@ -171,7 +171,6 @@ export const testConfig: TestConfig = {
                 result: '0x000000000000000000000000000000000000000000000000000000000000162e',
             },
             testInputFormatter: true,
-            testOutputFormatter: true,
             formattableInputProperties: ['storagePosition', 'blockIdentifier'],
         },
         {

--- a/packages/web3-eth/types.ts
+++ b/packages/web3-eth/types.ts
@@ -43,63 +43,37 @@ export type EthTransaction = {
     nonce?: ValidTypes;
 };
 
+/**
+ * @param gas eth_call consumes zero gas, but this parameter may be needed by some executions
+ */
+export type EthCallTransaction = {
+    from: PrefixedHexString;
+    to: PrefixedHexString;
+    gas?: ValidTypes;
+    gasPrice?: ValidTypes;
+    value?: ValidTypes;
+    data?: PrefixedHexString;
+};
+
 export type EthMinedTransaction = {
-    blockHash: string | null;
-    blockNumber: string | null;
-    from: string;
-    gas: string;
-    gasPrice: string;
-    hash: string;
-    input: string;
-    nonce: string;
-    to: string | null;
-    transactionIndex: string | null;
-    value: string;
-    v: string;
-    r: string;
-    s: string;
+    blockHash: PrefixedHexString | null;
+    blockNumber: ValidTypes | null;
+    from: PrefixedHexString;
+    gas: ValidTypes;
+    gasPrice: ValidTypes;
+    hash: PrefixedHexString;
+    input: PrefixedHexString;
+    nonce: ValidTypes;
+    to: PrefixedHexString | null;
+    transactionIndex: ValidTypes | null;
+    value: ValidTypes;
+    v: ValidTypes;
+    r: PrefixedHexString;
+    s: PrefixedHexString;
 };
 
-export type EthBlock = {
-    number: string | null;
-    hash: string | null;
-    parentHash: string;
-    nonce: string | null;
-    sha3Uncles: string;
-    logsBloom: string | null;
-    transactionsRoot: string;
-    stateRoot: string;
-    receiptsRoot: string;
-    miner: string;
-    difficulty: string;
-    totalDifficulty: string;
-    extraData: string;
-    size: string;
-    gasLimit: string;
-    gasUsed: string;
-    timestamp: string;
-    transactions: EthMinedTransaction[];
-    uncles: string[];
-    root?: string;
-    status?: string;
-};
-
-export type EthTransactionReceipt = {
-    transactionHash: string;
-    transactionIndex: string;
-    blockHash: string;
-    blockNumber: string;
-    from: string;
-    to: string | null;
-    cumulativeGasUsed: string;
-    gasUsed: string;
-    contractAdress: string | null;
-    logs: EthLog[];
-    logsBloom: string;
-};
-
-export type EthCompiledSolidity = {
-    code: string;
+export type CompiledSolidity = {
+    code: PrefixedHexString;
     info: {
         source: string;
         language: string;
@@ -164,7 +138,7 @@ export interface RpcBlockResult extends RpcResponse {
         number: ValidTypes | null;
         hash: PrefixedHexString | null;
         parentHash: PrefixedHexString;
-        nonce: ValidTypes | null;
+        nonce: PrefixedHexString | null;
         sha3Uncles: PrefixedHexString;
         logsBloom: PrefixedHexString | null;
         transactionsRoot: PrefixedHexString;
@@ -178,7 +152,7 @@ export interface RpcBlockResult extends RpcResponse {
         gasLimit: ValidTypes;
         gasUsed: ValidTypes;
         timestamp: ValidTypes;
-        transactions: PrefixedHexString[];
+        transactions: EthMinedTransaction[] | PrefixedHexString[];
         uncles: PrefixedHexString[];
     };
 }
@@ -215,51 +189,19 @@ export interface RpcTransactionReceiptResult extends RpcResponse {
         contractAddress: PrefixedHexString | null;
         logs: EthLog[];
         logsBloom: PrefixedHexString;
+        root?: PrefixedHexString;
+        status?: ValidTypes;
     };
 }
 
-export interface EthCallTransaction extends EthTransaction {
-    to: string;
-}
-
-export interface EthStringArrayResult extends RpcResponse {
+export interface RpcStringArrayResult extends RpcResponse {
     result: string[];
 }
 
-export interface EthBooleanResult extends RpcResponse {
-    result: boolean;
+export interface RpcCompiledSolidityResult extends RpcResponse {
+    result: CompiledSolidity;
 }
 
-export interface EthSyncingResult extends RpcResponse {
-    result:
-        | {
-              startingBlock: string;
-              currentBlock: string;
-              highestBlock: string;
-          }
-        | false;
-}
-
-export interface EthAccountsResult extends RpcResponse {
-    result: string[];
-}
-
-export interface EthBlockResult extends RpcResponse {
-    result: EthBlock | null;
-}
-
-export interface EthTransactionResult extends RpcResponse {
-    result: EthMinedTransaction | null;
-}
-
-export interface EthTransactionReceiptResult extends RpcResponse {
-    result: EthTransactionReceipt | null;
-}
-
-export interface EthCompiledSolidityResult extends RpcResponse {
-    result: EthCompiledSolidity;
-}
-
-export interface EthLogResult extends RpcResponse {
-    result: EthLog[];
+export interface RpcLogResult extends RpcResponse {
+    result: EthLog;
 }

--- a/packages/web3-eth/types.ts
+++ b/packages/web3-eth/types.ts
@@ -13,17 +13,19 @@ export enum BlockTags {
 
 export type BlockIdentifier = ValidTypes | BlockTags;
 
-export type EthLog = {
-    removed: boolean;
-    logIndex: string | null;
-    transactionIndex: string | null;
-    transactionHash: string | null;
-    blockHash: string | null;
-    blockNumber: string | null;
-    address: string;
-    data: string;
-    topics: string[];
-};
+export type EthLog =
+    | PrefixedHexString[]
+    | {
+          removed: boolean;
+          logIndex: ValidTypes | null;
+          transactionIndex: ValidTypes | null;
+          transactionHash: PrefixedHexString | null;
+          blockHash: PrefixedHexString | null;
+          blockNumber: ValidTypes | null;
+          address: PrefixedHexString;
+          data: PrefixedHexString;
+          topics: PrefixedHexString[];
+      };
 
 /**
  * @param to is optional when creating a new contract
@@ -127,16 +129,97 @@ export interface Web3EthOptions {
     returnType?: ValidTypesEnum;
 }
 
-export interface EthCallTransaction extends EthTransaction {
-    to: string;
+export interface RpcStringResult extends RpcResponse {
+    result: string;
 }
 
-export interface Web3EthResult extends RpcResponse {
+export interface RpcPrefixedHexStringResult extends RpcResponse {
+    result: PrefixedHexString;
+}
+
+export interface RpcValidTypeResult extends RpcResponse {
     result: ValidTypes;
 }
 
-export interface EthStringResult extends RpcResponse {
-    result: string;
+export interface RpcBooleanResult extends RpcResponse {
+    result: boolean;
+}
+
+export interface RpcSyncingResult extends RpcResponse {
+    result:
+        | boolean
+        | {
+              startingBlock: ValidTypes;
+              currentBlock: ValidTypes;
+              highestBlock: ValidTypes;
+          };
+}
+
+export interface RpcAccountsResult extends RpcResponse {
+    result: PrefixedHexString[];
+}
+
+export interface RpcBlockResult extends RpcResponse {
+    result: null | {
+        number: ValidTypes | null;
+        hash: PrefixedHexString | null;
+        parentHash: PrefixedHexString;
+        nonce: ValidTypes | null;
+        sha3Uncles: PrefixedHexString;
+        logsBloom: PrefixedHexString | null;
+        transactionsRoot: PrefixedHexString;
+        stateRoot: PrefixedHexString;
+        receiptsRoot: PrefixedHexString;
+        miner: PrefixedHexString;
+        difficulty: ValidTypes;
+        totalDifficulty: ValidTypes;
+        extraData: PrefixedHexString;
+        size: ValidTypes;
+        gasLimit: ValidTypes;
+        gasUsed: ValidTypes;
+        timestamp: ValidTypes;
+        transactions: PrefixedHexString[];
+        uncles: PrefixedHexString[];
+    };
+}
+
+export interface RpcTransactionResult extends RpcResponse {
+    result: null | {
+        blockHash: PrefixedHexString | null;
+        blockNumber: ValidTypes | null;
+        from: PrefixedHexString;
+        gas: ValidTypes;
+        gasPrice: ValidTypes;
+        hash: PrefixedHexString;
+        input: PrefixedHexString;
+        nonce: ValidTypes;
+        to: PrefixedHexString | null;
+        transactionIndex: ValidTypes | null;
+        value: ValidTypes;
+        v: ValidTypes;
+        r: PrefixedHexString;
+        s: PrefixedHexString;
+    };
+}
+
+export interface RpcTransactionReceiptResult extends RpcResponse {
+    result: null | {
+        transactionHash: PrefixedHexString;
+        transactionIndex: ValidTypes;
+        blockHash: PrefixedHexString;
+        blockNumber: ValidTypes;
+        from: PrefixedHexString;
+        to: PrefixedHexString | null;
+        cumulativeGasUsed: ValidTypes;
+        gasUsed: ValidTypes;
+        contractAddress: PrefixedHexString | null;
+        logs: EthLog[];
+        logsBloom: PrefixedHexString;
+    };
+}
+
+export interface EthCallTransaction extends EthTransaction {
+    to: string;
 }
 
 export interface EthStringArrayResult extends RpcResponse {

--- a/packages/web3-providers-base/types.ts
+++ b/packages/web3-providers-base/types.ts
@@ -18,8 +18,7 @@ export type RpcResponseResult =
     | (string | number)[]
     | { [key: string]: string | number }
     | BigInt
-    | null
-    | any;
+    | null;
 
 export interface ProviderOptions {
     providerUrl: string;

--- a/packages/web3-providers-base/types.ts
+++ b/packages/web3-providers-base/types.ts
@@ -11,14 +11,6 @@ export type RpcParams = (
     | boolean
     | EthFilter
 )[];
-export type RpcResponseResult =
-    | string
-    | number
-    | boolean
-    | (string | number)[]
-    | { [key: string]: string | number }
-    | BigInt
-    | null;
 
 export interface ProviderOptions {
     providerUrl: string;
@@ -50,7 +42,7 @@ export interface SendOptions extends CallOptions {
 export interface RpcResponse {
     id: number;
     jsonrpc: string;
-    result: RpcResponseResult;
+    result: any;
 }
 
 export interface SubscriptionResponse {

--- a/packages/web3-utils/src/index.ts
+++ b/packages/web3-utils/src/index.ts
@@ -148,13 +148,17 @@ export function formatRpcResultArray(
                 // rpcResponseResult is an array of results
                 // e.g. an array of filter changes or logs
                 for (const result of rpcResponseResult) {
+                    // @ts-ignore We're indexing result as an object, not an array
                     result[formattableProperty] = formatOutput(
+                        // @ts-ignore We're indexing result as an object, not an array
                         result[formattableProperty],
                         desiredType
                     );
                 }
             } else {
+                // @ts-ignore We're indexing result as an object, not an array
                 formattedResponseResult[formattableProperty] = formatOutput(
+                    // @ts-ignore We're indexing result as an object, not an array
                     rpcResponseResult[formattableProperty],
                     desiredType
                 );

--- a/packages/web3-utils/src/index.ts
+++ b/packages/web3-utils/src/index.ts
@@ -1,4 +1,3 @@
-import { RpcResponseResult } from 'web3-providers-base/types';
 import { setLengthLeft, toBuffer } from 'ethereumjs-util';
 
 import { ValidTypes, ValidTypesEnum, PrefixedHexString } from '../types';
@@ -64,6 +63,8 @@ export function toHex(
     byteLength?: number
 ): PrefixedHexString {
     try {
+        if (input === null) throw Error('Cannot convert null input');
+
         let hexInput: PrefixedHexString;
         let parsedHexString: PrefixedHexString;
         switch (determineValidType(input)) {
@@ -137,10 +138,10 @@ export function formatOutput(
 }
 
 export function formatRpcResultArray(
-    rpcResponseResult: RpcResponseResult,
+    rpcResponseResult: any,
     formattableProperties: string[],
     desiredType: ValidTypesEnum
-): RpcResponseResult {
+): any {
     try {
         let formattedResponseResult = rpcResponseResult;
         for (const formattableProperty of formattableProperties) {
@@ -148,17 +149,13 @@ export function formatRpcResultArray(
                 // rpcResponseResult is an array of results
                 // e.g. an array of filter changes or logs
                 for (const result of rpcResponseResult) {
-                    // @ts-ignore We're indexing result as an object, not an array
                     result[formattableProperty] = formatOutput(
-                        // @ts-ignore We're indexing result as an object, not an array
                         result[formattableProperty],
                         desiredType
                     );
                 }
             } else {
-                // @ts-ignore We're indexing result as an object, not an array
                 formattedResponseResult[formattableProperty] = formatOutput(
-                    // @ts-ignore We're indexing result as an object, not an array
                     rpcResponseResult[formattableProperty],
                     desiredType
                 );


### PR DESCRIPTION
After removing the `any` that was mentioned [here](https://github.com/ChainSafe/web3.js/pull/4107#discussion_r652876857), a whole slew of type errors popped up, so I took the opportunity to redo the types used by `web3-eth` package.

Additionally, doc blocks have become stale, this PR updates those as well