### PR TITLE
Enable subscribing to `error` event at `WebSocketProvider` underlying connection

### DIFF
--- a/packages/web3-providers-ws/src/index.ts
+++ b/packages/web3-providers-ws/src/index.ts
@@ -17,7 +17,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 import { EventEmitter } from 'events';
 import { ClientRequestArgs } from 'http';
-import WebSocket, { ClientOptions, CloseEvent, MessageEvent } from 'isomorphic-ws';
+import WebSocket, { ClientOptions, CloseEvent, ErrorEvent, MessageEvent } from 'isomorphic-ws';
 import {
 	EthExecutionAPI,
 	JsonRpcId,
@@ -72,6 +72,7 @@ export default class WebSocketProvider<
 	private readonly _onMessageHandler: (event: MessageEvent) => void;
 	private readonly _onOpenHandler: () => void;
 	private readonly _onCloseHandler: (event: CloseEvent) => void;
+	private readonly _onErrorHandler: (event: ErrorEvent) => void;
 
 	public constructor(
 		clientUrl: string,
@@ -102,6 +103,7 @@ export default class WebSocketProvider<
 		this._onMessageHandler = this._onMessage.bind(this);
 		this._onOpenHandler = this._onConnect.bind(this);
 		this._onCloseHandler = this._onClose.bind(this);
+		this._onErrorHandler = this._onError.bind(this);
 
 		this._init();
 		this.connect();
@@ -253,6 +255,11 @@ export default class WebSocketProvider<
 		this._webSocketConnection?.addEventListener('message', this._onMessageHandler);
 		this._webSocketConnection?.addEventListener('open', this._onOpenHandler);
 		this._webSocketConnection?.addEventListener('close', this._onCloseHandler);
+
+		// the error event listener may be already there because we do not remove it like the others
+		if (!this._webSocketConnection?.listeners('error')[0]) {
+			this._webSocketConnection?.addEventListener('error', this._onErrorHandler);
+		}
 	}
 
 	private _reconnect(): void {
@@ -331,6 +338,10 @@ export default class WebSocketProvider<
 		this._removeSocketListeners();
 	}
 
+	private _onError(event: ErrorEvent): void {
+		this._wsEventEmitter.emit('error', event);
+	}
+
 	private _clearQueues(event?: CloseEvent) {
 		if (this._pendingRequestsQueue.size > 0) {
 			this._pendingRequestsQueue.forEach(
@@ -357,6 +368,7 @@ export default class WebSocketProvider<
 		this._webSocketConnection?.removeEventListener('message', this._onMessageHandler);
 		this._webSocketConnection?.removeEventListener('open', this._onOpenHandler);
 		this._webSocketConnection?.removeEventListener('close', this._onCloseHandler);
+		// note: we intentionally keep the error event listener to be able to emit it in case an error happens when closing the connection
 	}
 
 	private _emitCloseEvent(code?: number, reason?: string): void {

--- a/packages/web3-providers-ws/test/integration/web_socket_provider_integration.test.ts
+++ b/packages/web3-providers-ws/test/integration/web_socket_provider_integration.test.ts
@@ -143,6 +143,22 @@ describeIf(isWs)('WebSocketProvider - implemented methods', () => {
 			webSocketProvider.disconnect(code);
 			await closePromise;
 		});
+
+		it('should be able to listen to `error` events that happen at the underlying websocket connection', async () => {
+			const wsProvider2 = new WebSocketProvider('ws://localhost:8545');
+			const validateEmittingErrors = new Promise((_, reject) => {
+				wsProvider2.on('error', (err: { message: string } | undefined) => {
+					reject(err?.message);
+				});
+			});
+
+			// This is a too early close of the connection that will cause the underlying connection to raise an error
+			wsProvider2.disconnect();
+
+			await expect(validateEmittingErrors).rejects.toMatch(
+				'WebSocket was closed before the connection was established',
+			);
+		});
 	});
 	describe('disconnect and reset test', () => {
 		it('should disconnect', async () => {


### PR DESCRIPTION
## Description

Implementation of  #([5330](https://github.com/ChainSafe/web3.js/issues/5330))


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` with success.
- [ ] I have tested the built `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
