### PR TITLE
Fix jsonrpc payload and response types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,7 @@ Released with 1.0.0-beta.37 code base.
 -  Update the documentation for `methods.myMethod.estimateGas` (#4702)
 -  Fix typos in REVIEW.md and TESTING.md (#4691)
 -  Fix encoding for "0x" string values (#4512)
+-  Fix jsonrpc payload and response types (#4743)
 
 
 ### Changed

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -17,9 +17,9 @@
  * @date 2018
  */
 
- import * as net from 'net';
- import * as http from 'http';
- import * as https from 'https';
+import * as net from 'net';
+import * as http from 'http';
+import * as https from 'https';
 
 export class formatters {
     static outputBigNumberFormatter(number: number): number;

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -216,7 +216,7 @@ export interface RequestItem {
 export interface JsonRpcPayload {
     jsonrpc: string;
     method: string;
-    params: any[];
+    params?: any[];
     id?: string | number;
 }
 

--- a/packages/web3-core-helpers/types/index.d.ts
+++ b/packages/web3-core-helpers/types/index.d.ts
@@ -17,9 +17,9 @@
  * @date 2018
  */
 
-import * as net from 'net';
-import * as http from 'http';
-import * as https from 'https';
+ import * as net from 'net';
+ import * as http from 'http';
+ import * as https from 'https';
 
 export class formatters {
     static outputBigNumberFormatter(number: number): number;
@@ -222,9 +222,13 @@ export interface JsonRpcPayload {
 
 export interface JsonRpcResponse {
     jsonrpc: string;
-    id: number;
+    id: string | number;
     result?: any;
-    error?: string;
+    error?: {
+      readonly code?: number;
+      readonly data?: unknown;
+      readonly message: string;
+    };
 }
 
 export interface RevertInstructionError extends Error {


### PR DESCRIPTION
## Description
The new Ganache v7 release is not compatible with Web3 as a provider due to some typing issues. We think this is an issue with some of Ganache's and some of Web3's types. This PR fixes the Web3 types.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
