### PR TITLE
Release/4.0.1 alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -822,7 +822,6 @@ should use 4.0.1-alpha.0 for testing.
 -   Replace the imported methods from `rpc_methods.ts` with `ethRpcMethods` imports from `web3-rpc-methods` (#5441)
 -   `Web3NetAPI` is now imported from `web3-types` instead of `web3-net` (#5441)
 -   Moved `rpc_methods` tests to `web3-rpc-methods` (#5441)
--   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
 -   Implemented the logic for `transactionBlockTimeout` (#5294)
 -   Use subscription at `rejectIfBlockTimeout` when the provider supports subscription. Implement this as an experimental feature (if `useSubscriptionWhenCheckingBlockTimeout` at `enableExperimentalFeatures` is `true`). (#5481)
 -   At some test cases, optimized some codes. (#5481)
@@ -859,6 +858,7 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth
 
 -   Fix `getBlock` returning empty transactions object on `hydrated` true (#5556)
+-   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
 
 #### web3-eth-contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -732,7 +732,7 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Dependency tree cannot be resolved by Yarn due to old deprecated packages picked by yarn - fixed (#5382)
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
@@ -757,8 +757,8 @@ should use 4.0.1-alpha.0 for testing.
 
 #### web3-eth
 
--   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
--   Implemented the logic for `transactionBlockTimeout` (#5294)
+-   `web3-rpc-methods` dependency (#5441)
+-   Added chain and hardfork validation for transaction and transaction.common object in `validateTransactionForSigning`
 
 #### web3-eth-abi
 
@@ -779,21 +779,76 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Added and exported three reusable utility functions: `pollTillDefined`, `rejectIfTimeout` and `rejectIfConditionAtInterval` which are useful when dealing with promises that involves polling, rejecting after timeout or rejecting if a condition was met when calling repeatably at every time intervals.
 
+#### web3-eth-personal
+
+-   `web3-rpc-methods` dependency (#5441)
+
+#### web3-eth-net
+
+-   `web3-rpc-methods` dependency (#5441)
+
+#### web3-providers-ipc
+
+-   Show error message and return dummy promise if socket is not writable (#5294)
+
+#### web3-rpc-methods
+
+-   web3-rpc-methods package added
+
+#### web3-types
+
+-   `Web3EthExecutionAPI` export (#5441)
+-   `Web3NetAPI` export (#5441)
+-   `EthPersonalAPI` export (#5441)
+
 ### Changed
 
 #### web3-core
 
 -   Default value for `API` generic for `Web3ContextObject` from `any` to `unknown` (#5393)
 -   Default value for `API` generic for `Web3ContextInitOptions` from `any` to `unknown` (#5393)
+-   Added validation when `defaultHardfork` and `defaultCommon.hardfork` are different in web3config
+-   Added validation when `defaultChain` and `defaultCommon.basechain` are different in web3config
+-   Added a new configuration variable `enableExperimentalFeatures`. (#5481)
 
 #### web3-error
 
 -   Moved `SignerError` from `web3-errors/src/errors/signature_errors.ts` to `web3-errors/src/errors/transaction_errors.ts`, and renamed it to `TransactionSigningError` (#5462)
+-   Corrected the error code for `JSONRPC_ERR_UNAUTHORIZED` to be `4100` (#5462)
 
 #### web3-eth
 
+-   `Web3EthExecutionAPI` is now imported via `web3-types` instead of `web3_eth_execution_api.ts` (#5441)
+-   Replace the imported methods from `rpc_methods.ts` with `ethRpcMethods` imports from `web3-rpc-methods` (#5441)
+-   `Web3NetAPI` is now imported from `web3-types` instead of `web3-net` (#5441)
+-   Moved `rpc_methods` tests to `web3-rpc-methods` (#5441)
+-   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
+-   Implemented the logic for `transactionBlockTimeout` (#5294)
 -   Use subscription at `rejectIfBlockTimeout` when the provider supports subscription. Implement this as an experimental feature (if `useSubscriptionWhenCheckingBlockTimeout` at `enableExperimentalFeatures` is `true`). (#5481)
--   At some test cases, optimize some codes. (#5481)
+-   At some test cases, optimized some codes. (#5481)
+
+#### web3-eth-accounts
+
+-   `signTransaction` and `privateKeyToAccount` will throw `TransactionSigningError` instead of `SignerError` now (#5462)
+
+#### web3-eth-ens
+
+-   `Web3NetAPI` is now imported from `web3-types` instead of `web3-net` (#5441)
+
+#### web3-eth-personal
+
+-   Import `EthPersonalAPI` from `web3-types` instead of local import (#5441)
+-   Replace the imported methods from `rcp_methods.ts` with `personalRpcMethods` imports from `web3-rpc-methods` (#5441)
+-   Replace use of `EthPersonalAPIManager` with `Web3RequestManager<EthPersonalAPI>` (#5441)
+
+#### web3-eth-net
+
+-   `Web3NetAPI` is now imported from `web3-types` instead of `web3_net_api.ts` (#5441)
+-   Replace the imported methods from `rpc_methods.ts` with `netRpcMethods` imports from `web3-rpc-methods` (#5441)
+
+#### web3-types
+
+-   `Web3APISpec`, `Web3APIMethod`, and `Web3APIParams` now supports `unknown` APIs (#5393)
 
 ### Fixed
 
@@ -822,3 +877,18 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth
 
 -   Moved the errors' classes from `web3-eth/src/errors.ts` to `web3-errors/src/errors/transaction_errors.ts` (#5462)
+
+#### web3-eth-personal
+
+-   Exported type `EthPersonalAPIManager`, `EthPersonalAPI` is not exported via `web3-types` (#5441)
+
+#### web3-eth-net
+
+-   `rpcMethods` export, these methods are now exported via `web3-rpc-methods` as `netRpcMethods` (#5441)
+-   `Web3NetAPI` export, now exported via `web3-types` as `Web3NetAPI` (#5441)
+
+#### web3-validator
+
+-   Removed direct function `toJSON()` in `Web3ValidatorError` class as its available via base class (#5435)
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
@@ -52,3 +52,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added validation when `defaultChain` and `defaultCommon.basechain` are different in web3config
 -   Added a new configuration variable `enableExperimentalFeatures`. (#5481)
 
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -25,14 +25,14 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-eth-iban": "^4.0.1-alpha.0",
-		"web3-providers-http": "^4.0.1-alpha.0",
-		"web3-providers-ipc": "^4.0.1-alpha.0",
-		"web3-providers-ws": "^4.0.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0",
-		"web3-validator": "^0.1.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-eth-iban": "^4.0.1-alpha.1",
+		"web3-providers-http": "^4.0.1-alpha.1",
+		"web3-providers-ipc": "^4.0.1-alpha.1",
+		"web3-providers-ws": "^4.0.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1",
+		"web3-validator": "^0.1.1-alpha.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [0.1.1-alpha.1]
 
 ### Added
 
@@ -51,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Corrected the error code for `JSONRPC_ERR_UNAUTHORIZED` to be `4100` (#5462)
-
-### Fixed
-
 -   Moved `SignerError` from `web3-errors/src/errors/signature_errors.ts` to `web3-errors/src/errors/transaction_errors.ts`, and renamed it to `TransactionSigningError` (#5462)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.1-alpha.1",
 	"description": "This package has web3 error classes",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -25,7 +25,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^0.1.1-alpha.0"
+		"web3-types": "^0.1.1-alpha.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -35,9 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
-
-### Fixed
+## [4.0.1-alpha.1]
 
 ### Added
 
@@ -47,3 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Return `BigInt` instead of `string` when decoding function parameters for large numbers, such as `uint256`. (#5435)
+
+## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ethereum/web3.js/tree/4.x/packages/web3-eth-abi",
@@ -26,9 +26,9 @@
 	},
 	"dependencies": {
 		"@ethersproject/abi": "^5.6.4",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -34,3 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I've improved the security in XY (#1000)
 
 -->
+
+## [Unreleased]
+
+### Changed
+
+-   `signTransaction` and `privateKeyToAccount` will throw `TransactionSigningError` instead of `SignerError` now (#5462)

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -35,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Changed
 
 -   `signTransaction` and `privateKeyToAccount` will throw `TransactionSigningError` instead of `SignerError` now (#5462)
+
+## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -42,9 +42,9 @@
 	"dependencies": {
 		"@ethereumjs/tx": "^3.5.2",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0",
-		"web3-validator": "^0.1.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1",
+		"web3-validator": "^0.1.1-alpha.1"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -171,7 +171,7 @@ const transactionHash = receipt.transactionHash;
 </p>
 </details>
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
@@ -181,3 +181,5 @@ const transactionHash = receipt.transactionHash;
 ### Fixed
 
 -   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ethereum/web3.js/tree/4.x/packages/web3-eth-contract",
@@ -28,13 +28,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.0",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-eth": "^4.0.1-alpha.0",
-		"web3-eth-abi": "^4.0.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0",
-		"web3-validator": "^0.1.1-alpha.0"
+		"web3-core": "^4.0.1-alpha.1",
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-eth": "^4.0.1-alpha.1",
+		"web3-eth-abi": "^4.0.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1",
+		"web3-validator": "^0.1.1-alpha.1"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -35,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Changed
 
 -   `Web3NetAPI` is now imported from `web3-types` instead of `web3-net` (#5441)
+
+## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -38,8 +38,7 @@
 		"jest-extended": "^3.0.1",
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
-		"typescript": "^4.7.4",
-		"web3-eth-contract": "^4.0.1-alpha.0"
+		"typescript": "^4.7.4"
 	},
 	"dependencies": {
 		"idna-uts46-hx": "^3.5.0",

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -27,7 +27,6 @@
 		"ens:download:reverse_registrar": "curl -L -o test/fixtures/ens/reverse_registrar.json 'https://api.etherscan.io/api?module=contract&action=getabi&address=0x084b1c3c81545d370f3634392de611caabff8148'"
 	},
 	"devDependencies": {
-		"web3-eth-contract": "^4.0.1-alpha.0",
 		"@types/jest": "^28.1.6",
 		"@typescript-eslint/eslint-plugin": "^5.30.7",
 		"@typescript-eslint/parser": "^5.30.7",
@@ -39,16 +38,17 @@
 		"jest-extended": "^3.0.1",
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
-		"typescript": "^4.7.4"
+		"typescript": "^4.7.4",
+		"web3-eth-contract": "^4.0.1-alpha.0"
 	},
 	"dependencies": {
 		"idna-uts46-hx": "^3.5.0",
-		"web3-core": "^4.0.1-alpha.0",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-eth": "^4.0.1-alpha.0",
-		"web3-eth-contract": "^4.0.1-alpha.0",
-		"web3-net": "^4.0.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3-core": "^4.0.1-alpha.1",
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-eth": "^4.0.1-alpha.1",
+		"web3-eth-contract": "^4.0.1-alpha.1",
+		"web3-net": "^4.0.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	}
 }

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -39,8 +39,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
@@ -50,3 +50,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 -   Exported type `EthPersonalAPIManager`, `EthPersonalAPI` is not exported via `web3-types` (#5441)
+
+## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -25,12 +25,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.0",
-		"web3-eth": "^4.0.1-alpha.0",
+		"web3-core": "^4.0.1-alpha.1",
+		"web3-eth": "^4.0.1-alpha.1",
 		"web3-rpc-methods": "^0.1.0-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0",
-		"web3-validator": "^0.1.1-alpha.0"
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1",
+		"web3-validator": "^0.1.1-alpha.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -45,6 +45,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.1-alpha.0"
+		"web3-providers-ws": "^4.0.1-alpha.1"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -48,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Replace the imported methods from `rpc_methods.ts` with `ethRpcMethods` imports from `web3-rpc-methods` (#5441)
 -   `Web3NetAPI` is now imported from `web3-types` instead of `web3-net` (#5441)
 -   Moved `rpc_methods` tests to `web3-rpc-methods` (#5441)
--   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
 -   Implemented the logic for `transactionBlockTimeout` (#5294)
 -   Use subscription at `rejectIfBlockTimeout` when the provider supports subscription. Implement this as an experimental feature (if `useSubscriptionWhenCheckingBlockTimeout` at `enableExperimentalFeatures` is `true`). (#5481)
 -   At some test cases, optimized some codes. (#5481)
@@ -60,5 +59,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fix `getBlock` returning empty transactions object on `hydrated` true (#5556)
+-   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
 
 ## [Unreleased]

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -35,12 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
 -   `web3-rpc-methods` dependency (#5441)
--   added chain and hardfork validation for transaction and transaction.common object in `validateTransactionForSigning`
+-   Added chain and hardfork validation for transaction and transaction.common object in `validateTransactionForSigning`
 
 ### Changed
 
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)
 -   Implemented the logic for `transactionBlockTimeout` (#5294)
 -   Use subscription at `rejectIfBlockTimeout` when the provider supports subscription. Implement this as an experimental feature (if `useSubscriptionWhenCheckingBlockTimeout` at `enableExperimentalFeatures` is `true`). (#5481)
--   At some test cases, optimize some codes. (#5481)
+-   At some test cases, optimized some codes. (#5481)
 
 ### Removed
 
@@ -60,3 +60,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fix `getBlock` returning empty transactions object on `hydrated` true (#5556)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -40,22 +40,22 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.0.1-alpha.0",
+		"web3-eth-abi": "^4.0.1-alpha.1",
 		"web3-eth-accounts": "^4.0.1-alpha.0",
-		"web3-providers-http": "^4.0.1-alpha.0"
+		"web3-providers-http": "^4.0.1-alpha.1"
 	},
 	"dependencies": {
 		"@ethereumjs/common": "^2.6.5",
 		"@ethereumjs/tx": "^3.5.2",
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.0.1-alpha.0",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-eth-accounts": "^4.0.1-alpha.0",
-		"web3-net": "^4.0.1-alpha.0",
-		"web3-providers-ws": "^4.0.1-alpha.0",
+		"web3-core": "^4.0.1-alpha.1",
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-eth-accounts": "^4.0.1-alpha.1",
+		"web3-net": "^4.0.1-alpha.1",
+		"web3-providers-ws": "^4.0.1-alpha.1",
 		"web3-rpc-methods": "^0.1.0-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0",
-		"web3-validator": "^0.1.1-alpha.0"
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1",
+		"web3-validator": "^0.1.1-alpha.1"
 	}
 }

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -41,7 +41,6 @@
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
 		"web3-eth-abi": "^4.0.1-alpha.1",
-		"web3-eth-accounts": "^4.0.1-alpha.0",
 		"web3-providers-http": "^4.0.1-alpha.1"
 	},
 	"dependencies": {

--- a/packages/web3-eth/src/schemas.ts
+++ b/packages/web3-eth/src/schemas.ts
@@ -84,7 +84,7 @@ export const transactionSchema = {
 			eth: 'address',
 		},
 		to: {
-			eth: 'address',
+			oneOf: [{ eth: 'address' }, { type: 'null' }],
 		},
 		value: {
 			eth: 'uint',
@@ -174,7 +174,7 @@ export const transactionInfoSchema = {
 			eth: 'address',
 		},
 		to: {
-			eth: 'address',
+			oneOf: [{ eth: 'address' }, { type: 'null' }],
 		},
 		value: {
 			eth: 'uint',

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
@@ -50,3 +50,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `rpcMethods` export, these methods are now exported via `web3-rpc-methods` as `netRpcMethods` (#5441)
 -   `Web3NetAPI` export, now exported via `web3-types` as `Web3NetAPI` (#5441)
+
+## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -39,9 +39,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.0",
+		"web3-core": "^4.0.1-alpha.1",
 		"web3-rpc-methods": "^0.1.0-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	}
 }

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -44,8 +44,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -34,3 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I've improved the security in XY (#1000)
 
 -->
+
+## [Unreleased]
+
+### Added
+
+-   Show error message and return dummy promise if socket is not writable (#5294)

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -35,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
 -   Show error message and return dummy promise if socket is not writable (#5294)
+
+## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -39,8 +39,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	}
 }

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -45,9 +45,9 @@
 	},
 	"dependencies": {
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0",
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -39,8 +39,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-validator": "^0.1.1-alpha.0"
+		"web3-core": "^4.0.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-validator": "^0.1.1-alpha.1"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [0.1.1-alpha.1]
 
 ### Added
 
@@ -46,3 +46,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   `Web3APISpec`, `Web3APIMethod`, and `Web3APIParams` now supports `unknown` APIs (#5393)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.1-alpha.1",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -35,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [4.0.1-alpha.1]
 
 ### Added
 
 -   Added and exported three reusable utility functions: `pollTillDefined`, `rejectIfTimeout` and `rejectIfConditionAtInterval` which are useful when dealing with promises that involves polling, rejecting after timeout or rejecting if a condition was met when calling repeatably at every time intervals.
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "dist/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -43,8 +43,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-validator": "^0.1.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-validator": "^0.1.1-alpha.1"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -34,3 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I've improved the security in XY (#1000)
 
 -->
+
+## [Unreleased]
+
+### Added
+
+-   Removed direct function `toJSON()` in `Web3ValidatorError` class as its available via base class (#5435)

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -35,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [0.1.1-alpha.1]
 
-### Added
+### Removed
 
 -   Removed direct function `toJSON()` in `Web3ValidatorError` class as its available via base class (#5435)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.1-alpha.1",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "dist/index.js",
 	"browser": "dist/index.min.js",
@@ -29,8 +29,8 @@
 	"dependencies": {
 		"ajv": "^8.11.0",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0"
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.1-alpha.0",
+	"version": "4.0.1-alpha.1",
 	"description": "Ethereum JavaScript API",
 	"main": "dist/index.js",
 	"browser": "dist/web3.min.js",
@@ -55,22 +55,22 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-http": "^4.0.1-alpha.0",
-		"web3-providers-ipc": "^4.0.1-alpha.0",
-		"web3-providers-ws": "^4.0.1-alpha.0"
+		"web3-providers-http": "^4.0.1-alpha.1",
+		"web3-providers-ipc": "^4.0.1-alpha.1",
+		"web3-providers-ws": "^4.0.1-alpha.1"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.0",
-		"web3-errors": "^0.1.1-alpha.0",
-		"web3-eth": "^4.0.1-alpha.0",
-		"web3-eth-abi": "^4.0.1-alpha.0",
-		"web3-eth-accounts": "^4.0.1-alpha.0",
-		"web3-eth-contract": "^4.0.1-alpha.0",
-		"web3-eth-ens": "^4.0.1-alpha.0",
-		"web3-eth-iban": "^4.0.1-alpha.0",
-		"web3-eth-personal": "^4.0.1-alpha.0",
-		"web3-net": "^4.0.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3-core": "^4.0.1-alpha.1",
+		"web3-errors": "^0.1.1-alpha.1",
+		"web3-eth": "^4.0.1-alpha.1",
+		"web3-eth-abi": "^4.0.1-alpha.1",
+		"web3-eth-accounts": "^4.0.1-alpha.1",
+		"web3-eth-contract": "^4.0.1-alpha.1",
+		"web3-eth-ens": "^4.0.1-alpha.1",
+		"web3-eth-iban": "^4.0.1-alpha.1",
+		"web3-eth-personal": "^4.0.1-alpha.1",
+		"web3-net": "^4.0.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-alpha.0' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-alpha.1' };

--- a/packages/web3/test/black_box/test/web3-eth-contract/erc20.test.ts
+++ b/packages/web3/test/black_box/test/web3-eth-contract/erc20.test.ts
@@ -20,10 +20,10 @@ import Contract from 'web3-eth-contract';
 import {
 	closeOpenConnection,
 	describeIf,
-	getSystemTestAccounts,
 	getSystemTestBackend,
 	isWs,
 	getSystemTestProvider,
+	createNewAccount,
 } from 'web3/test/shared_fixtures/system_tests_utils';
 import { ERC20TokenAbi, ERC20TokenBytecode } from '../fixtures/contracts/ERC20Token';
 
@@ -51,12 +51,16 @@ describeIf(getSystemTestBackend() === 'geth' || getSystemTestBackend() === 'gana
 	'Black Box Unit Tests - web3.eth.Contract',
 	() => {
 		describe('Geth || Ganache - ERC20', () => {
-			let accounts;
+			let account;
 			let web3: Web3;
 			let deployedContract: Contract<typeof ERC20TokenAbi>;
 
 			beforeAll(async () => {
-				accounts = await getSystemTestAccounts();
+				account = await createNewAccount({
+					unlock: true,
+					refill: true,
+					doNotImport: false,
+				});
 
 				web3 = new Web3(getSystemTestProvider());
 				deployedContract = await new web3.eth.Contract(ERC20TokenAbi)
@@ -65,7 +69,7 @@ describeIf(getSystemTestBackend() === 'geth' || getSystemTestBackend() === 'gana
 						// @ts-expect-error Type 'string' is not assignable to type 'undefined'.
 						arguments: ['420'],
 					})
-					.send({ from: accounts[0], gas: '10000000' });
+					.send({ from: account.address, gas: '10000000' });
 			});
 
 			afterAll(async () => {

--- a/packages/web3/test/black_box/test/web3-eth-contract/erc20.test.ts
+++ b/packages/web3/test/black_box/test/web3-eth-contract/erc20.test.ts
@@ -42,7 +42,7 @@ describeIf(getSystemTestBackend() === 'infura')('Black Box Unit Tests - web3.eth
 
 			expect(await contract.methods.name().call()).toBe('Tether USD');
 			expect(await contract.methods.symbol().call()).toBe('USDT');
-			expect(await contract.methods.decimals().call()).toBe('6');
+			expect(await contract.methods.decimals().call()).toBe(BigInt(6));
 		});
 	});
 });
@@ -80,8 +80,8 @@ describeIf(getSystemTestBackend() === 'geth' || getSystemTestBackend() === 'gana
 
 				expect(await contract.methods.name().call()).toBe('Gold');
 				expect(await contract.methods.symbol().call()).toBe('GLD');
-				expect(await contract.methods.decimals().call()).toBe('18');
-				expect(await contract.methods.totalSupply().call()).toBe('420');
+				expect(await contract.methods.decimals().call()).toBe(BigInt(18));
+				expect(await contract.methods.totalSupply().call()).toBe(BigInt(420));
 			});
 		});
 	},

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "0.0.1-alpha.0",
+	"version": "0.1.0-alpha.0",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -43,12 +43,12 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.0.1-alpha.0",
-		"web3-core": "^4.0.1-alpha.0",
-		"web3-eth-abi": "^4.0.1-alpha.0",
-		"web3-eth-contract": "^4.0.1-alpha.0",
-		"web3-types": "^0.1.1-alpha.0",
-		"web3-utils": "^4.0.1-alpha.0"
+		"web3": "^4.0.1-alpha.1",
+		"web3-core": "^4.0.1-alpha.1",
+		"web3-eth-abi": "^4.0.1-alpha.1",
+		"web3-eth-contract": "^4.0.1-alpha.1",
+		"web3-types": "^0.1.1-alpha.1",
+		"web3-utils": "^4.0.1-alpha.1"
 	},
 	"peerDependencies": {
 		"web3-core": ">= 4.0.1-alpha.0 < 5",


### PR DESCRIPTION
## [4.0.1-alpha.1]

### Added

#### web3-core

-   If the response error was `execution reverted`, raise `ContractExecutionError` and pass the response error to it in order to be set as `innerError` (this innerError will be decoded at web3-eth-contract if its ABI was provided according to EIP-838). (#5434)
-   Added a new configuration variable `enableExperimentalFeatures`. (#5481)
-   `registerPlugin` method to `Web3Context` (#5393)
-   `Web3PluginBase` exported abstract class (#5393)
-   `Web3EthPluginBase` exported abstract class (#5393)

#### web3-error

-   Add optional `innerError` property to the abstract class `Web3Error`. This `innerError` could be `Error`, `Error[]` or `undefined`. (#5435) (#5434)
-   The class `Web3ContractError` is moved to this package from `web3-eth-contract`. (#5434)
-   Added the error code `ERR_TX_SIGNING` and used it inside `TransactionSigningError` (#5462)
-   Added the error code `ERR_TX_GAS_MISMATCH` and used it inside `TransactionGasMismatchError` (#5462)
-   Added `SignatureError` to `web3-errors/src/errors/signature_errors.ts` (moved from `web3-eth/src/errors.ts`) (#5462)
-   Added the errors' classes to `web3-errors/src/errors/transaction_errors.ts` from `web3-eth/src/errors.ts` (#5462)
-   Added `TransactionBlockTimeoutError` class and its error code `ERR_TX_BLOCK_TIMEOUT` (#5294)
-   `ExistingPluginNamespaceError` class and it's error code `ERR_EXISTING_PLUGIN_NAMESPACE` (#5393)

#### web3-eth

-   `web3-rpc-methods` dependency (#5441)
-   Added chain and hardfork validation for transaction and transaction.common object in `validateTransactionForSigning`

#### web3-eth-abi

-   If an error happens when decoding a value, preserve that exception at `innerError` inside the error class `AbiError`. (#5435)
-   Add basic functionality that is used, by `web3-eth-contract`, when decoding error data according to EIP-838. (#5434)

#### web3-eth-contract

-   Decoding error data, using Error ABI if available, according to EIP-838. (#5434)
-   The class `Web3ContractError` is moved from this package to `web3-error`. (#5434)

#### web3-plugin-example

-   Example plugin for wrapping contract methods to provide custom functionality (#5393)
-   Example plugin for custom RPC methods using the `requestManager` (#5393)

#### web3-utils

-   Added and exported three reusable utility functions: `pollTillDefined`, `rejectIfTimeout` and `rejectIfConditionAtInterval` which are useful when dealing with promises that involves polling, rejecting after timeout or rejecting if a condition was met when calling repeatably at every time intervals.

#### web3-eth-personal

-   `web3-rpc-methods` dependency (#5441)

#### web3-eth-net

-   `web3-rpc-methods` dependency (#5441)

#### web3-providers-ipc

-   Show error message and return dummy promise if socket is not writable (#5294)

#### web3-rpc-methods

-   web3-rpc-methods package added

#### web3-types

-   `Web3EthExecutionAPI` export (#5441)
-   `Web3NetAPI` export (#5441)
-   `EthPersonalAPI` export (#5441)

### Changed

#### web3-core

-   Default value for `API` generic for `Web3ContextObject` from `any` to `unknown` (#5393)
-   Default value for `API` generic for `Web3ContextInitOptions` from `any` to `unknown` (#5393)
-   Added validation when `defaultHardfork` and `defaultCommon.hardfork` are different in web3config
-   Added validation when `defaultChain` and `defaultCommon.basechain` are different in web3config
-   Added a new configuration variable `enableExperimentalFeatures`. (#5481)

#### web3-error

-   Moved `SignerError` from `web3-errors/src/errors/signature_errors.ts` to `web3-errors/src/errors/transaction_errors.ts`, and renamed it to `TransactionSigningError` (#5462)
-   Corrected the error code for `JSONRPC_ERR_UNAUTHORIZED` to be `4100` (#5462)

#### web3-eth

-   `Web3EthExecutionAPI` is now imported via `web3-types` instead of `web3_eth_execution_api.ts` (#5441)
-   Replace the imported methods from `rpc_methods.ts` with `ethRpcMethods` imports from `web3-rpc-methods` (#5441)
-   `Web3NetAPI` is now imported from `web3-types` instead of `web3-net` (#5441)
-   Moved `rpc_methods` tests to `web3-rpc-methods` (#5441)
-   Implemented the logic for `transactionBlockTimeout` (#5294)
-   Use subscription at `rejectIfBlockTimeout` when the provider supports subscription. Implement this as an experimental feature (if `useSubscriptionWhenCheckingBlockTimeout` at `enableExperimentalFeatures` is `true`). (#5481)
-   At some test cases, optimized some codes. (#5481)

#### web3-eth-accounts

-   `signTransaction` and `privateKeyToAccount` will throw `TransactionSigningError` instead of `SignerError` now (#5462)

#### web3-eth-ens

-   `Web3NetAPI` is now imported from `web3-types` instead of `web3-net` (#5441)

#### web3-eth-personal

-   Import `EthPersonalAPI` from `web3-types` instead of local import (#5441)
-   Replace the imported methods from `rcp_methods.ts` with `personalRpcMethods` imports from `web3-rpc-methods` (#5441)
-   Replace use of `EthPersonalAPIManager` with `Web3RequestManager<EthPersonalAPI>` (#5441)

#### web3-eth-net

-   `Web3NetAPI` is now imported from `web3-types` instead of `web3_net_api.ts` (#5441)
-   Replace the imported methods from `rpc_methods.ts` with `netRpcMethods` imports from `web3-rpc-methods` (#5441)

#### web3-types

-   `Web3APISpec`, `Web3APIMethod`, and `Web3APIParams` now supports `unknown` APIs (#5393)

### Fixed

#### web3-error

-   Corrected the error code for `JSONRPC_ERR_UNAUTHORIZED` to be `4100` (#5462)

#### web3-eth

-   Fix `getBlock` returning empty transactions object on `hydrated` true (#5556)
-   [setimmediate](https://github.com/yuzujs/setImmediate) package to polyfill [setImmediate](https://nodejs.org/api/timers.html#setimmediatecallback-args) for browsers (#5450)

#### web3-eth-contract

-   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)

#### web3-eth-abi

-   Return `BigInt` instead of `string` when decoding function parameters for large numbers, such as `uint256`. (#5435)

#### web3-types

-   `Web3APISpec`, `Web3APIMethod`, and `Web3APIParams` now supports `unknown` APIs (#5393)

### Removed

#### web3-eth

-   Moved the errors' classes from `web3-eth/src/errors.ts` to `web3-errors/src/errors/transaction_errors.ts` (#5462)

#### web3-eth-personal

-   Exported type `EthPersonalAPIManager`, `EthPersonalAPI` is not exported via `web3-types` (#5441)

#### web3-eth-net

-   `rpcMethods` export, these methods are now exported via `web3-rpc-methods` as `netRpcMethods` (#5441)
-   `Web3NetAPI` export, now exported via `web3-types` as `Web3NetAPI` (#5441)

#### web3-validator

-   Removed direct function `toJSON()` in `Web3ValidatorError` class as its available via base class (#5435)
