### PR TITLE
Invalid `transactionPollingTimeout` compared to `transactionPollingInterval`

### DIFF
--- a/packages/web3-core/src/web3_config.ts
+++ b/packages/web3-core/src/web3_config.ts
@@ -64,7 +64,7 @@ export abstract class Web3Config
 		transactionBlockTimeout: 50,
 		transactionConfirmationBlocks: 24,
 		transactionPollingInterval: 1000,
-		transactionPollingTimeout: 750,
+		transactionPollingTimeout: 750 * 1000,
 		transactionReceiptPollingInterval: undefined,
 		transactionConfirmationPollingInterval: undefined,
 		blockHeaderTimeout: 10,

--- a/packages/web3-core/test/unit/__snapshots__/web3_context.test.ts.snap
+++ b/packages/web3-core/test/unit/__snapshots__/web3_context.test.ts.snap
@@ -20,7 +20,7 @@ Object {
     "transactionConfirmationBlocks": 24,
     "transactionConfirmationPollingInterval": undefined,
     "transactionPollingInterval": 1000,
-    "transactionPollingTimeout": 750,
+    "transactionPollingTimeout": 750000,
     "transactionReceiptPollingInterval": undefined,
     "transactionTypeParser": undefined,
   },

--- a/packages/web3-core/test/unit/web3_config.test.ts
+++ b/packages/web3-core/test/unit/web3_config.test.ts
@@ -33,7 +33,7 @@ const defaultConfig = {
 	transactionBlockTimeout: 50,
 	transactionConfirmationBlocks: 24,
 	transactionPollingInterval: 1000,
-	transactionPollingTimeout: 750,
+	transactionPollingTimeout: 750 * 1000,
 	transactionReceiptPollingInterval: undefined,
 	transactionConfirmationPollingInterval: undefined,
 	defaultTransactionType: '0x0',

--- a/packages/web3-eth/test/integration/defaults.test.ts
+++ b/packages/web3-eth/test/integration/defaults.test.ts
@@ -340,7 +340,7 @@ describe('defaults', () => {
 		it('transactionPollingInterval and transactionPollingTimeout', () => {
 			// default
 			expect(web3Eth.transactionPollingInterval).toBe(1000);
-			expect(web3Eth.transactionPollingTimeout).toBe(750);
+			expect(web3Eth.transactionPollingTimeout).toBe(750 * 1000);
 
 			// after set
 			web3Eth.setConfig({


### PR DESCRIPTION
## Description

Fixes #5320

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` with success.
- [x] I have tested the built `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
