### PR TITLE
eth.getBlock with hydrated = true returning empty transaction objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -781,6 +781,10 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Corrected the error code for `JSONRPC_ERR_UNAUTHORIZED` to be `4100` (#5462)
 
+#### web3-eth
+
+-   Fix `getBlock` returning empty transactions object on `hydrated` true (#5556)
+
 #### web3-eth-contract
 
 -   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -54,3 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 -   Moved the errors' classes from `web3-eth/src/errors.ts` to `web3-errors/src/errors/transaction_errors.ts` (#5462)
+
+### Fixed
+
+-   Fix `getBlock` returning empty transactions object on `hydrated` true (#5556)

--- a/packages/web3-eth/test/integration/rpc.block.test.ts
+++ b/packages/web3-eth/test/integration/rpc.block.test.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 import { FMT_BYTES, FMT_NUMBER } from 'web3-utils';
-import { TransactionInfo, TransactionReceipt } from 'web3-types';
+import { TransactionInfo, TransactionReceipt, Transaction } from 'web3-types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Contract } from 'web3-eth-contract';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -155,6 +155,11 @@ describe('rpc with block', () => {
 				b.totalDifficulty = '0x0';
 			}
 			expect(validator.validateJSONSchema(blockSchema, b)).toBeUndefined();
+
+			if (hydrated && b.transactions?.length > 0) {
+				// eslint-disable-next-line jest/no-conditional-expect
+				expect(b.transactions).toBeInstanceOf(Array<Transaction>);
+			}
 		});
 
 		it.each(

--- a/packages/web3-utils/src/formatter.ts
+++ b/packages/web3-utils/src/formatter.ts
@@ -78,12 +78,14 @@ const findSchemaByDataPath = (
 	oneOfPath: [string, number][] = [],
 ): JsonSchema | undefined => {
 	let result: JsonSchema = { ...schema } as JsonSchema;
-	let previousDataPath;
+	let previousDataPath: string | undefined;
 
 	for (const dataPart of dataPath) {
 		if (result.oneOf && previousDataPath) {
-			// eslint-disable-next-line no-loop-func
-			const path = oneOfPath.find((element: [string, number]) => element[0] === result.name);
+			const path = oneOfPath.find(function (element: [string, number]) {
+				return (this as unknown as string) === element[0];
+			}, previousDataPath ?? '');
+
 			if (path && path[0] === previousDataPath) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 				result = result.oneOf[path[1]];

--- a/packages/web3-utils/src/formatter.ts
+++ b/packages/web3-utils/src/formatter.ts
@@ -199,6 +199,18 @@ export const convert = (
 						_schemaProp = oneOfSchemaProp as JsonSchema;
 					}
 				}
+
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+				const oneOfProperty = dataPath.slice(0, -1).reduce(
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
+					(xs, x) => (xs?.[x] ? xs[x] : xs),
+					schema.properties,
+				);
+
+				if (oneOfProperty) {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+					oneOfProperty[dataPath.at(-1) as string] = { ..._schemaProp };
+				}
 			}
 
 			if (isNullish(_schemaProp?.items)) {

--- a/packages/web3-utils/src/formatter.ts
+++ b/packages/web3-utils/src/formatter.ts
@@ -78,12 +78,13 @@ const findSchemaByDataPath = (
 	oneOfPath: [string, number][] = [],
 ): JsonSchema | undefined => {
 	let result: JsonSchema = { ...schema } as JsonSchema;
+	let previousDataPath;
 
 	for (const dataPart of dataPath) {
-		if (result.oneOf && result.name) {
+		if (result.oneOf && previousDataPath) {
 			// eslint-disable-next-line no-loop-func
 			const path = oneOfPath.find((element: [string, number]) => element[0] === result.name);
-			if (path && path[0] === result.name) {
+			if (path && path[0] === previousDataPath) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 				result = result.oneOf[path[1]];
 			}
@@ -107,7 +108,8 @@ const findSchemaByDataPath = (
 		} else if (result.items && Array.isArray(result.items)) {
 			result = (result.items as JsonSchema[])[parseInt(dataPart, 10)];
 		}
-		result.name = dataPart;
+
+		if (result && dataPart) previousDataPath = dataPart;
 	}
 
 	return result;


### PR DESCRIPTION
## Description

Solution for #5470 

`eth.getBlock` was returning an empty object for `block.transactions`. 

The error was in https://github.com/web3/web3.js/blob/bfce27fbc27b0db0261e874044c7df5d338023e6/packages/web3-utils/src/formatter.ts#L158 inside `findSchemaByDataPath`, which doesn't handle the `oneOf` type ( and couldn't since no info is passed in order to choose the right one.)

My proposed solution is to save the options of `oneOf` and pass them to `findSchemaByDataPath`.

This was my testcase
```ts
                        const web3 = new Web3Eth(
				'https://mainnet.infura.io/v3/6120b2e72c304b4eadafe2bf33862ac4',
			);
			const blocks = await web3.getBlock(15602045, true);
			console.log(blocks.transactions);
```