### PR TITLE
Add clientConfig to WS test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,3 +441,4 @@ Released with 1.0.0-beta.37 code base.
 - lerna from 3.22.1 to 4.0.0 (#4231)
 - Dropped build tests in CI for Node v8 and v10, and added support for Node v14
 - Change default value for `maxPriorityFeePerGas` from `1 Gwei` to `2.5 Gwei` (#4284)
+- Add `clientConfig` to `e2e_windows` WebSocket test (#4299)

--- a/scripts/js/basic_usage.js
+++ b/scripts/js/basic_usage.js
@@ -57,7 +57,15 @@ async function main(){
   log('>>>>>>');
 
   // WebSockets
-  web3 = new Web3(process.env.INFURA_WSS);
+  web3 = new Web3(
+    process.env.INFURA_WSS,
+    {
+      clientConfig: {
+        maxReceivedFrameSize: 100000000,
+        maxReceivedMessageSize: 100000000,
+      }
+    }
+  );
   block = await getBlockWithRetry(web3);
   web3.currentProvider.disconnect();
   log(util.inspect(block));


### PR DESCRIPTION
We experience the issue mentioned in #3816 with our `e2e_windows` test suite, this aims to fix it