### PR TITLE
Polling for new blocks after blockHeaderTimeout passes or if error happened

### DIFF
--- a/packages/web3-eth/test/integration/defaults.test.ts
+++ b/packages/web3-eth/test/integration/defaults.test.ts
@@ -509,14 +509,14 @@ describe('defaults', () => {
 
 			// To cause the development node (like Ganache) to generate new block for the new transaction
 			// When another block is generated, the pervious transaction would be able to have 2 confirmations
-			setTimeout(() => {
-				// eslint-disable-next-line @typescript-eslint/no-floating-promises
-				eth.sendTransaction({
-					to,
-					value,
-					from,
-				});
-			}, 1000);
+			await new Promise<void>(resolve => {
+				setTimeout(resolve, 1000);
+			});
+			await eth.sendTransaction({
+				to,
+				value,
+				from,
+			});
 
 			// Ensure the promise the get the confirmations resolves with no error
 			await expect(confirmationPromise).resolves.toBeUndefined();

--- a/packages/web3-eth/test/integration/defaults.test.ts
+++ b/packages/web3-eth/test/integration/defaults.test.ts
@@ -464,9 +464,7 @@ describe('defaults', () => {
 			//	to ensure that polling of new blocks works in such cases.
 			// I will cause the providers that supports subscription (like WebSocket)
 			// 	to never return data through listening to new events
-			(eth.provider as Web3BaseProvider<Record<string, never>>).on = async (
-				..._args: unknown[]
-			) => {
+			(eth.provider as Web3BaseProvider<Record<string, never>>).on = async () => {
 				// eslint-disable-next-line no-promise-executor-return
 				await new Promise(res => setTimeout(res, 1000000));
 			};

--- a/packages/web3-eth/test/integration/defaults.test.ts
+++ b/packages/web3-eth/test/integration/defaults.test.ts
@@ -464,6 +464,7 @@ describe('defaults', () => {
 			//	to ensure that polling of new blocks works in such cases.
 			// I will cause the providers that supports subscription (like WebSocket)
 			// 	to never return data through listening to new events
+			// eslint-disable-next-line @typescript-eslint/no-misused-promises
 			(eth.provider as Web3BaseProvider<Record<string, never>>).on = async () => {
 				// eslint-disable-next-line no-promise-executor-return
 				await new Promise(res => setTimeout(res, 1000000));

--- a/packages/web3-eth/test/integration/defaults.test.ts
+++ b/packages/web3-eth/test/integration/defaults.test.ts
@@ -19,7 +19,7 @@ import WebSocketProvider from 'web3-providers-ws';
 import { Contract } from 'web3-eth-contract';
 import { hexToNumber, numberToHex, DEFAULT_RETURN_FORMAT } from 'web3-utils';
 import { TransactionBuilder, TransactionTypeParser, Web3Context, Web3PromiEvent } from 'web3-core';
-import { TransactionReceipt } from 'web3-types';
+import { TransactionReceipt, Web3BaseProvider } from 'web3-types';
 import {
 	prepareTransactionForSigning,
 	SendTransactionEvents,
@@ -449,6 +449,80 @@ describe('defaults', () => {
 			});
 			expect(eth2.blockHeaderTimeout).toBe(4);
 		});
+
+		it('should fallback to polling if provider support `on` but `newBlockHeaders` does not arrive in `blockHeaderTimeout` seconds', async () => {
+			const eth = new Web3Eth(clientUrl);
+
+			// Ensure the provider supports subscriptions to simulate the test scenario
+			// It will cause providers that does not support subscriptions (like http) to throw exception when subscribing.
+			// This case is tested to ensure that even if an error happen at subscription,
+			//	polling will still get the data from next blocks.
+			(eth.provider as Web3BaseProvider<Record<string, never>>).supportsSubscriptions = () =>
+				true;
+
+			// Cause the events to take a long time (more than blockHeaderTimeout),
+			//	to ensure that polling of new blocks works in such cases.
+			// I will cause the providers that supports subscription (like WebSocket)
+			// 	to never return data through listening to new events
+			(eth.provider as Web3BaseProvider<Record<string, never>>).on = async (
+				..._args: unknown[]
+			) => {
+				// eslint-disable-next-line no-promise-executor-return
+				await new Promise(res => setTimeout(res, 1000000));
+			};
+
+			// Make the test run faster by casing the polling to start after 1 second
+			eth.blockHeaderTimeout = 1;
+
+			const from = accounts[0];
+			const to = accounts[1];
+			const value = `0x1`;
+
+			const sentTx: Web3PromiEvent<
+				TransactionReceipt,
+				SendTransactionEvents<typeof DEFAULT_RETURN_FORMAT>
+			> = eth.sendTransaction({
+				to,
+				value,
+				from,
+			});
+
+			const confirmationPromise = new Promise((resolve: Resolve) => {
+				// Tx promise is handled separately
+				// eslint-disable-next-line no-void
+				void sentTx.on(
+					'confirmation',
+					({
+						confirmations,
+						receipt: { status },
+					}: {
+						confirmations: bigint;
+						receipt: { status: bigint };
+					}) => {
+						expect(status).toBe(BigInt(1));
+						// Being able to get 2 confirmations means the pooling for new blocks works
+						if (confirmations >= 2) {
+							resolve();
+						}
+					},
+				);
+			});
+
+			// To cause the development node (like Ganache) to generate new block for the new transaction
+			// When another block is generated, the pervious transaction would be able to have 2 confirmations
+			setTimeout(() => {
+				// eslint-disable-next-line @typescript-eslint/no-floating-promises
+				eth.sendTransaction({
+					to,
+					value,
+					from,
+				});
+			}, 1000);
+
+			// Ensure the promise the get the confirmations resolves with no error
+			await expect(confirmationPromise).resolves.toBeUndefined();
+		});
+
 		it('maxListenersWarningThreshold', () => {
 			// default
 			expect(web3Eth.maxListenersWarningThreshold).toBe(100);


### PR DESCRIPTION

## Description
Watch by polling for new blocks, if `blockHeaderTimeout` had passed without receiving the data of new blocks, or if an error happed while trying to watch for new blocks.

This is according to the issue: https://github.com/ChainSafe/web3.js/issues/5112 (Additionally, if an error happens, start polling).

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `yarn lint` with success and extended the tests and types if necessary.
- [x] I ran `yarn test:integration` and my test cases cover all the lines and branches of the added code.
- [x] I ran `yarn build` with success.
- [ ] I have tested the built `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
