### PR TITLE
`e2e_windows` Test Failure Fix for #4808

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -533,4 +533,4 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 -  Fix jsonrpc payload and response types (#4743) (#4761)
-
+-  Replaced xhr2-cookies dependency from web3-providers-http module to enable using custom `User-Agent` headers (#4808)

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -15,7 +15,7 @@
     "main": "lib/index.js",
     "dependencies": {
         "web3-core-helpers": "1.7.1",
-        "xhr2-cookies": "1.1.0"
+        "xhr2-cookies-patched": "1.1.0"
     },
     "devDependencies": {
         "dtslint": "^3.4.1",

--- a/packages/web3-providers-http/src/index.js
+++ b/packages/web3-providers-http/src/index.js
@@ -23,7 +23,7 @@
  */
 
 var errors = require('web3-core-helpers').errors;
-var XHR2 = require('xhr2-cookies').XMLHttpRequest; // jshint ignore: line
+var XHR2 = require('xhr2-cookies-patched').XMLHttpRequest; // jshint ignore: line
 var http = require('http');
 var https = require('https');
 

--- a/test/httpprovider.js
+++ b/test/httpprovider.js
@@ -7,7 +7,7 @@ var SandboxedModule = require('sandboxed-module');
 SandboxedModule.registerBuiltInSourceTransformer('istanbul');
 var HttpProvider = SandboxedModule.require('../packages/web3-providers-http', {
     requires: {
-        'xhr2-cookies': require('./helpers/FakeXHR2'),
+        'xhr2-cookies-patched': require('./helpers/FakeXHR2'),
         // 'xmlhttprequest': require('./helpers/FakeXMLHttpRequest')
     },
     singleOnly: true


### PR DESCRIPTION
Merge #4808 into a new branch, so that the `e2e_windows` test may have access to the Infura key