### PR TITLE
updating web3 utils BN

### DIFF
--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -545,14 +545,7 @@ var BNwrapped = function (value) {
         return new BN(value);
     } 
 };
-BNwrapped.BN = BNwrapped;
-BNwrapped.wordSize = 26;
-BNwrapped.isBN = BN.isBN;
-BNwrapped.max = BN.max;
-BNwrapped.min = BN.min;
-BNwrapped.mont = BN.mont;
-BNwrapped.red = BN.red;
-BNwrapped._prime = BN._prime;
+Object.setPrototypeOf(BNwrapped, BN);
 Object.setPrototypeOf(BNwrapped.prototype, BN.prototype);
 
 module.exports = {

--- a/packages/web3-utils/src/utils.js
+++ b/packages/web3-utils/src/utils.js
@@ -545,6 +545,15 @@ var BNwrapped = function (value) {
         return new BN(value);
     } 
 };
+BNwrapped.BN = BNwrapped;
+BNwrapped.wordSize = 26;
+BNwrapped.isBN = BN.isBN;
+BNwrapped.max = BN.max;
+BNwrapped.min = BN.min;
+BNwrapped.mont = BN.mont;
+BNwrapped.red = BN.red;
+BNwrapped._prime = BN._prime;
+Object.setPrototypeOf(BNwrapped.prototype, BN.prototype);
 
 module.exports = {
     BN: BNwrapped,


### PR DESCRIPTION
Was testing [1.7.4-rc.1](https://github.com/ChainSafe/web3.js/pull/5036) and many open zeppelin testcases were breaking due to the change of updating BN, this was due to us adding `BNwrapped` and not adding the prototype and attributes. 

This PR adds the methods/attributes to the BN object and allows the synthetix tests to pass.