### PR TITLE
Closes #4210, 4211 - allow non-hex values for eip1559 gas params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,3 +419,8 @@ Released with 1.0.0-beta.37 code base.
 ## [Unreleased]
 
 ## [1.5.1]
+
+### Added
+
+- `maxPriorityFeePerGas` and `maxFeePerGas` now included in `_txInputFormatter` (#4217)
+- If `maxPriorityFeePerGas` of `maxFeePerGas` present `_txInputFormatter` deletes `tx.gasPrice` (fixes #4211) (#4217)

--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -157,6 +157,10 @@ var _txInputFormatter = function (options) {
     if (options.gas || options.gasLimit) {
         options.gas = options.gas || options.gasLimit;
     }
+    
+    if (options.maxPriorityFeePerGas || options.maxFeePerGas) {
+        delete options.gasPrice;
+    }
 
     ['gasPrice', 'gas', 'value', 'maxPriorityFeePerGas', 'maxFeePerGas', 'nonce'].filter(function (key) {
         return options[key] !== undefined;

--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -158,7 +158,7 @@ var _txInputFormatter = function (options) {
         options.gas = options.gas || options.gasLimit;
     }
 
-    ['gasPrice', 'gas', 'value', 'nonce'].filter(function (key) {
+    ['gasPrice', 'gas', 'value', 'maxPriorityFeePerGas', 'maxFeePerGas', 'nonce'].filter(function (key) {
         return options[key] !== undefined;
     }).forEach(function (key) {
         options[key] = utils.numberToHex(options[key]);

--- a/test/eth.accounts.signTransaction.js
+++ b/test/eth.accounts.signTransaction.js
@@ -3,6 +3,7 @@ var Web3 = require('../packages/web3');
 var Accounts = require("./../packages/web3-eth-accounts");
 var chai = require('chai');
 var assert = chai.assert;
+var bn = require('bn.js');
 
 var common = {
     baseChain: 'mainnet',
@@ -648,6 +649,52 @@ var tests = [
         oldSignature: "0x02f8ca0180843b9aca00843b9aca0e826a4094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080f85bf859940000000000000000000000000000000000000101f842a00000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000060a780a0e3a2e10c7d3af3407ec2d38c64788d6673926e9b28d6d2e7df3c94cdf0548233a00ad3e5faafaf3a9350ab16c1be0198ce9ff3c6bef0b91e05488d757f07de9557",
         transactionHash: "0xbc2c9edab3d4e3a795fa402b52d6149e874de15f0cc6c0858eb34e1fe1ef31fe",
         messageHash: "0xa3a2cdc45e9cefb9a614ead90ce65f68bcf8a90dbe0ccbd84c1b62403bd05346"
+    },
+    {
+        // test #28
+        address: '0x2c7536E3605D9C16a7a3D7b1898e529396a65c23',
+        iban: 'XE0556YCRTEZ9JALZBSCXOK4UJ5F3HN03DV',
+        privateKey: '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
+        transaction: {
+            chainId: 1,
+            nonce: 0,
+            maxPriorityFeePerGas: new bn('0x3B9ACA00'),
+            maxFeePerGas: new bn('0xB2D05E00'),
+            gasLimit: '0x6A40',
+            to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
+            toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
+            value: "1000000000",
+            data: "",
+            common: commonLondon
+        },
+        // signature from eth_signTransaction
+        rawTransaction: "0x02f86e018084c733124884cb72ec20826a4094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080c001a08896fb9a5c033e0163b073cf7a951a1db2dca41b26b4188f13a05158eb26fd32a005e8855691199cd0b6dcae88f3325c374e2f0697b9c528a5c10d5bd8dfb6a3e3",
+        oldSignature: "0x02f86e018084c733124884cb72ec20826a4094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080c001a08896fb9a5c033e0163b073cf7a951a1db2dca41b26b4188f13a05158eb26fd32a005e8855691199cd0b6dcae88f3325c374e2f0697b9c528a5c10d5bd8dfb6a3e3",
+        transactionHash: "0xd5b7290a477b9c421d39e61d0f566ec33276fb49b9ff85cfd6152a18f1c92dab",
+        messageHash: "0x17e20e530a889ce52057de228b5b97edcad6002468d723346cd0b6b7a9943457"
+    },
+    {
+        // test #29
+        address: '0x2c7536E3605D9C16a7a3D7b1898e529396a65c23',
+        iban: 'XE0556YCRTEZ9JALZBSCXOK4UJ5F3HN03DV',
+        privateKey: '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
+        transaction: {
+            chainId: 1,
+            nonce: 0,
+            maxPriorityFeePerGas: '1000000000',
+            maxFeePerGas: '3000000000',
+            gasLimit: '0x6A40',
+            to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
+            toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
+            value: "1000000000",
+            data: "",
+            common: commonLondon
+        },
+        // signature from eth_signTransaction
+        rawTransaction: "0x02f86e0180843b9aca0084b2d05e00826a4094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080c080a0d1290a118d51918c1ca17e3af0267c45efcd745cf42e78eabc444c424d6bcf37a003c81e1fda169575023a94200ee034128747f91020e704abaee30dbcfc785c36",
+        oldSignature: "0x02f86e0180843b9aca0084b2d05e00826a4094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080c080a0d1290a118d51918c1ca17e3af0267c45efcd745cf42e78eabc444c424d6bcf37a003c81e1fda169575023a94200ee034128747f91020e704abaee30dbcfc785c36",
+        transactionHash: "0x82c19b39a6b7eaa0492863a8b236fad5018f267b4977c270ddd5228c4cbda60e",
+        messageHash: "0xe3beea0918f445c21eb2f42e3cbc3c5d54321ec642f47d12c473b2765df97f2b"
     },
 ];
 

--- a/test/formatters.inputTransactionFormatter.js
+++ b/test/formatters.inputTransactionFormatter.js
@@ -1,5 +1,7 @@
+var bn = require('bn.js');
 var chai = require('chai');
 var assert = chai.assert;
+
 var formatters = require('../packages/web3-core-helpers/src/formatters.js');
 
 var tests = [{
@@ -97,6 +99,57 @@ var tests = [{
         from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
         gas: '0x3e8',
         gasPrice: '0x3e8'
+    }
+}, {
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '1000',
+        maxFeePerGas: '1000'
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8'
+    }
+}, {
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: 1000,
+        maxFeePerGas: 1000
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8'
+    }
+}, {
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: new bn(1000),
+        maxFeePerGas: new bn(1000)
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8'
     }
 }];
 


### PR DESCRIPTION
## Description

Updates the transaction input formatter to allow the new 1559 gas params to be represented as numbers, bn, string numbers, etc... and then converted to a hex.

Closes #4210 Closes #4211

Note: Still need to add test cases, in transit rn.

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
