### PR TITLE
Handling EIP1559 transactions in outputTransactionFormatter

### DIFF
--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -239,7 +239,7 @@ var outputTransactionFormatter = function (tx) {
         tx.transactionIndex = utils.hexToNumber(tx.transactionIndex);
     tx.nonce = utils.hexToNumber(tx.nonce);
     tx.gas = utils.hexToNumber(tx.gas);
-    if (tx.gasPrice !== null)
+    if (tx.gasPrice)
         tx.gasPrice = outputBigNumberFormatter(tx.gasPrice);
     if (tx.maxFeePerGas)
         tx.maxFeePerGas = outputBigNumberFormatter(tx.maxFeePerGas);

--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -239,7 +239,14 @@ var outputTransactionFormatter = function (tx) {
         tx.transactionIndex = utils.hexToNumber(tx.transactionIndex);
     tx.nonce = utils.hexToNumber(tx.nonce);
     tx.gas = utils.hexToNumber(tx.gas);
-    tx.gasPrice = outputBigNumberFormatter(tx.gasPrice);
+    if (tx.gasPrice !== null)
+        tx.gasPrice = outputBigNumberFormatter(tx.gasPrice);
+    if (tx.maxFeePerGas)
+        tx.maxFeePerGas = outputBigNumberFormatter(tx.maxFeePerGas);
+    if (tx.maxPriorityFeePerGas)
+        tx.maxPriorityFeePerGas = outputBigNumberFormatter(tx.maxPriorityFeePerGas);
+    if (tx.type)
+        tx.type = utils.hexToNumber(tx.type);
     tx.value = outputBigNumberFormatter(tx.value);
 
     if (tx.to && utils.isAddress(tx.to)) { // tx.to could be `0x0` or `null` while contract creation

--- a/test/formatters.outputTransactionFormatter.js
+++ b/test/formatters.outputTransactionFormatter.js
@@ -38,7 +38,7 @@ describe('formatters', function () {
                 to: null,
                 value: '0x3e8',
                 gas: '0x3e8',
-                gasPrice: '0x3e8',
+                gasPrice: null,
                 nonce: '0xb',
                 transactionIndex: null,
                 blockNumber: null,
@@ -49,11 +49,46 @@ describe('formatters', function () {
                 to: null,
                 value: 1000,
                 gas: 1000,
-                gasPrice: '1000',
+                gasPrice: null,
                 nonce: 11,
                 blockNumber: null,
                 blockHash: null,
                 transactionIndex: null
+            });
+        });
+
+        it('should format EIP1559 values correctly', function () {
+
+            assert.deepEqual(formatters.outputTransactionFormatter({
+                accessList: [],
+                input: '0x3454645634534',
+                from: '0x11f4d0a3c12e86b4b5f39b213f7e19d048276dae',
+                to: null,
+                value: '0x3e8',
+                gas: '0x3e8',
+                gasPrice: '0x3e8',
+                maxFeePerGas: '0x104c533c00',
+                maxPriorityFeePerGas: '0x1a13b8600',
+                nonce: '0xb',
+                transactionIndex: null,
+                type: '0x2',
+                blockNumber: null,
+                blockHash: null
+            }), {
+                accessList: [],
+                input: '0x3454645634534',
+                from: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
+                to: null,
+                value: '1000',
+                gas: 1000,
+                gasPrice: '1000',
+                maxFeePerGas: '70000000000',
+                maxPriorityFeePerGas: '7000000000',
+                nonce: 11,
+                blockNumber: null,
+                blockHash: null,
+                transactionIndex: null,
+                type: 2
             });
         });
     });


### PR DESCRIPTION
## Description

Adds support for EIP1559 fields in the `outputTransactionFormatter`, this includes a null `gasPrice` which causes the current web3 version to error out calling `getTransaction`

Relates to https://github.com/ChainSafe/web3.js/issues/4105

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
