### PR TITLE
Accept predefined block numbers for eth_feeHistory

### DIFF
--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -389,7 +389,7 @@ var Eth = function Eth() {
             name: 'getFeeHistory',
             call: 'eth_feeHistory',
             params: 3,
-            inputFormatter: [utils.toNumber, utils.toHex, function(value) {return value}]
+            inputFormatter: [utils.toNumber, formatter.inputBlockNumberFormatter, function(value) {return value}]
         }),
         new Method({
             name: 'getAccounts',

--- a/test/eth.feeHistory.js
+++ b/test/eth.feeHistory.js
@@ -8,7 +8,7 @@ var methodCall = 'eth_feeHistory';
 var tests = [
     {
         args: [4, "0xA30953", []],
-        formattedArgs: [4, "0xA30953", []],
+        formattedArgs: [4, "0xa30953", []],
         result: {
             "baseFeePerGas": [
             "0xa",


### PR DESCRIPTION
## Description

Allow the `eth_feeHistory` method to accept predefined block numbers, e.g. "latest". This is the appropriate schema type as defined in the ethereum spec: https://github.com/ethereum/eth1.0-specs/blob/master/json-rpc/spec.json.

The current behavior of forcing the parameter into `utils.toHex` actually does convert "latest" into a hex far beyond head resulting in the node response of "request beyond head block" (for geth).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
