### PR TITLE
Don't default type = 0x0 for eth_sendTransaction and eth_sendRawTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,4 +431,4 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
-- `type: 0x0` was being added to legacy transaction when using `eth.sendTransaction` or `eth_sendRawTransaction` (#4241)
+- `type: 0x0` was being added to legacy transaction when using `eth.sendTransaction`, `eth.sendRawTransaction`, of `eth.signTransaction` (#4241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,4 +431,5 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 
-- `type: 0x0` was being added to legacy transaction when using `eth.sendTransaction`, `eth.sendRawTransaction`, of `eth.signTransaction` (#4241)
+- Remove transaction `type` defaulting for `eth.sendTransaction`, `eth.sendRawTransaction` (#4241)
+- `type: 0x0` was being added to legacy transaction when using `eth.signTransaction` (#4241)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -428,3 +428,7 @@ Released with 1.0.0-beta.37 code base.
 ## [Unreleased]
 
 ## [1.5.2]
+
+### Fixed
+
+- `type: 0x0` was being added to legacy transaction when using `eth.sendTransaction` or `eth_sendRawTransaction` (#4241)

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -782,9 +782,6 @@ Method.prototype.buildCall = function () {
                 )
             )
         ) {
-            if (typeof payload.params[0].type === 'undefined') 
-                payload.params[0].type = _handleTxType(payload.params[0]);
-
             _handleTxPricing(method, payload.params[0]).then(txPricing => {
                 if (txPricing.gasPrice !== undefined) {
                     payload.params[0].gasPrice = txPricing.gasPrice;
@@ -830,44 +827,6 @@ Method.prototype.buildCall = function () {
     return send;
 };
 
-function _handleTxType(tx) {
-    // Taken from https://github.com/ethers-io/ethers.js/blob/2a7ce0e72a1e0c9469e10392b0329e75e341cf18/packages/abstract-signer/src.ts/index.ts#L215
-    const hasEip1559 = (tx.maxFeePerGas !== undefined || tx.maxPriorityFeePerGas !== undefined);
-
-    let txType;
-
-    if (tx.type !== undefined) {
-        txType = utils.toHex(tx.type)
-    } else if (tx.type === undefined && hasEip1559) {
-        txType = '0x2'
-    }
-
-    if (tx.gasPrice !== undefined && (txType === '0x2' || hasEip1559))
-        throw Error("eip-1559 transactions don't support gasPrice");
-    if ((txType === '0x1' || txType === '0x0') && hasEip1559)
-        throw Error("pre-eip-1559 transaction don't support maxFeePerGas/maxPriorityFeePerGas");
-    
-    if (
-        hasEip1559 ||
-        (
-            (tx.common && tx.common.hardfork && tx.common.hardfork.toLowerCase() === HardForks.London) ||
-            (tx.hardfork && tx.hardfork.toLowerCase() === HardForks.London)
-        )
-    ) {
-        txType = '0x2';
-    } else if (
-        tx.accessList ||
-        (
-            (tx.common && tx.common.hardfork && tx.common.hardfork.toLowerCase() === HardForks.Berlin) ||
-            (tx.hardfork && tx.hardfork.toLowerCase() === HardForks.Berlin)
-        )
-    ) {
-        txType = '0x1';
-    }
-    
-    return txType
-}
-
 function _handleTxPricing(method, tx) {
     return new Promise((resolve, reject) => {
         try {
@@ -887,50 +846,39 @@ function _handleTxPricing(method, tx) {
                 params: 0
             })).createFunction(method.requestManager);
 
-            if ((
-                tx.type === undefined || tx.type < '0x2')
-                && tx.gasPrice !== undefined
-            ) {
-                // Legacy transaction, return provided gasPrice
-                resolve({ gasPrice: tx.gasPrice })
-            } else {
-                Promise.all([
-                    getBlockByNumber(),
-                    getGasPrice()
-                ]).then(responses => {
-                    const [block, gasPrice] = responses;
-                    if (
-                        (tx.type === '0x2') &&
-                        block && block.baseFeePerGas
-                    ) {
-                        // The network supports EIP-1559
-    
-                        // Taken from https://github.com/ethers-io/ethers.js/blob/ba6854bdd5a912fe873d5da494cb5c62c190adde/packages/abstract-provider/src.ts/index.ts#L230
-                        let maxPriorityFeePerGas, maxFeePerGas;
-    
-                        if (tx.gasPrice) {
-                            // Using legacy gasPrice property on an eip-1559 network,
-                            // so use gasPrice as both fee properties
-                            maxPriorityFeePerGas = tx.gasPrice;
-                            maxFeePerGas = tx.gasPrice;
-                            delete tx.gasPrice;
-                        } else {
-                            maxPriorityFeePerGas = tx.maxPriorityFeePerGas || '0x3B9ACA00'; // 1 Gwei
-                            maxFeePerGas = tx.maxFeePerGas ||
-                                utils.toHex(
-                                    utils.toBN(block.baseFeePerGas)
-                                        .mul(utils.toBN(2))
-                                        .add(utils.toBN(maxPriorityFeePerGas))
-                                );
-                        }
-                        resolve({ maxFeePerGas, maxPriorityFeePerGas });
+            Promise.all([
+                getBlockByNumber(),
+                getGasPrice()
+            ]).then(responses => {
+                const [block, gasPrice] = responses;
+                if (block && block.baseFeePerGas) {
+                    // The network supports EIP-1559
+
+                    // Taken from https://github.com/ethers-io/ethers.js/blob/ba6854bdd5a912fe873d5da494cb5c62c190adde/packages/abstract-provider/src.ts/index.ts#L230
+                    let maxPriorityFeePerGas, maxFeePerGas;
+
+                    if (tx.gasPrice) {
+                        // Using legacy gasPrice property on an eip-1559 network,
+                        // so use gasPrice as both fee properties
+                        maxPriorityFeePerGas = tx.gasPrice;
+                        maxFeePerGas = tx.gasPrice;
+                        delete tx.gasPrice;
                     } else {
-                        if (tx.maxPriorityFeePerGas || tx.maxFeePerGas)
-                            throw Error("Network doesn't support eip-1559")
-                        resolve({ gasPrice });
+                        maxPriorityFeePerGas = tx.maxPriorityFeePerGas || '0x3B9ACA00'; // 1 Gwei
+                        maxFeePerGas = tx.maxFeePerGas ||
+                            utils.toHex(
+                                utils.toBN(block.baseFeePerGas)
+                                    .mul(utils.toBN(2))
+                                    .add(utils.toBN(maxPriorityFeePerGas))
+                            );
                     }
-                })
-            }
+                    resolve({ maxFeePerGas, maxPriorityFeePerGas });
+                } else {
+                    if (tx.maxPriorityFeePerGas || tx.maxFeePerGas)
+                        throw Error("Network doesn't support eip-1559")
+                    resolve({ gasPrice });
+                }
+            })
         } catch (error) {
             reject(error)
         }

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -840,8 +840,6 @@ function _handleTxType(tx) {
         txType = utils.toHex(tx.type)
     } else if (tx.type === undefined && hasEip1559) {
         txType = '0x2'
-    } else {
-        txType = '0x0'
     }
 
     if (tx.gasPrice !== undefined && (txType === '0x2' || hasEip1559))

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -28,7 +28,6 @@ var formatters = require('web3-core-helpers').formatters;
 var utils = require('web3-utils');
 var promiEvent = require('web3-core-promievent');
 var Subscriptions = require('web3-core-subscriptions').subscriptions;
-var HardForks = require('@ethereumjs/common').Hardfork;
 
 var EthersTransactionUtils = require('@ethersproject/transactions');
 

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -887,7 +887,10 @@ function _handleTxPricing(method, tx) {
                 params: 0
             })).createFunction(method.requestManager);
 
-            if (tx.type < '0x2' && tx.gasPrice !== undefined) {
+            if ((
+                tx.type === undefined || tx.type < '0x2')
+                && tx.gasPrice !== undefined
+            ) {
                 // Legacy transaction, return provided gasPrice
                 resolve({ gasPrice: tx.gasPrice })
             } else {

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -331,8 +331,6 @@ function _handleTxType(tx) {
         txType = utils.toHex(tx.type)
     } else if (tx.type === undefined && hasEip1559) {
         txType = '0x2'
-    } else {
-        txType = '0x0'
     }
 
     if (tx.gasPrice !== undefined && (txType === '0x2' || hasEip1559))
@@ -364,7 +362,10 @@ function _handleTxType(tx) {
 function _handleTxPricing(_this, tx) {
     return new Promise((resolve, reject) => {
         try {
-            if (tx.type < '0x2' && tx.gasPrice !== undefined) {
+            if (
+                (tx.type === undefined || tx.type < '0x2')
+                && tx.gasPrice !== undefined
+            ) {
                 // Legacy transaction, return provided gasPrice
                 resolve({ gasPrice: tx.gasPrice })
             } else {

--- a/test/contract.js
+++ b/test/contract.js
@@ -2678,8 +2678,7 @@ var runTests = function(contractFactory) {
                     '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
-                    gasPrice: '0x45656456456456',
-                    type: '0x0'
+                    gasPrice: '0x45656456456456'
                 }]);
 
                 done();

--- a/test/contract.js
+++ b/test/contract.js
@@ -2678,7 +2678,8 @@ var runTests = function(contractFactory) {
                     '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
-                    gasPrice: '0x45656456456456'
+                    maxPriorityFeePerGas: '0x3B9ACA00',
+                    maxFeePerGas: '0x3b9aca0e'
                 }]);
 
                 done();

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -68,8 +68,7 @@ var tests = [{
         from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
         to: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
         value: "0x11f71f76bb1",
-        gasPrice: "0x1234567",
-        type: "0x0"
+        gasPrice: "0x1234567"
     }],
     result3: '0x1234567'
 },{

--- a/test/method.buildCall.js
+++ b/test/method.buildCall.js
@@ -209,8 +209,7 @@ describe('lib/web3/method', function () {
                     from: '0x11f4d0a3c12e86b4b5f39b213f7e19d048276dae',
                     to: '0x11f4d0a3c12e86b4b5f39b213f7e19d048276dae',
                     data: '0xa123456',
-                    gasPrice: '0x1234567453543456321456321',
-                    type: '0x0'
+                    gasPrice: '0x1234567453543456321456321'
                 }]);
 
                 done();

--- a/test/method.buildCall.js
+++ b/test/method.buildCall.js
@@ -209,7 +209,8 @@ describe('lib/web3/method', function () {
                     from: '0x11f4d0a3c12e86b4b5f39b213f7e19d048276dae',
                     to: '0x11f4d0a3c12e86b4b5f39b213f7e19d048276dae',
                     data: '0xa123456',
-                    gasPrice: '0x1234567453543456321456321'
+                    gasPrice: '0x1234567453543456321456321',
+                    type: '0x2'
                 }]);
 
                 done();
@@ -220,7 +221,8 @@ describe('lib/web3/method', function () {
             send({
                 from: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
                 to: '0x11f4d0A3c12e86B4b5F39B213F7E19D048276DAe',
-                data: '0xa123456'
+                data: '0xa123456',
+                type: '0x2'
             });
 
         });


### PR DESCRIPTION
Previous to this PR, `eth_sendTransaction` and `eth_sendRawTransaction` would default to include `type = 0x0` when creating the tx object. Now, `type` will not be defaulted if EIP-1559 or EIP-2930 params aren't passed

Addresses issues mentioned [here](https://github.com/MetaMask/metamask-extension/issues/11824#issuecomment-898880026)

Supersedes #4240