### PR TITLE
Block Schema Fix

### DIFF
--- a/packages/web3-eth/src/schemas.ts
+++ b/packages/web3-eth/src/schemas.ts
@@ -281,12 +281,21 @@ export const blockSchema = {
 		size: {
 			eth: 'uint',
 		},
-		// TODO: This attribute can be array of hashes or transaction info
 		transactions: {
-			type: 'array',
-			items: {
-				...transactionInfoSchema,
-			},
+			oneOf: [
+				{
+					type: 'array',
+					items: {
+						...transactionInfoSchema,
+					},
+				},
+				{
+					type: 'array',
+					items: {
+						eth: 'bytes32',
+					},
+				},
+			],
 		},
 		uncles: {
 			type: 'array',

--- a/packages/web3-eth/test/integration/rpc.block.test.ts
+++ b/packages/web3-eth/test/integration/rpc.block.test.ts
@@ -16,11 +16,13 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 import WebSocketProvider from 'web3-providers-ws';
 import { FMT_BYTES, FMT_NUMBER } from 'web3-utils';
-import { Block, TransactionInfo, TransactionReceipt } from 'web3-types';
+import { TransactionInfo, TransactionReceipt } from 'web3-types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Contract } from 'web3-eth-contract';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import IpcProvider from 'web3-providers-ipc';
+import { validator } from 'web3-validator';
+
 import { Web3Eth } from '../../src';
 
 import {
@@ -32,7 +34,8 @@ import {
 } from '../fixtures/system_test_utils';
 import { BasicAbi, BasicBytecode } from '../shared_fixtures/build/Basic';
 import { toAllVariants } from '../shared_fixtures/utils';
-import { sendFewTxes, validateBlock, validateTransaction } from './helper';
+import { sendFewTxes, validateTransaction } from './helper';
+import { blockSchema } from '../../src/schemas';
 
 describe('rpc with block', () => {
 	let web3Eth: Web3Eth;
@@ -128,7 +131,7 @@ describe('rpc with block', () => {
 				b.miner = '0x0000000000000000000000000000000000000000';
 				b.totalDifficulty = '0x0';
 			}
-			validateBlock(b as Block);
+			expect(validator.validateJSONSchema(blockSchema, b)).toBeUndefined();
 		});
 
 		it.each(

--- a/packages/web3-utils/src/formatter.ts
+++ b/packages/web3-utils/src/formatter.ts
@@ -145,7 +145,6 @@ export const convert = (
 	schema: JsonSchema,
 	dataPath: string[],
 	format: DataFormat,
-	knownSchemaProp?: JsonSchema,
 ) => {
 	// If it's a scalar value
 	if (!isObject(data) && !Array.isArray(data)) {
@@ -156,7 +155,7 @@ export const convert = (
 
 	for (const [key, value] of Object.entries(object)) {
 		dataPath.push(key);
-		const schemaProp = knownSchemaProp ?? findSchemaByDataPath(schema, dataPath);
+		const schemaProp = findSchemaByDataPath(schema, dataPath);
 
 		// If value is a scaler value
 		if (isNullish(schemaProp)) {
@@ -181,7 +180,7 @@ export const convert = (
 			// a schema using oneOf. This chunk of code was intended to handle
 			// BlockSchema.transactions
 			// TODO BlockSchema.transactions are not being formatted
-			if (schemaProp?.oneOf) {
+			if (schemaProp?.oneOf !== undefined) {
 				for (const oneOfSchemaProp of schemaProp.oneOf) {
 					if (
 						!Array.isArray(schemaProp?.items) &&
@@ -231,7 +230,6 @@ export const convert = (
 						schema,
 						dataPath,
 						format,
-						_schemaProp,
 					);
 				}
 

--- a/packages/web3-utils/src/formatter.ts
+++ b/packages/web3-utils/src/formatter.ts
@@ -145,6 +145,7 @@ export const convert = (
 	schema: JsonSchema,
 	dataPath: string[],
 	format: DataFormat,
+	knownSchemaProp?: JsonSchema,
 ) => {
 	// If it's a scalar value
 	if (!isObject(data) && !Array.isArray(data)) {
@@ -155,7 +156,7 @@ export const convert = (
 
 	for (const [key, value] of Object.entries(object)) {
 		dataPath.push(key);
-		const schemaProp = findSchemaByDataPath(schema, dataPath);
+		const schemaProp = knownSchemaProp ?? findSchemaByDataPath(schema, dataPath);
 
 		// If value is a scaler value
 		if (isNullish(schemaProp)) {
@@ -174,7 +175,29 @@ export const convert = (
 
 		// If value is an array
 		if (Array.isArray(value)) {
-			if (isNullish(schemaProp?.items)) {
+			let _schemaProp = schemaProp;
+
+			// TODO This is a naive approach to solving the issue of
+			// a schema using oneOf. This chunk of code was intended to handle
+			// BlockSchema.transactions
+			// TODO BlockSchema.transactions are not being formatted
+			if (schemaProp?.oneOf) {
+				for (const oneOfSchemaProp of schemaProp.oneOf) {
+					if (
+						!Array.isArray(schemaProp?.items) &&
+						((typeof value[0] === 'object' &&
+							((oneOfSchemaProp as JsonSchema)?.items as JsonSchema)?.type ===
+								'object') ||
+							(typeof value[0] === 'string' &&
+								((oneOfSchemaProp as JsonSchema)?.items as JsonSchema)?.type !==
+									'object'))
+					) {
+						_schemaProp = oneOfSchemaProp as JsonSchema;
+					}
+				}
+			}
+
+			if (isNullish(_schemaProp?.items)) {
 				// Can not find schema for array item, delete that item
 				delete object[key];
 				dataPath.pop();
@@ -183,12 +206,12 @@ export const convert = (
 			}
 
 			// If schema for array items is a single type
-			if (isObject(schemaProp.items) && !isNullish(schemaProp.items.eth)) {
+			if (isObject(_schemaProp.items) && !isNullish(_schemaProp.items.eth)) {
 				for (let i = 0; i < value.length; i += 1) {
 					(object[key] as unknown[])[i] = convertScalarValue(
 						value[i],
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-						schemaProp?.items?.eth as string,
+						_schemaProp?.items?.eth as string,
 						format,
 					);
 				}
@@ -199,8 +222,8 @@ export const convert = (
 
 			// If schema for array items is an object
 			if (
-				!Array.isArray(schemaProp?.items) &&
-				(schemaProp?.items as JsonSchema).type === 'object'
+				!Array.isArray(_schemaProp?.items) &&
+				(_schemaProp?.items as JsonSchema).type === 'object'
 			) {
 				for (const arrObject of value) {
 					convert(
@@ -208,6 +231,7 @@ export const convert = (
 						schema,
 						dataPath,
 						format,
+						_schemaProp,
 					);
 				}
 
@@ -216,11 +240,11 @@ export const convert = (
 			}
 
 			// If schema for array is a tuple
-			if (Array.isArray(schemaProp?.items)) {
+			if (Array.isArray(_schemaProp?.items)) {
 				for (let i = 0; i < value.length; i += 1) {
 					(object[key] as unknown[])[i] = convertScalarValue(
 						value[i],
-						(schemaProp.items as JsonSchema[])[i].eth as string,
+						(_schemaProp.items as JsonSchema[])[i].eth as string,
 						format,
 					);
 				}

--- a/packages/web3-utils/src/formatter.ts
+++ b/packages/web3-utils/src/formatter.ts
@@ -181,6 +181,11 @@ export const convert = (
 			// BlockSchema.transactions
 			// TODO BlockSchema.transactions are not being formatted
 			if (schemaProp?.oneOf !== undefined) {
+				// The following code is basically saying:
+				// if the schema specifies oneOf, then we are to loop
+				// over each possible schema and check if they type of the schema
+				// matches the type of value[0], and if so we use the oneOfSchemaProp
+				// as the schema for formatting
 				for (const oneOfSchemaProp of schemaProp.oneOf) {
 					if (
 						!Array.isArray(schemaProp?.items) &&


### PR DESCRIPTION
`blockSchema.transactions` can either be an array of transaction hashes, or an array of transaction objects. Before this PR the schema only handled an array of transaction hashes. The fix that was applied here is very specific to handling `oneOf` for transactions, so I'm not confident in this being a good general solution for the use of `oneOf` in schemas and this code should be refactored to be more general