### PR TITLE
Revert e2e.ganache.core.sh change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,7 +421,7 @@ Released with 1.0.0-beta.37 code base.
 ### Changed
 
 - Updates the use of `hexToNumber` to `outputBigNumberFormatter` (which returns a number string instead of a number) (#3976)
-- Update `e2e.ganahce.core.sh` to point to ChainSafe's fork of `ganache-core` (#3976)
+- Revert changes to `e2e.ganahce.core.sh` (#4207)
 
 ### Removed
 

--- a/scripts/e2e.ganache.core.sh
+++ b/scripts/e2e.ganache.core.sh
@@ -9,9 +9,9 @@
 set -o errexit
 
 # Install ganache-core
-git clone https://github.com/ChainSafe/ganache-core
+git clone https://github.com/trufflesuite/ganache-core
 cd ganache-core
-git checkout 2.13.2-overflow-fix
+git checkout tags/v2.13.0
 
 # Install via registry and verify
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"


### PR DESCRIPTION
Was previously pointing to a ChainSafe fork of the repo, this PR reverts it to the [trufflesuite repo](https://github.com/trufflesuite/ganache-core)