### PR TITLE
Allow web3-providers-ws in web workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Released with 1.0.0-beta.37 code base.
 - Fix hexToNumber and hexToNumberString prefix validation (#3086)
 - The receipt will now returned on a EVM error (this got removed on beta.18) (#3129)
 - Fixes transaction confirmations with the HttpProvider (#3140)
+- Fix error in web worker for web3-providers-ws (#4745)
 
 ## [1.2.3]
 

--- a/packages/web3-providers-ws/src/helpers.js
+++ b/packages/web3-providers-ws/src/helpers.js
@@ -19,7 +19,7 @@ if (isNode || isRN) {
         helpers = require('url').parse;
     }
 } else {
-    _btoa = btoa.bind(window);
+    _btoa = btoa.bind(globalThis);
     helpers = function(url) {
         return new URL(url);
     };


### PR DESCRIPTION
## Description

`window` is not defined in web workers, using `globalThis` allow using ws provider inside a web worker.
NOTE: `globalThis` is widely supported, but not available in internet explorer.

## Type of change

Bug fix

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
