### PR TITLE
[Docs] Updated solidity example to modern syntax

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -51,47 +51,51 @@ Example
 
 .. code-block:: javascript
 
+    pragma solidity ^0.8.4;
     contract Test {
         uint a;
-        address d = 0x12345678901234567890123456789012;
+        address d = 0xdCad3a6d3569DF655070DEd06cb7A1b2Ccd1D3AF;
 
-        function Test(uint testInt)  { a = testInt;}
+        constructor(uint testInt)  { a = testInt;}
 
         event Event(uint indexed b, bytes32 c);
 
         event Event2(uint indexed b, bytes32 c);
 
-        function foo(uint b, bytes32 c) returns(address) {
-            Event(b, c);
+        function foo(uint b, bytes32 c) public returns(address) {
+            emit Event(b, c);
             return d;
         }
     }
 
+
     // would result in the JSON:
-    [{
-        "type":"constructor",
-        "payable":false,
-        "stateMutability":"nonpayable"
-        "inputs":[{"name":"testInt","type":"uint256"}],
-      },{
-        "type":"function",
-        "name":"foo",
-        "constant":false,
-        "payable":false,
-        "stateMutability":"nonpayable",
-        "inputs":[{"name":"b","type":"uint256"}, {"name":"c","type":"bytes32"}],
-        "outputs":[{"name":"","type":"address"}]
-      },{
-        "type":"event",
-        "name":"Event",
-        "inputs":[{"indexed":true,"name":"b","type":"uint256"}, {"indexed":false,"name":"c","type":"bytes32"}],
-        "anonymous":false
-      },{
-        "type":"event",
-        "name":"Event2",
-        "inputs":[{"indexed":true,"name":"b","type":"uint256"},{"indexed":false,"name":"c","type":"bytes32"}],
-        "anonymous":false
-    }]
+    [
+        {
+            "type": "constructor"
+            "stateMutability": "nonpayable",
+            "inputs": [{"internalType":"uint256","name":"testInt","type":"uint256"}],
+        },
+        {
+            "type": "event"
+            "name": "Event",
+            "inputs": [{"indexed":true,"internalType":"uint256","name":"b","type":"uint256"},{"indexed":false,"internalType":"bytes32","name":"c","type":"bytes32"}],
+            "anonymous": false,
+        },
+        {
+            "type": "event"
+            "name": "Event2",
+            "inputs": [{"indexed":true,"internalType":"uint256","name":"b","type":"uint256"},{"indexed":false,"internalType":"bytes32","name":"c","type":"bytes32"}],
+            "anonymous": false,
+        },
+        {
+            "type": "function"
+            "name": "foo",
+            "stateMutability": "nonpayable",
+            "inputs": [{"internalType":"uint256","name":"b","type":"uint256"},{"internalType":"bytes32","name":"c","type":"bytes32"}],
+            "outputs": [{"internalType":"address","name":"","type":"address"}],
+        }
+    ]
 
 
 ------------------------------------------------------------------------------

--- a/docs/web3-bzz.rst
+++ b/docs/web3-bzz.rst
@@ -8,7 +8,7 @@ web3.bzz
 
 
 The ``web3-bzz`` package allows you to interact with swarm, the decentralized file store.
-For more see the `Swarm Docs <http://swarm-guide.readthedocs.io/en/latest/>`_.
+For more see the `Swarm Docs <https://docs.ethswarm.org/docs/>`_.
 
 
 .. code-block:: javascript

--- a/docs/web3-bzz.rst
+++ b/docs/web3-bzz.rst
@@ -8,7 +8,7 @@ web3.bzz
 
 
 The ``web3-bzz`` package allows you to interact with swarm, the decentralized file store.
-For more see the `Swarm Docs <https://docs.ethswarm.org/docs/>`_.
+For more see the `Swarm Docs <http://swarm-guide.readthedocs.io/en/latest/>`_.
 
 
 .. code-block:: javascript


### PR DESCRIPTION
## Description

Replaced the old constructor function syntax with the modern one, added 'emit' to event calls, added pragma, added a valid bytes32 value and updated the JSON ABI.

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
