### PR TITLE
eth_feeHistory (EIP 1559)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,7 @@ Released with 1.0.0-beta.37 code base.
 ### Added
 
 - London transaction support (#4155)
+- RPC support `eth_feehistory` call
 
 ### Changed
  - Grammar fix (#4088) and updated Swarm (#4151)and Whisper doc links (#4170)

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -716,6 +716,43 @@ Example
 
 ------------------------------------------------------------------------------
 
+.. _eth-feehistory:
+
+
+getFeeHistory
+=====================
+
+.. code-block:: javascript
+
+    web3.eth.getFeeHistory(blockCount, newestBlock, rewardPercentiles, [callback])
+
+Transaction fee history
+Returns base fee per gas and transaction effective priority fee per gas history for the requested block range if available. 
+The range between headBlock-4 and headBlock is guaranteed to be available while retrieving data from the pending block and older
+history are optional to support. For pre-EIP-1559 blocks the gas prices are returned as rewards and zeroes are returned for the base fee per gas.
+
+----------
+Parameters
+----------
+
+1. ``String|Number|BN|BigNumber`` - Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query. Less than requested may be returned if not all blocks are available.
+2. ``String|Number|BN|BigNumber`` - Highest number block of the requested range.
+3. ``Array of numbers`` - A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used. Example: `["0", "25", "50", "75", "100"]` or `["0", "0.5", "1", "1.5", "3", "80"]`
+4. ``Function`` - (optional) Optional callback, returns an error object as first parameter and the result as second.
+
+-------
+Returns
+-------
+
+``Promise`` returns ``Object`` - Fee history for the returned block range. The object:
+
+- ``Number`` oldestBlock  - Lowest number block of the returned range.
+- ``Array of strings`` baseFeePerGas  - An array of block base fees per gas. This includes the next block after the newest of the returned range, because this value can be derived from the newest block. Zeroes are returned for pre-EIP-1559 blocks.
+- ``Array of numbers`` gasUsedRatio  - An array of block gas used ratios. These are calculated as the ratio of gasUsed and gasLimit.
+- ``Array of string arrays`` reward  - An array of effective priority fee per gas data points from a single block. All zeroes are returned if the block is empty.
+
+------------------------------------------------------------------------------
+
 
 getAccounts
 =====================

--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -389,6 +389,7 @@ var Eth = function Eth() {
             name: 'getFeeHistory',
             call: 'eth_feeHistory',
             params: 3,
+            inputFormatter: [utils.toNumber, utils.toHex, function(value) {return value}]
         }),
         new Method({
             name: 'getAccounts',

--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -386,6 +386,11 @@ var Eth = function Eth() {
             outputFormatter: formatter.outputBigNumberFormatter
         }),
         new Method({
+            name: 'getFeeHistory',
+            call: 'eth_feeHistory',
+            params: 3,
+        }),
+        new Method({
             name: 'getAccounts',
             call: 'eth_accounts',
             params: 0,

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -146,8 +146,15 @@ export class Eth {
     ): Promise<number>;
 
     getGasPrice(
+        blockCount: number,
+        newestBlock: string,
+        rewardPercentiles: number[],
         callback?: (error: Error, gasPrice: string) => void
     ): Promise<string>;
+
+    getFeeHistory(
+        callback?: (error: Error, feeHistory: FeeHistoryResult) => void
+    ): Promise<FeeHistoryResult>;
 
     getAccounts(
         callback?: (error: Error, accounts: string[]) => void
@@ -438,4 +445,11 @@ export interface StorageProof {
     key: string;
     value: string;
     proof: string[];
+}
+
+export interface FeeHistoryResult {
+    oldestBlock: string;
+    baseFeePerGas: string[];
+    gasUsedRatio: number[];
+    reward: string[][];
 }

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -146,13 +146,13 @@ export class Eth {
     ): Promise<number>;
 
     getGasPrice(
-        blockCount: number,
-        newestBlock: string,
-        rewardPercentiles: number[],
         callback?: (error: Error, gasPrice: string) => void
     ): Promise<string>;
 
     getFeeHistory(
+        blockCount: number,
+        newestBlock: string,
+        rewardPercentiles: number[],
         callback?: (error: Error, feeHistory: FeeHistoryResult) => void
     ): Promise<FeeHistoryResult>;
 

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -150,8 +150,8 @@ export class Eth {
     ): Promise<string>;
 
     getFeeHistory(
-        blockCount: number,
-        newestBlock: string,
+        blockCount: number | BigNumber | BN | string,
+        lastBlock: number | BigNumber | BN | string,
         rewardPercentiles: number[],
         callback?: (error: Error, feeHistory: FeeHistoryResult) => void
     ): Promise<FeeHistoryResult>;
@@ -448,8 +448,8 @@ export interface StorageProof {
 }
 
 export interface FeeHistoryResult {
-    oldestBlock: string;
     baseFeePerGas: string[];
     gasUsedRatio: number[];
+    oldestBlock: number;
     reward: string[][];
 }

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -32,7 +32,8 @@ import {
     TransactionConfig,
     hardfork,
     Common,
-    chain
+    chain,
+    FeeHistoryResult
 } from 'web3-eth';
 import BN = require('bn.js');
 import BigNumber from 'bignumber.js';
@@ -177,6 +178,11 @@ eth.getChainId((error: Error, chainId: number) => {});
 eth.getGasPrice();
 // $ExpectType Promise<string>
 eth.getGasPrice((error: Error, gasPrice: string) => {});
+
+// $ExpectType Promise<FeeHistoryResult>
+eth.getFeeHistory();
+// $ExpectType Promise<FeeHistoryResult>
+eth.getFeeHistory((error: Error, feeHistory: FeeHistoryResult) => {});
 
 // $ExpectType Promise<string[]>
 eth.getAccounts();

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -180,9 +180,13 @@ eth.getGasPrice();
 eth.getGasPrice((error: Error, gasPrice: string) => {});
 
 // $ExpectType Promise<FeeHistoryResult>
-eth.getFeeHistory();
+eth.getFeeHistory(
+    4, "0xA30953", []
+);
 // $ExpectType Promise<FeeHistoryResult>
-eth.getFeeHistory((error: Error, feeHistory: FeeHistoryResult) => {});
+eth.getFeeHistory(
+    4, "0xA30953", [],
+    (error: Error, feeHistory: FeeHistoryResult) => {});
 
 // $ExpectType Promise<string[]>
 eth.getAccounts();

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -436,5 +436,7 @@ module.exports = {
     isTopicInBloom: utils.isTopicInBloom,
     isInBloom: utils.isInBloom,
 
-    compareBlockNumbers: compareBlockNumbers
+    compareBlockNumbers: compareBlockNumbers,
+
+    toNumber: utils.toNumber
 };

--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -521,6 +521,17 @@ var sha3Raw = function(value) {
     return value;
 };
 
+/**
+ * Auto converts any given value into it's hex representation,
+ * then converts hex to number.
+ *
+ * @method toNumber
+ * @param {String|Number|BN} value
+ * @return {Number}
+ */
+var toNumber = function(value) {
+    return typeof value === 'number' ? value : hexToNumber(toHex(value));
+}
 
 module.exports = {
     BN: BN,
@@ -550,5 +561,6 @@ module.exports = {
     rightPad: rightPad,
     toTwosComplement: toTwosComplement,
     sha3: sha3,
-    sha3Raw: sha3Raw
+    sha3Raw: sha3Raw,
+    toNumber: toNumber
 };

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -178,6 +178,7 @@ export interface Utils {
     testTopic(bloom: string, topic: string): boolean;
     getSignatureParameters(signature: string): {r: string; s: string; v: number};
     stripHexPrefix(str: string): string;
+    toNumber(value: number | string | BN): number;
 }
 
 export interface Units {

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -122,6 +122,7 @@ export function testAddress(bloom: string, address: string): boolean;
 export function testTopic(bloom: string, topic: string): boolean;
 export function getSignatureParameters(signature: string): {r: string; s: string; v: number};
 export function stripHexPrefix(str: string): string;
+export function toNumber(value: number | string | BN): number;
 
 // interfaces
 export interface Utils {

--- a/packages/web3-utils/types/tests/to-number-test.ts
+++ b/packages/web3-utils/types/tests/to-number-test.ts
@@ -1,0 +1,44 @@
+/*
+    This file is part of web3.js.
+
+    web3.js is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    web3.js is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * @file to-number-test.ts
+ * @author Josh Stevens <joshstevens19@hotmail.co.uk>
+ * @date 2018
+ */
+
+import BN = require('bn.js');
+import {toNumber} from 'web3-utils';
+
+// $ExpectType number
+toNumber('234');
+// $ExpectType number
+toNumber(234);
+// $ExpectType number
+toNumber(new BN(3));
+
+// $ExpectError
+toNumber(['string']);
+// $ExpectError
+toNumber(true);
+// $ExpectError
+toNumber([4]);
+// $ExpectError
+toNumber({});
+// $ExpectError
+toNumber(null);
+// $ExpectError
+toNumber(undefined);

--- a/test/eth.feeHistory.js
+++ b/test/eth.feeHistory.js
@@ -1,45 +1,123 @@
+var BigNumber = require('bignumber.js');
+
 var testMethod = require('./helpers/test.method.js');
 
 var method = 'getFeeHistory';
 var methodCall = 'eth_feeHistory';
 
-var tests = [{
-    args: [4, "0xA30953", []],
-    formattedArgs: [4, "0xA30953", []],
-    result: {
-        "baseFeePerGas": [
-          "0xa",
-          "0x9",
-          "0x8",
-          "0x9",
-          "0x9"
-        ],
-        "gasUsedRatio": [
-          0.003920375,
-          0.002625,
-          0.904999125,
-          0.348347625
-        ],
-        "oldestBlock": 10684752
+var tests = [
+    {
+        args: [4, "0xA30953", []],
+        formattedArgs: [4, "0xA30953", []],
+        result: {
+            "baseFeePerGas": [
+            "0xa",
+            "0x9",
+            "0x8",
+            "0x9",
+            "0x9"
+            ],
+            "gasUsedRatio": [
+            0.003920375,
+            0.002625,
+            0.904999125,
+            0.348347625
+            ],
+            "oldestBlock": 10684752
+        },
+        formattedResult: {
+            "baseFeePerGas": [
+            "0xa",
+            "0x9",
+            "0x8",
+            "0x9",
+            "0x9"
+            ],
+            "gasUsedRatio": [
+            0.003920375,
+            0.002625,
+            0.904999125,
+            0.348347625
+            ],
+            "oldestBlock": 10684752
+        },
+        call: methodCall
     },
-    formattedResult: {
-        "baseFeePerGas": [
-          "0xa",
-          "0x9",
-          "0x8",
-          "0x9",
-          "0x9"
-        ],
-        "gasUsedRatio": [
-          0.003920375,
-          0.002625,
-          0.904999125,
-          0.348347625
-        ],
-        "oldestBlock": 10684752
+    {
+        args: ['0x4', 10684755, []],
+        formattedArgs: [4, "0xa30953", []],
+        result: {
+            "baseFeePerGas": [
+            "0xa",
+            "0x9",
+            "0x8",
+            "0x9",
+            "0x9"
+            ],
+            "gasUsedRatio": [
+            0.003920375,
+            0.002625,
+            0.904999125,
+            0.348347625
+            ],
+            "oldestBlock": 10684752
+        },
+        formattedResult: {
+            "baseFeePerGas": [
+            "0xa",
+            "0x9",
+            "0x8",
+            "0x9",
+            "0x9"
+            ],
+            "gasUsedRatio": [
+            0.003920375,
+            0.002625,
+            0.904999125,
+            0.348347625
+            ],
+            "oldestBlock": 10684752
+        },
+        call: methodCall
     },
-    call: methodCall
-}];
+    {
+        args: [new BigNumber(4), '10684755', []],
+        formattedArgs: [4, "0xa30953", []],
+        result: {
+            "baseFeePerGas": [
+            "0xa",
+            "0x9",
+            "0x8",
+            "0x9",
+            "0x9"
+            ],
+            "gasUsedRatio": [
+            0.003920375,
+            0.002625,
+            0.904999125,
+            0.348347625
+            ],
+            "oldestBlock": 10684752
+        },
+        formattedResult: {
+            "baseFeePerGas": [
+            "0xa",
+            "0x9",
+            "0x8",
+            "0x9",
+            "0x9"
+            ],
+            "gasUsedRatio": [
+            0.003920375,
+            0.002625,
+            0.904999125,
+            0.348347625
+            ],
+            "oldestBlock": 10684752
+        },
+        call: methodCall
+    }
+];
 
 
 testMethod.runTests('eth', method, tests);

--- a/test/eth.feeHistory.js
+++ b/test/eth.feeHistory.js
@@ -1,0 +1,29 @@
+var testMethod = require('./helpers/test.method.js');
+
+var method = 'getFeeHistory';
+var methodCall = 'eth_feeHistory';
+
+var tests = [{
+    args: [4, "0xA30953", []],
+    result: {
+        "baseFeePerGas": [
+          "0xa",
+          "0x9",
+          "0x8",
+          "0x9",
+          "0x9"
+        ],
+        "gasUsedRatio": [
+          0.003920375,
+          0.002625,
+          0.904999125,
+          0.348347625
+        ],
+        "oldestBlock": 10684752
+    },
+    call: methodCall
+}];
+
+
+testMethod.runTests('eth', method, tests);
+

--- a/test/eth.feeHistory.js
+++ b/test/eth.feeHistory.js
@@ -5,7 +5,24 @@ var methodCall = 'eth_feeHistory';
 
 var tests = [{
     args: [4, "0xA30953", []],
+    formattedArgs: [4, "0xA30953", []],
     result: {
+        "baseFeePerGas": [
+          "0xa",
+          "0x9",
+          "0x8",
+          "0x9",
+          "0x9"
+        ],
+        "gasUsedRatio": [
+          0.003920375,
+          0.002625,
+          0.904999125,
+          0.348347625
+        ],
+        "oldestBlock": 10684752
+    },
+    formattedResult: {
         "baseFeePerGas": [
           "0xa",
           "0x9",

--- a/test/eth_methods.js
+++ b/test/eth_methods.js
@@ -27,6 +27,7 @@ describe('eth', function() {
         u.methodExists(eth, 'isMining');
         u.methodExists(eth, 'getCoinbase');
         u.methodExists(eth, 'getGasPrice');
+        u.methodExists(eth, 'getFeeHistory');
         u.methodExists(eth, 'getHashrate');
         u.methodExists(eth, 'getAccounts');
         u.methodExists(eth, 'getBlockNumber');

--- a/test/utils.hexToNumber.js
+++ b/test/utils.hexToNumber.js
@@ -1,0 +1,23 @@
+var assert = require('assert');
+var utils = require('../packages/web3-utils');
+
+describe('lib/utils/utils', function () {
+    describe('hexToNumber', function () {
+        it('should return the correct value', function () {
+
+            assert.equal(utils.hexToNumber("0x3e8"), 1000);
+            assert.equal(utils.hexToNumber('0x1f0fe294a36'), 2134567897654);
+            // allow compatiblity
+            assert.equal(utils.hexToNumber(100000), 100000);
+        });
+
+        it('should validate hex strings', function() {
+            try {
+              utils.hexToNumber('100000');
+              assert.fail();
+            } catch (error){
+              assert(error.message.includes('is not a valid hex string'))
+            }
+        })
+    });
+});

--- a/test/utils.toNumber.js
+++ b/test/utils.toNumber.js
@@ -1,23 +1,61 @@
-var assert = require('assert');
+var chai = require('chai');
 var utils = require('../packages/web3-utils');
 
+var BigNumber = require('bignumber.js');
+var BN = require('bn.js');
+
+var assert = chai.assert;
+
+var tests = [
+    { value: 1, expected: 1 },
+    { value: '1', expected: 1 },
+    { value: '0x1', expected: 1},
+    { value: '15', expected: 15},
+    { value: '0xf', expected: 15},
+    { value: -1, expected: -1},
+    { value: '-1', expected: -1},
+    { value: '-0x1', expected: -1},
+    { value: '-15', expected: -15},
+    { value: '-0xf', expected: -15},
+    { value: '0x657468657265756d', expected: '0x657468657265756d', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: '0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd', expected: '0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: '-0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', expected: '-0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: '-0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd', expected: '-0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: 0, expected: 0},
+    { value: '0', expected: 0},
+    { value: '0x0', expected: 0},
+    { value: -0, expected: -0},
+    { value: '-0', expected: -0},
+    { value: '-0x0', expected: -0},
+    { value: [1,2,3,{test: 'data'}], expected: '0x5b312c322c332c7b2274657374223a2264617461227d5d', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: {test: 'test'}, expected: '0x7b2274657374223a2274657374227d', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: '{"test": "test"}', expected: '0x7b2274657374223a202274657374227d', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: 'myString', expected: '0x6d79537472696e67', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: 'myString 34534!', expected: '0x6d79537472696e6720333435333421', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: new BN(15), expected: 15},
+    { value: new BigNumber(15), expected: 15},
+    { value: 'Heeäööä👅D34ɝɣ24Єͽ-.,äü+#/', expected: '0x486565c3a4c3b6c3b6c3a4f09f9185443334c99dc9a33234d084cdbd2d2e2cc3a4c3bc2b232f', error: true, errorMessage: 'Number can only safely store up to 53 bits'},
+    { value: true, expected: 1},
+    { value: false, expected: 0},
+];
+
 describe('lib/utils/utils', function () {
-    describe('hexToNumber', function () {
-        it('should return the correct value', function () {
-
-            assert.equal(utils.hexToNumber("0x3e8"), 1000);
-            assert.equal(utils.hexToNumber('0x1f0fe294a36'), 2134567897654);
-            // allow compatiblity
-            assert.equal(utils.hexToNumber(100000), 100000);
-        });
-
-        it('should validate hex strings', function() {
-            try {
-              utils.hexToNumber('100000');
-              assert.fail();
-            } catch (error){
-              assert(error.message.includes('is not a valid hex string'))
+    describe('toNumber', function () {
+        tests.forEach(function (test) {
+            if (test.error) {
+                it('should error with message', function () {
+                    try {
+                        utils.toNumber(test.value)
+                        assert.fail();
+                    } catch(err){
+                        assert.strictEqual(err.message, test.errorMessage);
+                    }
+                });
+            } else {
+                it('should turn ' + test.value + ' to ' + test.expected, function () {
+                    assert.strictEqual(utils.toNumber(test.value), test.expected);
+                });
             }
-        })
+        });
     });
 });


### PR DESCRIPTION
Add missing `getFeeHistory` call that's made available via EIP 1559

**NOTE**

- ~[RPC docs](https://playground.open-rpc.org/) say that `blockCount` should be a hex string, but in my testing using Infura URLs on Ropsten and Rinkeby, only integers seem to be supported. Additionally, for `newestBlock`, block tags (e.g. `earliest`, `latest`, etc) don't seem to be supported, only hex strings~ To combat this, I added input formatters to `blockCount` and `lastBlock`
- Should be merged alongside #4190