### PR TITLE
Improve timeout handling for the block polling for confirmation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -475,3 +475,7 @@ Released with 1.0.0-beta.37 code base.
 ## [Unreleased]
 
 ## [1.6.2]
+
+### Changed
+
+- Correct `web3.rst` example in documentation (#4511)

--- a/docs/web3.rst
+++ b/docs/web3.rst
@@ -64,7 +64,7 @@ The Web3 class is an umbrella package to house all Ethereum related modules.
 
     var Web3 = require('web3');
 
-    // "Web3.providers.givenProvider" will be set if in an Ethereum supported browser.
+    // "Web3.givenProvider" will be set if in an Ethereum supported browser.
     var web3 = new Web3(Web3.givenProvider || 'ws://some.local-or-remote.node:8546');
 
     > web3.eth

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -205,6 +205,7 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
         timeoutCount = 0,
         confirmationCount = 0,
         intervalId = null,
+        blockHeaderTimeoutId = null,
         lastBlock = null,
         receiptJSON = '',
         gasProvided = ((!!payload.params[0] && typeof payload.params[0] === 'object') && payload.params[0].gas) ? payload.params[0].gas : null,
@@ -273,6 +274,7 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
                 sub = {
                     unsubscribe: function () {
                         clearInterval(intervalId);
+                        clearTimeout(blockHeaderTimeoutId);
                     }
                 };
             }
@@ -572,7 +574,7 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
         });
 
         // Fallback to polling if tx receipt didn't arrived in "blockHeaderTimeout" [10 seconds]
-        setTimeout(() => {
+        blockHeaderTimeoutId = setTimeout(() => {
             if(!blockHeaderArrived) {
                 startInterval();
             }


### PR DESCRIPTION
## Description

Improve the timeout handling to cover one edge case. 

Fixes #4526

## Type of change

- [x] Improvement 

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
