### PR TITLE
fix: getOrSetDefaultOptions modifies the caller argument

### DIFF
--- a/packages/web3-eth-contract/src/index.js
+++ b/packages/web3-eth-contract/src/index.js
@@ -382,16 +382,16 @@ Contract.prototype._getOrSetDefaultOptions = function getOrSetDefaultOptions(opt
     var gasPrice = options.gasPrice ? String(options.gasPrice): null;
     var from = options.from ? utils.toChecksumAddress(formatters.inputAddressFormatter(options.from)) : null;
 
-    options.data = options.data || this.options.data;
-
-    options.from = from || this.options.from;
-    options.gasPrice = gasPrice || this.options.gasPrice;
-    options.gas = options.gas || options.gasLimit || this.options.gas;
-
     // TODO replace with only gasLimit?
-    delete options.gasLimit;
+    const { gasLimit, ...restOptions } = options;
 
-    return options;
+    return {
+        ...restOptions,
+        data: options.data || this.options.data,
+        from: from || this.options.from,
+        gasPrice: gasPrice || this.options.gasPrice,
+        gas: options.gas || options.gasLimit || this.options.gas,
+    };
 };
 
 


### PR DESCRIPTION
## Description

I'm facing an issue with contract methods call and found out `getOrSetDefaultOptions` modifies the caller argument, if calling multiple methods with the same param object using `Promise.all`, the resolved value will be incorrect. 

There is also something else that changes the value of input args, but in this PR I'm just focusing on `getOrSetDefaultOptions`.

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->
Fixes #5055 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` with success.
- [x] I have tested the built `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
