### PR TITLE
BatchRequest assumes JSON RPC requests are returned in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,7 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
  -  Fix readthedoc's build for web3js documentation (#4425)
+ -  Fix response sorting for batch requests (#4250)
 
 ### Changed
 

--- a/packages/web3-core-requestmanager/src/batch.js
+++ b/packages/web3-core-requestmanager/src/batch.js
@@ -47,8 +47,10 @@ Batch.prototype.add = function (request) {
  */
 Batch.prototype.execute = function () {
     var requests = this.requests;
+    var sortResponses = this._sortResponses.bind(this);
+
     this.requestManager.sendBatch(requests, function (err, results) {
-        results = results || [];
+        results = sortResponses(results);
         requests.map(function (request, index) {
             return results[index] || {};
         }).forEach(function (result, index) {
@@ -70,6 +72,11 @@ Batch.prototype.execute = function () {
         });
     });
 };
+
+// Sort responses
+Batch.prototype._sortResponses = function (responses) {    
+    return (responses || []).sort((a, b) => a.id - b.id);
+}
 
 module.exports = Batch;
 

--- a/test/batch.js
+++ b/test/batch.js
@@ -6,6 +6,25 @@ var FakeIpcProvider = require('./helpers/FakeIpcProvider');
 
 
 describe('lib/web3/batch', function () {
+    describe('_sortResponses', function () {
+        it('should sort the responses in order of requests', function() {
+            var provider = new FakeIpcProvider();
+            var web3 = new Web3(provider);
+
+            var batch = new web3.BatchRequest();
+            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000000', 'latest', () => {}));
+            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000005', 'latest', () => {}));
+
+            const res1 = {id: 1, result: 'res1'}
+            const res2 = {id: 2, result: 'res2'}
+            const res3 = {id: 3, result: 'res3'}
+            const sortedResponses = batch._sortResponses([res3, res1, res2]);
+
+            assert.deepEqual(sortedResponses, [res1, res2, res3]);
+            batch.execute();
+        });
+    });
+
     describe('execute', function () {
         it('should execute batch request', function (done) {
 


### PR DESCRIPTION
## Description

Fix the sorting logic for the batch request. 

Fixes  #4250

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
