### PR TITLE
fix: send tx for injected providers

### DIFF
--- a/packages/web3-eth/src/utils/reject_if_block_timeout.ts
+++ b/packages/web3-eth/src/utils/reject_if_block_timeout.ts
@@ -161,12 +161,12 @@ export async function rejectIfBlockTimeout(
 	web3Context: Web3Context<EthExecutionAPI>,
 	transactionHash?: Bytes,
 ): Promise<[Promise<never>, ResourceCleaner]> {
-	const provider: Web3BaseProvider = web3Context.requestManager.provider as Web3BaseProvider;
+	const { provider } = web3Context.requestManager;
 	let callingRes: [Promise<never>, ResourceCleaner];
 	const starterBlockNumber = await getBlockNumber(web3Context, NUMBER_DATA_FORMAT);
 	// TODO: once https://github.com/web3/web3.js/issues/5521 is implemented, remove checking for `enableExperimentalFeatures.useSubscriptionWhenCheckingBlockTimeout`
 	if (
-		provider.supportsSubscriptions() &&
+		(provider as Web3BaseProvider).supportsSubscriptions?.() &&
 		web3Context.enableExperimentalFeatures.useSubscriptionWhenCheckingBlockTimeout
 	) {
 		callingRes = await resolveBySubscription(web3Context, starterBlockNumber, transactionHash);


### PR DESCRIPTION
## Description

Please include a summary of the changes and be sure to follow our [Contribution Guidelines](../blob/1.x/CONTRIBUTIONS.md).

Implementation wrongly assumes every provider has `supportsSubscriptions` method which is not true for injected providers.

No idea how to write test for that.

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

Fixes #5591 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist for 1.x:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` with success.
- [ ] I have tested the built `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.

## Checklist for 4.x:

- [ ] I have selected the correct 4.x base branch.
- [ ] Within the description, the feature or issue is discussed in detail or an issue is linked.   
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added any required tests for the changes I made 
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `yarn` successfully
- [ ] I ran `yarn lint` successfully
- [ ] I ran `yarn build:web` successfully
- [ ] I ran `yarn test:unit` successfully
- [ ] I ran `yarn test:integration` successfully
- [ ] I ran `compile:contracts` successfully
- [ ] I have tested my code.
- [ ] I have updated the corresponding `CHANGELOG.md` file in the packages I have edited.
