### PR TITLE
Release/4.0.0 alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,8 +600,6 @@ Released with 1.0.0-beta.37 code base.
 
 -   Updated `got` lib version and fixed other libs using npm audit fix (#5178) (#5254)
 
-## [Unreleased]
-
 ## [4.0.0-alpha.0]
 
 ### Added
@@ -724,3 +722,5 @@ Released with 1.0.0-beta.37 code base.
 
 -   `givenProvider` default value is undefined
 -   `currentProvider` default value is undefined
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -591,7 +591,7 @@ Released with 1.0.0-beta.37 code base.
 -   Fix typos in web3-eth-accounts.rst & TESTING.md (#5047)
 -   Fix remove wallet using an index when an account address and address lowercase are equal (#5049)
 -   Improve README.md & Fix typos (#4848)
--   Add optional hex formatting parameter for getTransactionrReceipt (#5153)
+-   Add optional hex formatting parameter for getTransactionReceipt (#5153)
 -   Fix transactionRoot -> transactionsRoot in BlockHeader (#5083)
 -   Fix Promise in Accounts.signTransaction() throwing errors that cannot be caught (#4724)
 -   Fixed unit tests & removed dead code for web3-providers-http (#5228)
@@ -602,7 +602,7 @@ Released with 1.0.0-beta.37 code base.
 
 ## [Unreleased]
 
-## [4.0.0-alpha.1]
+## [4.0.0-alpha.0]
 
 ### Added
 

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.0-alpha.1",
+	"version": "4.0.0-alpha.0",
 	"description": "Ethereum JavaScript API",
 	"main": "dist/index.js",
 	"browser": "dist/web3.min.js",

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.0-alpha.1' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.0-alpha.0' };


### PR DESCRIPTION
### Summary
Web3.js 4.0.0-alpha.0 is a complete overhaul. This alpha version is written in TypeScript and has many exciting features.  Features such as:
-  Full types support ( including Dynamic Contracts Typing  )
- ETH functions optional data formatters
- ETH RPC method wrappers for advance users
- Validation functionality using schema
- Configurable behavior of the sendTransaction
- Easy extensibility and high readability
- Clear specs of base wallet, base providers and much more

Check out our 4.x API documentation (https://docs.web3js.org/) for the full details. The release contains mostly 1.x parity functionality with some documented breaking changes.  Most of the packages in this release have been unit tested and only selected packages are E2E tested (web3, web3-eth, web3-contracts, web3-eth-personal, web3-providers-http and  web3-providers-ws). 

Checkout our 1.x to 4.x migration guide (https://docs.web3js.org/docs/guides/web3_migration_guide) for testing the 4.0.0-alpha.0 release and share your feedback with us.  


### Added

#### web3-errors

-   `web3-errors` new package is created, it has Web3 Error codes and classes

#### web3-types

-   `web3-types` new package is created, it provides the common data structures and interfaces for web3 modules

#### web3-validator

-   `web3-validator` new package is created, it has JSON-Schema compatible validator functionality for Web3

### Removed

#### web3-bzz

-   This Package is deprecated

#### web3-shh

-   This Package is deprecated

#### web3-core-helpers

-   This Package is removed, `errors` are moved to `web3-errors` package and formatters are moved in `web3-core` package

#### web3-core-method

-   This Package is removed, and `web3-core-method` functionality is moved to `web3-eth` package

#### web3-core-promieevent

-   This Package is removed, and core promi events functionality is moved to `web3-core` package

#### web3-core-requestmanager

-   This Package is removed, batch requests and request manager functionality is moved to `web3-core` package

#### web3-core-subscription

-   This Package is removed, and core subscription functionality is moved to `web3-core` package

### Changed

#### web3

-   Passing callbacks to functions is no longer supported, except for event listeners.
-   Method `extend` is deprecated

#### web3-core

-   The function `outputBigNumberFormatter` in `web3-core-helper` renamed to `outputBigIntFormatter` under `web3-core`
-   Removed `this.defaultBlock` context from `inputDefaultBlockNumberFormatter` in `web3-core-helper` and converted to additional parameter
-   Removed `this.defaultBlock` context from `inputTransactionFormatter` in `web3-core-helper` and converted to additional parameter

#### web3-utils

-   The following functions `soliditySha3` `soliditySha3Raw` `encodePacked` now includes type validation and requires type specification, instead of guessing the value type
-   The functions `soliditySha3`, `soliditySha3Raw` and `encodePacked` did not support BN; But, now supports `BigInt`
-   The functions `flattenTypes` and `jsonInterfaceMethodToString` moved to the `web3-eth-abi` package
-   The function `isAddress` now includes an optional parameter `checkChecksum` type boolean
-   `isBoolean` now accept `1`, and `0` as valid values to test. Ref: `web3-validator`

#### web3-eth-accounts

-   `create` function does not take in the optional parameter `entropy`
-   `Wallet.create` function doesn't accept `entropy` param

#### web3-validator

-   `isBoolean` now accept `1`, and `0` as valid values to test.

#### web3-eth-contract

-   Event logs do not support types for indexed properties, but named properties are supported.
-   Types for overloaded ABI functions are not yet supported.
-   `signTransaction` will not fill any default values, and it will only sign and return result. For filling default values, use `web3-eth` package
-   `recover` function's last param is boolean `hashed`, it is used to indicate if data provided is already hashed or not. By default, this function will assume data is not hashed.
-   The `Wallet` no longer supports address/number indexing. Have to use `wallet.get` instead.
-   `Wallet.create` function doesn't accept `entropy` param
-   `contract.method.send()` will resolve to transaction receipt instead of `transactionHash`. User can use `receipt.transactionHash` instead.

#### web3-net

-   Package will not support web3.bzz.net and web3.shh.net

#### web3-eth-iban

-   IBAN constructor now has validation checks for indirect/direct iban.
-   `isDirect`, `isValid`, `isIndirect` are now also included as static methods.

#### web3-eth-ens

-   `setMultihash` is not supported in web3-eth-ens 4.x as it's deprecated in ENS public resolver (https://github.com/ensdomains/resolvers/blob/master/contracts/PublicResolver.sol)
-   `setContent` is not supported in web3-eth-ens 4.x as it's deprecated in ENS public resolver (https://github.com/ensdomains/resolvers/blob/master/contracts/PublicResolver.sol)
-   `getContent` is not supported in web3-eth-ens 4.x as it's deprecated in ENS public resolver.
-   `getMultihash` is not supported in web3-eth-ens 4.x as it's deprecated in ENS public resolver.

#### web3-eth-abi

-   `internalType` was renamed to `baseType` in all abi types

#### web3-eth

-   `givenProvider` default value is undefined
-   `defaultHardfork` default value is 'london'
-   `defaultAccount` default value is undefined
-   `defaultNetworkId` default value is undefined
-   When sending a transaction, if Ethereum Node does not respond within `transactionSendTimeout`, throw an Error.

#### web3-eth-subscribe

-   `clearSubscriptions` Instead of returning `true` , `clearSubscriptions` now returns array of subscription's ids

#### web3-eth-personal

-   `givenProvider` default value is undefined
-   `currentProvider` default value is undefined
