### PR TITLE
Emit past contract events based on `fromBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -863,7 +863,7 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth-contract
 
 -   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)
--   Emit past contract events based on `fromBlock`  when passed to contract.events.<eventName> (#5201)
+-   Emit past contract events based on `fromBlock`  when passed to `contract.events.someEventName` (#5201)
 
 #### web3-eth-abi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -863,6 +863,7 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth-contract
 
 -   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)
+-   Emit past contract events based on `fromBlock`  when passed to contract.events.<eventName> (#5201)
 
 #### web3-eth-abi
 

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -181,6 +181,6 @@ const transactionHash = receipt.transactionHash;
 ### Fixed
 
 -   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)
--   Emit past contract events based on `fromBlock`  when passed to contract.events.<eventName> (#5201)
+-   Emit past contract events based on `fromBlock`  when passed to `contract.events.someEventName` (#5201)
 
 ## [Unreleased]

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -181,5 +181,6 @@ const transactionHash = receipt.transactionHash;
 ### Fixed
 
 -   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)
+-   Emit past contract events based on `fromBlock`  when passed to contract.events.<eventName> (#5201)
 
 ## [Unreleased]

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -1181,18 +1181,30 @@ export class Contract<Abi extends ContractAbi>
 		returnFormat: DataFormat = DEFAULT_RETURN_FORMAT,
 	): ContractBoundEvent {
 		return (...params: unknown[]) => {
-			const encodedParams = encodeEventABI(this.options, abi, params[0] as EventParameters);
-
+			const { topics, fromBlock } = encodeEventABI(
+				this.options,
+				abi,
+				params[0] as EventParameters,
+			);
 			const sub = new LogsSubscription(
 				{
 					address: this.options.address,
-					topics: encodedParams.topics,
+					topics,
 					abi,
 					jsonInterface: this._jsonInterface,
 				},
 				{ requestManager: this.requestManager, returnFormat },
 			);
-
+			if (!isNullish(fromBlock)) {
+				// emit past events when fromBlock is defined
+				this.getPastEvents(abi.name, { fromBlock, topics }, returnFormat)
+					.then(logs => {
+						logs.forEach(log => sub.emit('data', log as EventLog));
+					})
+					.catch(() => {
+						sub.emit('error', new SubscriptionError('Failed to get past events.'));
+					});
+			}
 			this.subscriptionManager?.addSubscription(sub).catch(() => {
 				sub.emit('error', new SubscriptionError('Failed to subscribe.'));
 			});

--- a/packages/web3-eth-contract/test/integration/contract_events.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_events.test.ts
@@ -134,14 +134,14 @@ describe('contract', () => {
 				return expect(
 					processAsync(async resolve => {
 						// trigger multiple events
-						await Promise.all(
-							eventValues.map(v => {
-								// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-								return contractDeployed.methods
-									.firesMultiValueEvent('Event Value', v, false)
-									.send(sendOptions);
-							}),
-						);
+						for (const eventValue of eventValues) {
+							// Wait for every transaction, before firing the next one, to prevent a possible nonce duplication.
+							// eslint-disable-next-line no-await-in-loop
+							await contractDeployed.methods
+								.firesMultiValueEvent('Event Value', eventValue, false)
+								.send(sendOptions);
+						}
+
 						const event = contractDeployed.events.MultiValueEvent({
 							fromBlock: 'earliest',
 						});

--- a/packages/web3-eth-contract/test/integration/contract_events.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_events.test.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Contract } from '../../src';
+import { Contract, EventLog } from '../../src';
 import { BasicAbi, BasicBytecode } from '../shared_fixtures/build/Basic';
 import { processAsync } from '../shared_fixtures/utils';
 import {
@@ -136,6 +136,7 @@ describe('contract', () => {
 						// trigger multiple events
 						await Promise.all(
 							eventValues.map(v => {
+								// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 								return contractDeployed.methods
 									.firesMultiValueEvent('Event Value', v, false)
 									.send(sendOptions);
@@ -145,7 +146,7 @@ describe('contract', () => {
 							fromBlock: 'earliest',
 						});
 
-						const pastEvents = [];
+						const pastEvents: EventLog[] = [];
 						event.on('data', d => {
 							pastEvents.push(d);
 							if (pastEvents.length === eventValues.length) {

--- a/packages/web3-eth-contract/test/integration/contract_events.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_events.test.ts
@@ -124,7 +124,6 @@ describe('contract', () => {
 				);
 			},
 		);
-	});
 
 		itIf(isWs)(
 			'should fetch past events when "fromBlock" is passed to contract.events.<eventName>',
@@ -164,7 +163,9 @@ describe('contract', () => {
 				);
 			},
 		);
+	});
 
+	describe('events subscription with HTTP', () => {
 		itIf(isHttp)('should fail to subscribe', async () => {
 			// eslint-disable-next-line no-async-promise-executor, @typescript-eslint/no-misused-promises
 			const failedSubscriptionPromise = new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Description

This PR address the bug described in #5201 where past contact events wouldn't be fetched when `fromBlock` property was passed. 

This change checks for the existence of that property, call past events and emits them.


Fixes #5201 


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist for 4.x:

- [x] I have selected the correct 4.x base branch.
- [x] Within the description, the feature or issue is discussed in detail or an issue is linked.   
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added any required tests for the changes I made 
- [ ] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `yarn` successfully
- [x] I ran `yarn lint` successfully
- [x] I ran `yarn build:web` successfully
- [ ] I ran `yarn test:unit` successfully
- [ ] I ran `yarn test:integration` successfully
- [ ] I ran `compile:contracts` successfully
- [x] I have tested my code.
- [ ] I have updated the corresponding `CHANGELOG.md` file in the packages I have edited.
