### PR TITLE
Add input formatting to `rpc_method_wrappers` (#4608)

### DIFF
--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -11,7 +11,7 @@ import {
 } from 'web3-common';
 import { Web3Context } from 'web3-core';
 import { Address, BlockTag, Bytes, Filter, HexString32Bytes, Numbers } from 'web3-utils';
-import { isBlockTag, isHexString32Bytes } from 'web3-validator';
+import { isBlockTag, isBytes, isHexString32Bytes } from 'web3-validator';
 import * as rpcMethods from './rpc_methods';
 import {
 	accountSchema,
@@ -128,15 +128,20 @@ export const getCode = async (
 
 export async function getBlock<ReturnFormat extends DataFormat>(
 	web3Context: Web3Context<EthExecutionAPI>,
-	block: HexString32Bytes | BlockNumberOrTag = web3Context.defaultBlock,
+	block: Bytes | BlockNumberOrTag = web3Context.defaultBlock,
 	hydrated = false,
 	returnFormat: ReturnFormat,
 ) {
 	let response;
-	if (isHexString32Bytes(block as string)) {
+	if (isBytes(block)) {
+		const blockHashFormatted = format(
+			{ eth: 'bytes32' },
+			block as Bytes,
+			DEFAULT_RETURN_FORMAT,
+		);
 		response = await rpcMethods.getBlockByHash(
 			web3Context.requestManager,
-			block as HexString32Bytes,
+			blockHashFormatted,
 			hydrated,
 		);
 	} else {
@@ -155,14 +160,19 @@ export async function getBlock<ReturnFormat extends DataFormat>(
 
 export async function getBlockTransactionCount<ReturnFormat extends DataFormat>(
 	web3Context: Web3Context<EthExecutionAPI>,
-	block: HexString32Bytes | BlockNumberOrTag = web3Context.defaultBlock,
+	block: Bytes | BlockNumberOrTag = web3Context.defaultBlock,
 	returnFormat: ReturnFormat,
 ) {
 	let response;
-	if (isHexString32Bytes(block as string)) {
+	if (isBytes(block)) {
+		const blockHashFormatted = format(
+			{ eth: 'bytes32' },
+			block as Bytes,
+			DEFAULT_RETURN_FORMAT,
+		);
 		response = await rpcMethods.getBlockTransactionCountByHash(
 			web3Context.requestManager,
-			block as HexString32Bytes,
+			blockHashFormatted,
 		);
 	} else {
 		const blockNumberFormatted = isBlockTag(block as string)
@@ -179,14 +189,19 @@ export async function getBlockTransactionCount<ReturnFormat extends DataFormat>(
 
 export async function getBlockUncleCount<ReturnFormat extends DataFormat>(
 	web3Context: Web3Context<EthExecutionAPI>,
-	block: HexString32Bytes | BlockNumberOrTag = web3Context.defaultBlock,
+	block: Bytes | BlockNumberOrTag = web3Context.defaultBlock,
 	returnFormat: ReturnFormat,
 ) {
 	let response;
-	if (isHexString32Bytes(block as string)) {
+	if (isBytes(block)) {
+		const blockHashFormatted = format(
+			{ eth: 'bytes32' },
+			block as Bytes,
+			DEFAULT_RETURN_FORMAT,
+		);
 		response = await rpcMethods.getUncleCountByBlockHash(
 			web3Context.requestManager,
-			block as HexString32Bytes,
+			blockHashFormatted,
 		);
 	} else {
 		const blockNumberFormatted = isBlockTag(block as string)
@@ -203,17 +218,22 @@ export async function getBlockUncleCount<ReturnFormat extends DataFormat>(
 
 export async function getUncle<ReturnFormat extends DataFormat>(
 	web3Context: Web3Context<EthExecutionAPI>,
-	block: HexString32Bytes | BlockNumberOrTag = web3Context.defaultBlock,
+	block: Bytes | BlockNumberOrTag = web3Context.defaultBlock,
 	uncleIndex: Numbers,
 	returnFormat: ReturnFormat,
 ) {
 	const uncleIndexFormatted = format({ eth: 'uint' }, uncleIndex, DEFAULT_RETURN_FORMAT);
 
 	let response;
-	if (isHexString32Bytes(block as string)) {
+	if (isBytes(block)) {
+		const blockHashFormatted = format(
+			{ eth: 'bytes32' },
+			block as Bytes,
+			DEFAULT_RETURN_FORMAT,
+		);
 		response = await rpcMethods.getUncleByBlockHashAndIndex(
 			web3Context.requestManager,
-			block as HexString32Bytes,
+			blockHashFormatted,
 			uncleIndexFormatted,
 		);
 	} else {
@@ -263,7 +283,7 @@ export async function getPendingTransactions<ReturnFormat extends DataFormat>(
 
 export async function getTransactionFromBlock<ReturnFormat extends DataFormat>(
 	web3Context: Web3Context<EthExecutionAPI>,
-	block: HexString32Bytes | BlockNumberOrTag = web3Context.defaultBlock,
+	block: Bytes | BlockNumberOrTag = web3Context.defaultBlock,
 	transactionIndex: Numbers,
 	returnFormat: ReturnFormat,
 ) {
@@ -274,10 +294,15 @@ export async function getTransactionFromBlock<ReturnFormat extends DataFormat>(
 	);
 
 	let response;
-	if (isHexString32Bytes(block as string)) {
+	if (isBytes(block)) {
+		const blockHashFormatted = format(
+			{ eth: 'bytes32' },
+			block as Bytes,
+			DEFAULT_RETURN_FORMAT,
+		);
 		response = await rpcMethods.getTransactionByBlockHashAndIndex(
 			web3Context.requestManager,
-			block as HexString32Bytes,
+			blockHashFormatted,
 			transactionIndexFormatted,
 		);
 	} else {

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -462,6 +462,7 @@ export function sendSignedTransaction<ReturnFormat extends DataFormat>(
 	const promiEvent = new PromiEvent<ReceiptInfo, SendSignedTransactionEvents>(resolve => {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		setImmediate(async () => {
+			// Formatting signedTransaction as per returnFormat to be returned to user
 			const signedTransactionFormatted = format(
 				{ eth: 'bytes' },
 				signedTransaction,
@@ -470,6 +471,7 @@ export function sendSignedTransaction<ReturnFormat extends DataFormat>(
 
 			promiEvent.emit('sending', signedTransactionFormatted);
 
+			// Formatting signedTransaction to be send to RPC endpoint
 			const signedTransactionFormattedHex = format(
 				{ eth: 'bytes' },
 				signedTransaction,

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -10,8 +10,8 @@ import {
 	DEFAULT_RETURN_FORMAT,
 } from 'web3-common';
 import { Web3Context } from 'web3-core';
-import { Address, BlockTag, Bytes, Filter, HexString32Bytes, Numbers } from 'web3-utils';
-import { isBlockTag, isBytes, isHexString32Bytes } from 'web3-validator';
+import { Address, BlockTag, Bytes, Filter, Numbers } from 'web3-utils';
+import { isBlockTag, isBytes } from 'web3-validator';
 import * as rpcMethods from './rpc_methods';
 import {
 	accountSchema,

--- a/packages/web3-eth/src/rpc_methods.ts
+++ b/packages/web3-eth/src/rpc_methods.ts
@@ -528,6 +528,11 @@ export async function getProof(
 	storageKey: HexString32Bytes,
 	blockNumber: BlockNumberOrTag,
 ) {
+	validator.validate(
+		['address', 'bytes32', 'blockNumberOrTag'],
+		[address, storageKey, blockNumber],
+	);
+
 	return requestManager.send({
 		method: 'eth_getProof',
 		params: [address, storageKey, blockNumber],

--- a/packages/web3-eth/src/types.ts
+++ b/packages/web3-eth/src/types.ts
@@ -6,7 +6,7 @@ import {
 	FMT_NUMBER,
 	FormatType,
 } from 'web3-common';
-import { Address, Bytes, Numbers } from 'web3-utils';
+import { Address, BlockTag, Bytes, Numbers } from 'web3-utils';
 
 export type ValidChains = 'goerli' | 'kovan' | 'mainnet' | 'rinkeby' | 'ropsten' | 'sepolia';
 export type Hardfork =
@@ -211,3 +211,5 @@ export interface AccountObject {
 	readonly accountProof: Bytes[];
 	readonly storageProof: StorageProof[];
 }
+
+export type BlockNumberOrTag = Numbers | BlockTag;

--- a/packages/web3-eth/src/web3_eth.ts
+++ b/packages/web3-eth/src/web3_eth.ts
@@ -4,17 +4,18 @@ import { DataFormat, DEFAULT_RETURN_FORMAT, TransactionWithSender } from 'web3-c
 import { Web3Context } from 'web3-core';
 import {
 	Address,
-	BlockNumberOrTag,
+	Bytes,
 	Filter,
 	HexString32Bytes,
 	HexString8Bytes,
 	HexStringBytes,
+	Numbers,
 	Uint,
 	Uint256,
 } from 'web3-utils';
 import * as rpcMethods from './rpc_methods';
 import * as rpcMethodsWrappers from './rpc_method_wrappers';
-import { SendTransactionOptions, Transaction, TransactionCall } from './types';
+import { BlockNumberOrTag, SendTransactionOptions, Transaction, TransactionCall } from './types';
 import { Web3EthExecutionAPI } from './web3_eth_execution_api';
 
 export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
@@ -66,14 +67,14 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 
 	public async getStorageAt(
 		address: Address,
-		storageSlot: Uint256,
+		storageSlot: Numbers,
 		blockNumber: BlockNumberOrTag = this.defaultBlock,
 	) {
-		return rpcMethods.getStorageAt(this.requestManager, address, storageSlot, blockNumber);
+		return rpcMethodsWrappers.getStorageAt(this, address, storageSlot, blockNumber);
 	}
 
 	public async getCode(address: Address, blockNumber: BlockNumberOrTag = this.defaultBlock) {
-		return rpcMethods.getCode(this.requestManager, address, blockNumber);
+		return rpcMethodsWrappers.getCode(this, address, blockNumber);
 	}
 
 	public async getBlock<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
@@ -102,14 +103,14 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 
 	public async getUncle<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
 		block: HexString32Bytes | BlockNumberOrTag = this.defaultBlock,
-		uncleIndex: Uint,
+		uncleIndex: Numbers,
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 	) {
 		return rpcMethodsWrappers.getUncle(this, block, uncleIndex, returnFormat);
 	}
 
 	public async getTransaction<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
-		transactionHash: HexString32Bytes,
+		transactionHash: Bytes,
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 	) {
 		return rpcMethodsWrappers.getTransaction(this, transactionHash, returnFormat);
@@ -125,7 +126,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 		ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT,
 	>(
 		block: HexString32Bytes | BlockNumberOrTag = this.defaultBlock,
-		transactionIndex: Uint,
+		transactionIndex: Numbers,
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 	) {
 		return rpcMethodsWrappers.getTransactionFromBlock(
@@ -138,10 +139,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 
 	public async getTransactionReceipt<
 		ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT,
-	>(
-		transactionHash: HexString32Bytes,
-		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
-	) {
+	>(transactionHash: Bytes, returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat) {
 		return rpcMethodsWrappers.getTransactionReceipt(this, transactionHash, returnFormat);
 	}
 
@@ -163,14 +161,16 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 		return rpcMethodsWrappers.sendTransaction(this, transaction, returnFormat, options);
 	}
 
-	public async sendSignedTransaction(transaction: HexStringBytes) {
-		return rpcMethods.sendRawTransaction(this.requestManager, transaction);
+	public async sendSignedTransaction<
+		ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT,
+	>(transaction: Bytes, returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat) {
+		return rpcMethodsWrappers.sendSignedTransaction(this, transaction, returnFormat);
 	}
 
 	// TODO address can be an address or the index of a local wallet in web3.eth.accounts.wallet
 	// https://web3js.readthedocs.io/en/v1.5.2/web3-eth.html?highlight=sendTransaction#sign
-	public async sign(message: HexStringBytes, address: Address) {
-		return rpcMethods.sign(this.requestManager, message, address);
+	public async sign(message: Bytes, address: Address) {
+		return rpcMethodsWrappers.sign(this, message, address);
 	}
 
 	public async signTransaction(transaction: Transaction) {
@@ -186,23 +186,19 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 		return rpcMethodsWrappers.call(this, transaction, blockNumber);
 	}
 
-	// TODO Missing param
 	public async estimateGas<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
-		transaction: Partial<TransactionWithSender>,
+		transaction: Transaction,
 		blockNumber: BlockNumberOrTag = this.defaultBlock,
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 	) {
 		return rpcMethodsWrappers.estimateGas(this, transaction, blockNumber, returnFormat);
 	}
 
-	public async getPastLogs(filter: Filter) {
-		return rpcMethods.getLogs(this.requestManager, {
-			...filter,
-			// These defaults are carried over from 1.x
-			// https://web3js.readthedocs.io/en/v1.5.2/web3-eth.html?highlight=sendTransaction#getpastlogs
-			fromBlock: filter.fromBlock ?? this.defaultBlock,
-			toBlock: filter.toBlock ?? this.defaultBlock,
-		});
+	public async getPastLogs<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
+		filter: Filter,
+		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
+	) {
+		return rpcMethodsWrappers.getLogs(this, filter, returnFormat);
 	}
 
 	public async getWork() {
@@ -232,10 +228,9 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 		return rpcMethods.getNodeInfo(this.requestManager);
 	}
 
-	// TODO - Format input
 	public async getProof<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
 		address: Address,
-		storageKey: HexString32Bytes,
+		storageKey: Bytes,
 		blockNumber: BlockNumberOrTag = this.defaultBlock,
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 	) {
@@ -243,9 +238,9 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI> {
 	}
 
 	public async getFeeHistory<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
-		blockCount: Uint,
+		blockCount: Numbers,
 		newestBlock: BlockNumberOrTag = this.defaultBlock,
-		rewardPercentiles: number[],
+		rewardPercentiles: Numbers[],
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 	) {
 		return rpcMethodsWrappers.getFeeHistory(

--- a/packages/web3-eth/src/web3_eth.ts
+++ b/packages/web3-eth/src/web3_eth.ts
@@ -1,18 +1,8 @@
 // Disabling because returnTypes must be last param to match 1.x params
 /* eslint-disable default-param-last */
-import { DataFormat, DEFAULT_RETURN_FORMAT, TransactionWithSender } from 'web3-common';
+import { DataFormat, DEFAULT_RETURN_FORMAT } from 'web3-common';
 import { Web3Context } from 'web3-core';
-import {
-	Address,
-	Bytes,
-	Filter,
-	HexString32Bytes,
-	HexString8Bytes,
-	HexStringBytes,
-	Numbers,
-	Uint,
-	Uint256,
-} from 'web3-utils';
+import { Address, Bytes, Filter, HexString32Bytes, HexString8Bytes, Numbers } from 'web3-utils';
 import * as rpcMethods from './rpc_methods';
 import * as rpcMethodsWrappers from './rpc_method_wrappers';
 import { BlockNumberOrTag, SendTransactionOptions, Transaction, TransactionCall } from './types';

--- a/packages/web3-eth/test/fixtures/rpc_methods_with_params.ts
+++ b/packages/web3-eth/test/fixtures/rpc_methods_with_params.ts
@@ -260,7 +260,7 @@ export const getFeeHistoryValidData: [Uint, BlockNumberOrTag, number[]][] = [
 export const getProofValidData: [Address, HexString32Bytes, BlockNumberOrTag, AccountObject][] = [
 	[
 		'0x1234567890123456789012345678901234567890',
-		'0x295a70b2de5e3953354a6a8344e616ed314d7251',
+		'0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 		'0x1',
 		{
 			accountProof: [
@@ -289,7 +289,7 @@ export const getProofValidData: [Address, HexString32Bytes, BlockNumberOrTag, Ac
 	],
 	[
 		'0x1234567890123456789012345678901234567890',
-		'0x295a70b2de5e3953354a6a8344e616ed314d7251',
+		'0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 		BlockTags.EARLIEST,
 		{
 			accountProof: [
@@ -318,7 +318,7 @@ export const getProofValidData: [Address, HexString32Bytes, BlockNumberOrTag, Ac
 	],
 	[
 		'0x1234567890123456789012345678901234567890',
-		'0x295a70b2de5e3953354a6a8344e616ed314d7251',
+		'0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 		BlockTags.LATEST,
 		{
 			accountProof: [
@@ -347,7 +347,7 @@ export const getProofValidData: [Address, HexString32Bytes, BlockNumberOrTag, Ac
 	],
 	[
 		'0x1234567890123456789012345678901234567890',
-		'0x295a70b2de5e3953354a6a8344e616ed314d7251',
+		'0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 		BlockTags.PENDING,
 		{
 			accountProof: [

--- a/packages/web3-validator/src/types.ts
+++ b/packages/web3-validator/src/types.ts
@@ -5,7 +5,7 @@ export { JSONSchemaType } from 'ajv';
 export { DataValidateFunction, DataValidationCxt } from 'ajv/dist/types';
 
 export type Web3ValidationErrorObject = ErrorObject;
-export type ValidInputTypes = Buffer | bigint | string | number | boolean;
+export type ValidInputTypes = ArrayBuffer | Buffer | bigint | string | number | boolean;
 
 export type EthBaseTypes = 'bool' | 'bytes' | 'string' | 'uint' | 'int' | 'address' | 'tuple';
 export type EthBaseTypesWithMeta =


### PR DESCRIPTION
This PR expands the parameter types for `rpc_method_wrappers.ts` to allow for `Bytes` and `Numbers` type. These parameters are formatted to hex strings before calling `rpc_methods.ts`

Tests are not included in this PR, but will be added subsequently. I'd like to refactor the `web3-eth` tests to follow the pattern established by #4875, so will include these tests in that PR

This is also completes and closes #4608 