### PR TITLE
Abi type `uint` does not fail with negative numbers

### DIFF
--- a/packages/web3-validator/src/validation/numbers.ts
+++ b/packages/web3-validator/src/validation/numbers.ts
@@ -57,7 +57,11 @@ export const isInt = (
 	let size!: number;
 
 	if (options?.abiType) {
-		const { baseTypeSize } = parseBaseType(options.abiType);
+		const { baseTypeSize, baseType } = parseBaseType(options.abiType);
+
+		if (baseType !== 'int') {
+			return false;
+		}
 
 		if (baseTypeSize) {
 			size = baseTypeSize;

--- a/packages/web3-validator/test/fixtures/validation.ts
+++ b/packages/web3-validator/test/fixtures/validation.ts
@@ -66,12 +66,12 @@ export const invalidIntDataWithSize: [any, number][] = [
 ];
 
 export const validIntDataWithAbiType: [any, string][] = [
-	['-0x48', 'uint8'],
-	['-0x123c', 'uint16'],
-	['-0x0dec0518fa672a70027b04c286582e543ab17319fbdd384fa7bc8f3d5a542c0b', 'uint256'],
-	['-1', 'uint16'],
-	[-1, 'uint8'],
-	[BigInt(-12), 'uint64'],
+	['0x48', 'int8'],
+	['0x123c', 'int16'],
+	['0x0dec0518fa672a70027b04c286582e543ab17319fbdd384fa7bc8f3d5a542c0b', 'int256'],
+	['-1', 'int16'],
+	[-1, 'int8'],
+	[BigInt(-12), 'int64'],
 ];
 
 export const invalidIntDataWithAbiType: [any, string][] = [


### PR DESCRIPTION
## Description

Update the validation issue for the uint. 

Fixes #4777

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
