### PR TITLE
Remove morden testnet (#4339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -514,5 +514,10 @@ Released with 1.0.0-beta.37 code base.
 ### Changed
 -  Muted E2E gnosis dex tests in CI until fix for issue #4436 is applied (#4701)
 
+
+### Removed
+- Removed deprecated Morden testnet code (#4339)
+
+
 ### Security
 -  Ran `npm audit fix` to address vulnerabilities and update libraries (#4719) (#4728)

--- a/docs/web3-eth-net.rst
+++ b/docs/web3-eth-net.rst
@@ -33,7 +33,6 @@ Returns
 
 ``Promise`` returns ``String``:
     - ``"main"`` for main network
-    - ``"morden"`` for the morden test network
     - ``"ropsten"`` for the morden test network
     - ``"private"`` for undetectable networks.
 

--- a/packages/web3-eth/src/getNetworkType.js
+++ b/packages/web3-eth/src/getNetworkType.js
@@ -41,10 +41,6 @@ var getNetworkType = function (callback) {
                 id === 1) {
                 returnValue = 'main';
             }
-            if (genesis.hash === '0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303' &&
-                id === 2) {
-                returnValue = 'morden';
-            }
             if (genesis.hash === '0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d' &&
                 id === 3) {
                 returnValue = 'ropsten';

--- a/test/eth.net.getNetworkType.js
+++ b/test/eth.net.getNetworkType.js
@@ -8,10 +8,6 @@ var tests = [{
     id: 1,
     result: 'main'
 },{
-    hash: '0cd786a2425d16f152c658316c423e6ce1181e15c3295826d7c9904cba9ce303',
-    id: 2,
-    result: 'morden'
-},{
     hash: '0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d',
     id: 3,
     result: 'ropsten'


### PR DESCRIPTION
Merged #4339 into branch `wyatt/1.x/4339-remove-morden` so [e2e_windows](https://github.com/ChainSafe/web3.js/runs/5125395312?check_suite_focus=true) test would run