### PR TITLE
Bump maxPriorityFeePerGas to 2.5 Gwei - Closes #4283

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -439,4 +439,5 @@ Released with 1.0.0-beta.37 code base.
 - ethers from 5.1.4 to 5.4.4 (#4231)
 - karma from 5.2.3 to 6.3.4 (#4231)
 - lerna from 3.22.1 to 4.0.0 (#4231)
-- Droped build tests in CI for Node v8 and v10, and added support for Node v14
+- Dropped build tests in CI for Node v8 and v10, and added support for Node v14
+- Change default value for `maxPriorityFeePerGas` from `1 Gwei` to `2.5 Gwei` (#4284)

--- a/docs/web3-eth.rst
+++ b/docs/web3-eth.rst
@@ -1460,7 +1460,7 @@ Parameters
     - ``gasPrice`` - ``Number|String|BN|BigNumber``: (optional) The price of gas for this transaction in :ref:`wei <what-is-wei>`, defaults to :ref:`web3.eth.gasPrice <eth-gasprice>`.
     - ``type`` - ``Number|String|BN|BigNumber``: (optional) A positive unsigned 8-bit number between 0 and 0x7f that represents the type of the transaction. 
     - ``maxFeePerGas`` - ``Number|String|BN``: (optional, defaulted to ``(2 * block.baseFeePerGas) + maxPriorityFeePerGas``) The maximum fee per gas that the transaction is willing to pay in total
-    - ``maxPriorityFeePerGas`` - ``Number|String|BN`` (optional, defaulted to ``1 Gwei``) The maximum fee per gas to give miners to incentivize them to include the transaction (Priority fee)
+    - ``maxPriorityFeePerGas`` - ``Number|String|BN`` (optional, defaulted to ``2.5 Gwei``) The maximum fee per gas to give miners to incentivize them to include the transaction (Priority fee)
     - ``accessList`` - ``List of hexstrings`` (optional) a list of addresses and storage keys that the transaction plans to access
     - ``data`` - ``String``: (optional) Either a `ABI byte string <http://solidity.readthedocs.io/en/latest/abi-spec.html>`_ containing the data of the function call on a contract, or in the case of a contract-creation transaction the initialisation code.
     - ``nonce`` - ``Number``: (optional) Integer of the nonce. This allows to overwrite your own pending transactions that use the same nonce.

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -863,7 +863,7 @@ function _handleTxPricing(method, tx) {
                         maxFeePerGas = tx.gasPrice;
                         delete tx.gasPrice;
                     } else {
-                        maxPriorityFeePerGas = tx.maxPriorityFeePerGas || '0x3B9ACA00'; // 1 Gwei
+                        maxPriorityFeePerGas = tx.maxPriorityFeePerGas || '0x9502F900'; // 2.5 Gwei
                         maxFeePerGas = tx.maxFeePerGas ||
                             utils.toHex(
                                 utils.toBN(block.baseFeePerGas)

--- a/packages/web3-eth-accounts/src/index.js
+++ b/packages/web3-eth-accounts/src/index.js
@@ -390,7 +390,7 @@ function _handleTxPricing(_this, tx) {
                             maxFeePerGas = tx.gasPrice;
                             delete tx.gasPrice;
                         } else {
-                            maxPriorityFeePerGas = tx.maxPriorityFeePerGas || '0x3B9ACA00'; // 1 Gwei
+                            maxPriorityFeePerGas = tx.maxPriorityFeePerGas || '0x9502F900'; // 2.5 Gwei
                             maxFeePerGas = tx.maxFeePerGas ||
                                 utils.toHex(
                                     utils.toBN(block.baseFeePerGas)

--- a/test/contract.js
+++ b/test/contract.js
@@ -2678,8 +2678,8 @@ var runTests = function(contractFactory) {
                     '0000000000000000000000000000000000000000000000000000000000000011' ,
                     to: addressLowercase,
                     from: addressLowercase,
-                    maxPriorityFeePerGas: '0x3B9ACA00',
-                    maxFeePerGas: '0x3b9aca0e'
+                    maxPriorityFeePerGas: '0x9502F900',
+                    maxFeePerGas: '0x9502f90e'
                 }]);
 
                 done();

--- a/test/e2e.method.signing.js
+++ b/test/e2e.method.signing.js
@@ -253,6 +253,7 @@ describe('transaction and message signing [ @E2E ]', function() {
             value:    web3.utils.toHex(web3.utils.toWei('0.1', 'ether')),
             gas: web3.utils.toHex(21000),
             maxFeePerGas: '0x59682F00', // 1.5 Gwei
+            maxPriorityFeePerGas: '0x1DCD6500', // .5 Gwei
             accessList: []
         };
 

--- a/test/eth.accounts.signTransaction.js
+++ b/test/eth.accounts.signTransaction.js
@@ -614,6 +614,7 @@ var tests = [
             chainId: 1,
             nonce: 0,
             gas: 27200,
+            maxPriorityFeePerGas: '0x3B9ACA00',
             gasLimit: '0x6A40',
             to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
             toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
@@ -636,6 +637,7 @@ var tests = [
             chainId: 1,
             nonce: 0,
             gas: 27200,
+            maxPriorityFeePerGas: '0x3B9ACA00',
             gasLimit: '0x6A40',
             to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
             toIban: 'XE04S1IRT2PR8A8422TPBL9SR6U0HODDCUT', // will be switched to "to" in the test
@@ -757,6 +759,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     });
                 });
 
@@ -789,6 +792,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     });
                 });
 
@@ -828,6 +832,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     });
                 });
 
@@ -868,6 +873,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     });
                 });
                 
@@ -909,6 +915,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     });
                 });
 
@@ -955,6 +962,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     });
                 });
 
@@ -1016,6 +1024,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     });
                 });
 
@@ -1044,6 +1053,7 @@ describe("eth", function () {
                     })
                     .catch(e => {
                         console.log(i, e)
+                        done(e);
                     })
                 });
             }


### PR DESCRIPTION
## Description

Update the occurrence of default value of `maxPriorityFeePerGas`  from `0x3B9ACA00` to `0x9502F900`. Which is equivalent of `1 Gwei` to `2.5 Gwei`.

Fixes #4283

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
