### PR TITLE
Export WebSocketProvider as default

### DIFF
--- a/packages/web3-providers-ws/types/index.d.ts
+++ b/packages/web3-providers-ws/types/index.d.ts
@@ -22,4 +22,4 @@
 
 import { WebsocketProviderBase } from 'web3-core-helpers';
 
-export class WebsocketProvider extends WebsocketProviderBase { }
+export default class WebsocketProvider extends WebsocketProviderBase { }


### PR DESCRIPTION
## Description

Updates export of `WebsocketProvider` in `web3-providers-ws` types to be default so that it is constructible

Fixes https://ethereum.stackexchange.com/questions/34122/typeerror-web3-providers-websocketprovider-is-not-a-constructor

Before change importing WebSocketProvider in a typescript file produces the error `web3_providers_ws_1.WebsocketProvider is not a constructor` when trying to call it with `new WebsocketProvider("<host>", { ... })`

## Type of change

Changes export type

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` with success.
- [ ] I have tested the built `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
