### PR TITLE
Fix: _jsonInterfaceMethodToString export in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,6 +607,7 @@ Released with 1.0.0-beta.37 code base.
 
 -  Fixed types for getPastEvents (#4955) (#5260)
 -  Fix Log type by adding missing `removed` property (#4877)
+-  Fixed types for `web3.utils._jsonInterfaceMethodToString` (#5550)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -614,6 +614,6 @@ Released with 1.0.0-beta.37 code base.
 
 ## [Unreleased]
 
-## [1.8.2]
+### Fixed
 
 -  Fixed types for `web3.utils._jsonInterfaceMethodToString` (#5550)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,7 +607,6 @@ Released with 1.0.0-beta.37 code base.
 
 -  Fixed types for getPastEvents (#4955) (#5260)
 -  Fix Log type by adding missing `removed` property (#4877)
--  Fixed types for `web3.utils._jsonInterfaceMethodToString` (#5550)
 
 ### Changed
 
@@ -616,3 +615,5 @@ Released with 1.0.0-beta.37 code base.
 ## [Unreleased]
 
 ## [1.8.2]
+
+-  Fixed types for `web3.utils._jsonInterfaceMethodToString` (#5550)

--- a/packages/web3-utils/types/index.d.ts
+++ b/packages/web3-utils/types/index.d.ts
@@ -169,7 +169,7 @@ export interface Utils {
     isContractAddressInBloom(bloom: string, contractAddress: string): boolean;
     isTopicInBloom(bloom: string, topic: string): boolean;
     isTopic(topic: string): boolean;
-    jsonInterfaceMethodToString(abiItem: AbiItem): string;
+    _jsonInterfaceMethodToString(abiItem: AbiItem): string;
     soliditySha3(...val: Mixed[]): string | null;
     soliditySha3Raw(...val: Mixed[]): string;
     encodePacked(...val: Mixed[]): string | null;


### PR DESCRIPTION
Found a TypeScript export error in web3.js v1.x

`web3.utils.jsonInterfaceMethodToString` is [exported](https://github.com/web3/web3.js/blob/a7b5dea0e98c0b7742c2477c511cb16acc1f27c2/packages/web3-utils/src/index.js#L381) with underscore in JS. In TS types however the underscore is not present.

Steps to reproduce:

```typescript
import Web3 from "web3"

let web3 = new Web3()

console.log(`web3.utils.jsonInterfaceMethodToString: `, web3.utils.jsonInterfaceMethodToString)
// outputs: "web3.utils.jsonInterfaceMethodToString:  undefined"

console.log(`web3.utils._jsonInterfaceMethodToString: `, (web3.utils as any)._jsonInterfaceMethodToString)
// outputs: "web3.utils._jsonInterfaceMethodToString:  [Function: _jsonInterfaceMethodToString]"
```

This PR fixes this error in web3.js 1.x