### PR TITLE
Fix confirmation check after transaction getting stuck in a loop in some situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -533,4 +533,4 @@ Released with 1.0.0-beta.37 code base.
 
 ### Fixed
 -  Fix jsonrpc payload and response types (#4743) (#4761)
-
+-  Fix confirmation check not ever finishing in some cases

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -306,7 +306,7 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
                     }
 
                     // check if confirmation listener exists
-                    if (defer.eventEmitter.listeners('confirmation').length > 0) {
+                    if (!canUnsubscribe || defer.eventEmitter.listeners('confirmation').length > 0) {
                         var block;
 
                         // If there was an immediately retrieved receipt, it's already
@@ -339,7 +339,7 @@ Method.prototype._confirmTransaction = function (defer, result, payload) {
                         }
                         canUnsubscribe = false;
 
-                        if (confirmationCount === method.transactionConfirmationBlocks + 1) { // add 1 so we account for conf 0
+                        if (confirmationCount >= method.transactionConfirmationBlocks + 1) { // add 1 so we account for conf 0
                             sub.unsubscribe();
                             defer.eventEmitter.removeAllListeners();
                         }


### PR DESCRIPTION
## Description

Sometimes, the checkConfirmation login became completely stuck and unable to exit properly, wasting a lot of CPU cycles and API calls on nothing.

I've seen this behaviour in situations where the generations of new blocks was slow (in which case polling kicks in and both polling and subscription remained working, but only one of them would ever finish) and when using `.once('confirmation')` on the result of a `sendSignedTransaction` call.

This PR fixes the afforementioned cases in the most simple way I came up with that doesn't break other stuff.


## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have selected the correct base branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
    - Honestly, I have no idea how to test this, it doesn't produce any internally visible anything
- [X] I ran `npm run test:unit` with success.
- [X] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [X] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [X] I have tested my code on the live network.
    - On rinkeby, where I actually had the problem (and the problem is gone)
- [x] I have checked the Deploy Preview and it looks correct.
- [X] I have updated the `CHANGELOG.md` file in the root folder.
