### PR TITLE
Update Github Workflow for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,16 +22,7 @@ jobs:
 
             - uses: actions/checkout@v2
 
-            - uses: actions/cache@v2
-              id: cache-deps
-              with:
-                  path: |
-                      node_modules
-                      */*/node_modules
-                  key: ${{ runner.os }}-node14-${{ hashFiles('**/yarn-lock.json') }}
-
             - run: yarn
-              if: steps.cache-deps.outputs.cache-hit != 'true'
 
             - run: yarn lint
     unit:
@@ -43,16 +34,6 @@ jobs:
 
             - uses: actions/checkout@v2
 
-            - uses: actions/cache@v2
-              id: cache-deps
-              with:
-                  path: |
-                      node_modules
-                      */*/node_modules
-                  key: ${{ runner.os }}-node14-${{ hashFiles('**/yarn-lock.json') }}
-
             - run: yarn
-
-            - run: yarn build
 
             - run: yarn test:unit


### PR DESCRIPTION
- Removes `cache-deps` as it was not working correctly
- Remove unnecessary build step before running unit tests (previous `yarn` command will already run build)