### PR TITLE
`setImmediate` Not Defined in Browsers Fix

### DIFF
--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -34,3 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I've improved the security in XY (#1000)
 
 -->
+
+## [4.0.1-alpha.1]
+
+### Added
+
+-   `setimmediate` package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [4.0.1-alpha.1]
+## [Unreleased]
 
 ### Added
 

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -39,4 +39,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   `setimmediate` package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
+-   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -47,6 +47,7 @@
 	"dependencies": {
 		"@ethereumjs/common": "^2.6.5",
 		"@ethereumjs/tx": "^3.5.2",
+		"setimmediate": "^1.0.5",
 		"web3-core": "^4.0.1-alpha.0",
 		"web3-errors": "^0.1.1-alpha.0",
 		"web3-eth-accounts": "^4.0.1-alpha.0",

--- a/packages/web3-eth/src/index.ts
+++ b/packages/web3-eth/src/index.ts
@@ -45,6 +45,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 /**
  *
  */
+import 'setimmediate';
 
 import { Web3Eth } from './web3_eth';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9378,7 +9378,7 @@ set-value@^2.0.0, set-value@^2.0.1:
 
 setimmediate@^1.0.5:
   version "1.0.5"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  resolved "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.2.0:


### PR DESCRIPTION
## What This PR Does

 [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) is [not supported](https://caniuse.com/?search=setimmediate) by most browsers. [This](https://github.com/yuzujs/setImmediate) popular package was added to `web3-eth` package to add a polyfill for browsers or use native Node.js implementation when available

**Note** I attempted to figure out why our `sendTransaction`, `sendSignedTransaction` and `subscribe` test didn't fail when running within the browser when using Cypress, but couldn't figure it out. Instead I manually tested that adding this package fixes the issue with both the [minified build](https://github.com/spacesailor24/web3-5393-min-test) and [importing via yarn and building with webpack](https://github.com/spacesailor24/web3-5450-set-immediate-test)

---

### Added

-   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)