### PR TITLE
ens registry abi - 4.x

### DIFF
--- a/packages/web3-eth-ens/src/ABI/Registry.js
+++ b/packages/web3-eth-ens/src/ABI/Registry.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var REGISTRY = [
+const REGISTRY = [
 	{
 		anonymous: false,
 		inputs: [

--- a/packages/web3-eth-ens/src/ABI/Registry.js
+++ b/packages/web3-eth-ens/src/ABI/Registry.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const REGISTRY = [
 	{
 		anonymous: false,

--- a/packages/web3-eth-ens/src/ABI/Registry.js
+++ b/packages/web3-eth-ens/src/ABI/Registry.js
@@ -1,0 +1,375 @@
+'use strict';
+
+var REGISTRY = [
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+			{
+				indexed: true,
+				internalType: 'address',
+				name: 'operator',
+				type: 'address',
+			},
+			{
+				indexed: false,
+				internalType: 'bool',
+				name: 'approved',
+				type: 'bool',
+			},
+		],
+		name: 'ApprovalForAll',
+		type: 'event',
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				indexed: true,
+				internalType: 'bytes32',
+				name: 'label',
+				type: 'bytes32',
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+		],
+		name: 'NewOwner',
+		type: 'event',
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'resolver',
+				type: 'address',
+			},
+		],
+		name: 'NewResolver',
+		type: 'event',
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				indexed: false,
+				internalType: 'uint64',
+				name: 'ttl',
+				type: 'uint64',
+			},
+		],
+		name: 'NewTTL',
+		type: 'event',
+	},
+	{
+		anonymous: false,
+		inputs: [
+			{
+				indexed: true,
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				indexed: false,
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+		],
+		name: 'Transfer',
+		type: 'event',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+			{
+				internalType: 'address',
+				name: 'operator',
+				type: 'address',
+			},
+		],
+		name: 'isApprovedForAll',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool',
+			},
+		],
+		stateMutability: 'view',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+		],
+		name: 'owner',
+		outputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address',
+			},
+		],
+		stateMutability: 'view',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+		],
+		name: 'recordExists',
+		outputs: [
+			{
+				internalType: 'bool',
+				name: '',
+				type: 'bool',
+			},
+		],
+		stateMutability: 'view',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+		],
+		name: 'resolver',
+		outputs: [
+			{
+				internalType: 'address',
+				name: '',
+				type: 'address',
+			},
+		],
+		stateMutability: 'view',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'address',
+				name: 'operator',
+				type: 'address',
+			},
+			{
+				internalType: 'bool',
+				name: 'approved',
+				type: 'bool',
+			},
+		],
+		name: 'setApprovalForAll',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+		],
+		name: 'setOwner',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+			{
+				internalType: 'address',
+				name: 'resolver',
+				type: 'address',
+			},
+			{
+				internalType: 'uint64',
+				name: 'ttl',
+				type: 'uint64',
+			},
+		],
+		name: 'setRecord',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'address',
+				name: 'resolver',
+				type: 'address',
+			},
+		],
+		name: 'setResolver',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'bytes32',
+				name: 'label',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+		],
+		name: 'setSubnodeOwner',
+		outputs: [
+			{
+				internalType: 'bytes32',
+				name: '',
+				type: 'bytes32',
+			},
+		],
+		stateMutability: 'nonpayable',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'bytes32',
+				name: 'label',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'address',
+				name: 'owner',
+				type: 'address',
+			},
+			{
+				internalType: 'address',
+				name: 'resolver',
+				type: 'address',
+			},
+			{
+				internalType: 'uint64',
+				name: 'ttl',
+				type: 'uint64',
+			},
+		],
+		name: 'setSubnodeRecord',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+			{
+				internalType: 'uint64',
+				name: 'ttl',
+				type: 'uint64',
+			},
+		],
+		name: 'setTTL',
+		outputs: [],
+		stateMutability: 'nonpayable',
+		type: 'function',
+	},
+	{
+		inputs: [
+			{
+				internalType: 'bytes32',
+				name: 'node',
+				type: 'bytes32',
+			},
+		],
+		name: 'ttl',
+		outputs: [
+			{
+				internalType: 'uint64',
+				name: '',
+				type: 'uint64',
+			},
+		],
+		stateMutability: 'view',
+		type: 'function',
+	},
+];
+
+module.exports = REGISTRY;

--- a/packages/web3-eth-ens/src/ABI/Registry.ts
+++ b/packages/web3-eth-ens/src/ABI/Registry.ts
@@ -368,6 +368,6 @@ const REGISTRY = [
 		stateMutability: 'view',
 		type: 'function',
 	},
-];
+] as const;
 
 module.exports = REGISTRY;


### PR DESCRIPTION
This PR only includes the registry ABI for ENS #4601 

Migrate the following ABI from web3-eth-ens 1.x branch to 4.x rewrite
Testing to deploy on private chain and testing the contract code.
Registry Abi:

owner
resolver
ttl
setOwner
setResolver
setTTL
setSubnodeOwner
setRecord
setSubnodeRecord
setApprovalForAll
isApprovedForAll
recordExists

