### PR TITLE
Let toChecksumAddress throw for 'undefined'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,3 +441,4 @@ Released with 1.0.0-beta.37 code base.
 - lerna from 3.22.1 to 4.0.0 (#4231)
 - Dropped build tests in CI for Node v8 and v10, and added support for Node v14
 - Change default value for `maxPriorityFeePerGas` from `1 Gwei` to `2.5 Gwei` (#4284)
+- `utils.toChecksumAddress` now throws for `undefined`

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -292,11 +292,8 @@ var toWei = function(number, unit) {
  * @return {String}
  */
 var toChecksumAddress = function (address) {
-    if (typeof address === 'undefined') return '';
-
-    if(!/^(0x)?[0-9a-f]{40}$/i.test(address))
+    if(typeof address !== 'string' || !/^(0x)?[0-9a-f]{40}$/i.test(address))
         throw new Error('Given address "'+ address +'" is not a valid Ethereum address.');
-
 
 
     address = address.toLowerCase().replace(/^0x/i,'');
@@ -350,7 +347,7 @@ var compareBlockNumbers = function(a, b) {
             return 1;
         } else {
             // b !== ("pending" OR "latest"), thus a > b
-            return -1 
+            return -1
         }
     } else if (a == "pending") {
         // b (== OR <) "latest", thus a > b

--- a/test/extend.js
+++ b/test/extend.js
@@ -77,12 +77,13 @@ describe('web3', function () {
                                 count++;
                         });
 
+                        const params = property.params === 2 ? ['0x11f4d0a3c12e86b4b5f39b213f7e19d048276dae', 'latest'] : [];
                         if(test.property) {
                             assert.isFunction(web3[test.property][property.name]);
-                            web3[test.property][property.name]();
+                            web3[test.property][property.name].apply(web3, params);
                         } else {
                             assert.isFunction(web3[property.name]);
-                            web3[property.name]();
+                            web3[property.name].apply(web3, params);
                         }
                     });
                 }

--- a/test/formatters.inputAddressFormatter.js
+++ b/test/formatters.inputAddressFormatter.js
@@ -24,7 +24,9 @@ var errorTests = [
     '0x11f4d0a3c12e86B4b5F39b213f7E19D048276DAe',
     {},
     [],
-    ''
+    '',
+    undefined,
+    null,
 ];
 
 describe('formatters', function () {


### PR DESCRIPTION
## Description

`Web3.utils.toChecksumAddress` throws for invalid addresses, but for an unknown reason has a special case if input = `undefined`. This PR makes the behavior more predictable by making validation more strict - throwing if the input is not a string. 

## Type of change

Marking this as a **potentially breaking change** since it was previously explicitly allowed (https://github.com/ChainSafe/web3.js/commit/c6c344d7d892d3fa0f02db1f8f2aaebd800637e4), even though it does not seem like expected behavior?