### PR TITLE
Replace deprecated String.prototype.substr() (#4855)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,3 +547,6 @@ Released with 1.0.0-beta.37 code base.
 -  Fix web3-core-method throws on `f.call = this.call` when intrinsic is frozen (#4918) (#4938)
 -  Fix static tuple encoding (#4673) (#4884)
 -  Fix bug in handleRevert logic for eth_sendRawTransaction (#4902)
+
+### Changed
+-  Replace deprecated String.prototype.substr() (#4855)

--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -157,7 +157,7 @@ var _txInputFormatter = function (options) {
     if (options.gas || options.gasLimit) {
         options.gas = options.gas || options.gasLimit;
     }
-    
+
     if (options.maxPriorityFeePerGas || options.maxFeePerGas) {
         delete options.gasPrice;
     }
@@ -402,7 +402,7 @@ var outputLogFormatter = function (log) {
         typeof log.transactionHash === 'string' &&
         typeof log.logIndex === 'string') {
         var shaId = utils.sha3(log.blockHash.replace('0x', '') + log.transactionHash.replace('0x', '') + log.logIndex.replace('0x', ''));
-        log.id = 'log_' + shaId.replace('0x', '').substr(0, 8);
+        log.id = 'log_' + shaId.replace('0x', '').slice(0, 8);
     } else if (!log.id) {
         log.id = null;
     }

--- a/packages/web3-eth-iban/src/index.js
+++ b/packages/web3-eth-iban/src/index.js
@@ -50,7 +50,7 @@ const iso13616Prepare = function (iban) {
     const Z = 'Z'.charCodeAt(0);
 
     iban = iban.toUpperCase();
-    iban = iban.substr(4) + iban.substr(0,4);
+    iban = iban.slice(4) + iban.slice(0, 4);
 
     return iban.split('').map(function(n) {
         const code = n.charCodeAt(0);
@@ -220,7 +220,7 @@ class Iban {
      * @returns {String} checksum
      */
     checksum () {
-        return this._iban.substr(2, 2);
+        return this._iban.slice(2, 4);
     };
 
     /**
@@ -231,7 +231,7 @@ class Iban {
      * @returns {String} institution identifier
      */
     institution () {
-        return this.isIndirect() ? this._iban.substr(7, 4) : '';
+        return this.isIndirect() ? this._iban.slice(7, 11) : '';
     };
 
     /**
@@ -242,7 +242,7 @@ class Iban {
      * @returns {String} client identifier
      */
     client () {
-        return this.isIndirect() ? this._iban.substr(11) : '';
+        return this.isIndirect() ? this._iban.slice(11) : '';
     };
 
     /**
@@ -253,7 +253,7 @@ class Iban {
      */
     toAddress () {
         if (this.isDirect()) {
-            const base36 = this._iban.substr(4);
+            const base36 = this._iban.slice(4);
             const asBn = new BigNumber(base36, 36);
             return utils.toChecksumAddress(asBn.toString(16, 20));
         }

--- a/packages/web3-utils/src/index.js
+++ b/packages/web3-utils/src/index.js
@@ -173,7 +173,7 @@ var hexToAscii = function(hex) {
         i = 2;
     }
     for (; i < l; i+=2) {
-        var code = parseInt(hex.substr(i, 2), 16);
+        var code = parseInt(hex.slice(i, i + 2), 16);
         str += String.fromCharCode(code);
     }
 
@@ -350,7 +350,7 @@ var compareBlockNumbers = function(a, b) {
             return 1;
         } else {
             // b !== ("pending" OR "latest"), thus a > b
-            return -1 
+            return -1
         }
     } else if (a == "pending") {
         // b (== OR <) "latest", thus a > b

--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -207,7 +207,7 @@ var hexToUtf8 = function(hex) {
     var l = hex.length;
 
     for (var i=0; i < l; i+=2) {
-        code = parseInt(hex.substr(i, 2), 16);
+        code = parseInt(hex.slice(i, i + 2), 16);
         // if (code !== 0) {
         str += String.fromCharCode(code);
         // }
@@ -273,7 +273,7 @@ var numberToHex = function (value) {
     var number = toBN(value);
     var result = number.toString(16);
 
-    return number.lt(new BN(0)) ? '-0x' + result.substr(1) : '0x' + result;
+    return number.lt(new BN(0)) ? '-0x' + result.slice(1) : '0x' + result;
 };
 
 
@@ -315,7 +315,7 @@ var hexToBytes = function(hex) {
     hex = hex.replace(/^0x/i,'');
 
     for (var bytes = [], c = 0; c < hex.length; c += 2)
-        bytes.push(parseInt(hex.substr(c, 2), 16));
+        bytes.push(parseInt(hex.slice(c, c + 2), 16));
     return bytes;
 };
 

--- a/test/eth.ens.js
+++ b/test/eth.ens.js
@@ -34,7 +34,7 @@ function prepareProviderForSetter(provider, signature, types, params, error) {
                 gas: '0x64',
                 gasPrice: '0x64',
                 nonce: '0x1',
-                data: sha3(signature).slice(0, 10) + abiCoder.encodeParameters(types, params).substr(2),
+                data: sha3(signature).slice(0, 10) + abiCoder.encodeParameters(types, params).slice(2),
                 to: '0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e'
             }]
         );

--- a/test/utils.sha3.js
+++ b/test/utils.sha3.js
@@ -20,8 +20,8 @@ describe('web3.sha3', function () {
     });
     it('should return sha3 with hex prefix when hex input', function() {
         var sha3Hex = function(value){
-            if (value.length > 2 && value.substr(0, 2) === '0x') {
-                value = value.substr(2);
+            if (value.length > 2 && value.startsWith('0x')) {
+                value = value.slice(2);
             }
             value = CryptoJS.enc.Hex.parse(value);
 


### PR DESCRIPTION
For https://github.com/ChainSafe/web3.js/pull/4855 's e2e windows tests