### PR TITLE
add: custom transaction polling interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -484,7 +484,8 @@ Released with 1.0.0-beta.37 code base.
 
 ### Added
 - `maxPriorityFeePerGas` and `maxFeePerGas` added to `Transaction` and `TransactionConfig` interfaces (#4232) (#4585)
-
+- `transactionPollingInterval` added to web3, contract and method constructor options. defaults to 1 second. (#4584)
+- 
 ### Fixed
  -  Fix readthedoc's build for web3js documentation (#4425)
  -  Fix response sorting for batch requests (#4250)

--- a/docs/web3-eth-contract.rst
+++ b/docs/web3-eth-contract.rst
@@ -380,6 +380,27 @@ Returns
 
 ------------------------------------------------------------------------------
 
+.. _eth-contract-module-transactionpollinginterval:
+
+transactionPollingInterval
+=====================
+
+.. code-block:: javascript
+
+    web3.eth.Contract.transactionPollingInterval
+    contract.transactionPollingInterval // on contract instance
+
+The ``transactionPollingInterval`` is used over HTTP connections. This option defines the number of seconds between Web3 calls for a receipt which confirms that a transaction was mined by the network.
+
+
+-------
+Returns
+-------
+
+``number``: The current value of transactionPollingInterval (default: 1000)
+
+------------------------------------------------------------------------------
+
 .. _eth-contract-module-handlerevert:
 
 handleRevert

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -56,6 +56,7 @@ var Method = function Method(options) {
     this.transactionBlockTimeout = options.transactionBlockTimeout || 50;
     this.transactionConfirmationBlocks = options.transactionConfirmationBlocks || 24;
     this.transactionPollingTimeout = options.transactionPollingTimeout || 750;
+    this.transactionPollingInterval = options.transactionPollingInterval || 1000;
     this.blockHeaderTimeout = options.blockHeaderTimeout || 10; // 10 seconds
     this.defaultCommon = options.defaultCommon;
     this.defaultChain = options.defaultChain;
@@ -553,7 +554,7 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
         let blockHeaderArrived = false; 
 
         const startInterval = () => {
-            intervalId = setInterval(checkConfirmation.bind(null, existingReceipt, true), 1000);
+            intervalId = setInterval(checkConfirmation.bind(null, existingReceipt, true), method.transactionPollingInterval);
         };
 
         // If provider do not support event subscription use polling

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -1058,6 +1058,7 @@ Contract.prototype._executeMethod = function _executeMethod(){
                 transactionBlockTimeout: _this._parent.transactionBlockTimeout,
                 transactionConfirmationBlocks: _this._parent.transactionConfirmationBlocks,
                 transactionPollingTimeout: _this._parent.transactionPollingTimeout,
+                transactionPollingInterval: _this._parent.transactionPollingInterval,
                 defaultCommon: _this._parent.defaultCommon,
                 defaultChain: _this._parent.defaultChain,
                 defaultHardfork: _this._parent.defaultHardfork,

--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -234,6 +234,19 @@ var Contract = function Contract(jsonInterface, address, options) {
         },
         enumerable: true
     });
+    Object.defineProperty(this, 'transactionPollingInterval', {
+        get: function () {
+            if (_this.options.transactionPollingInterval === 0) {
+                return _this.options.transactionPollingInterval;
+            }
+
+            return _this.options.transactionPollingInterval || this.constructor.transactionPollingInterval;
+        },
+        set: function (val) {
+            _this.options.transactionPollingInterval = val;
+        },
+        enumerable: true
+    });
     Object.defineProperty(this, 'transactionConfirmationBlocks', {
         get: function () {
             if (_this.options.transactionConfirmationBlocks === 0) {


### PR DESCRIPTION
## Description

allow to set via options the interval which polls for TX status
#2621 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
