### PR TITLE
Throw error on broken links in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -46,7 +46,7 @@ const config = {
 	url: 'https://docs.web3js.org',
 	baseUrl: '/',
 	onBrokenLinks: 'throw',
-	onBrokenMarkdownLinks: 'warn',
+	onBrokenMarkdownLinks: 'throw',
 	favicon: 'img/favicon.ico',
 
 	// GitHub pages deployment config.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,7 +45,7 @@ const config = {
 	tagline: 'The ultimate JavaScript library for Ethereum',
 	url: 'https://docs.web3js.org',
 	baseUrl: '/',
-	onBrokenLinks: 'warn',
+	onBrokenLinks: 'throw',
 	onBrokenMarkdownLinks: 'warn',
 	favicon: 'img/favicon.ico',
 


### PR DESCRIPTION
## Description

Reverts setting back to 'throw' error when we have broken links in the docs. 

## Checklist for 4.x:

- [ ] I have selected the correct 4.x base branch.
- [ ] Within the description, the feature or issue is discussed in detail or an issue is linked.   
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added any required tests for the changes I made 
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `yarn` successfully
- [ ] I ran `yarn lint` successfully
- [ ] I ran `yarn build:web` successfully
- [ ] I ran `yarn test:unit` successfully
- [ ] I ran `yarn test:integration` successfully
- [ ] I ran `compile:contracts` successfully
- [ ] I have tested my code.
- [ ] I have updated the corresponding `CHANGELOG.md` file in the packages I have edited.
