### PR TITLE
Manually export `web3-core` exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -905,3 +905,9 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth-accounts
 
 -   These types were moved from `web3-eth-accounts` to `web3-types` package: Cipher, CipherOptions, ScryptParams, PBKDF2SHA256Params, KeyStore (#5581 )
+
+### Changed
+
+#### web3-core
+
+-   Refactor module exports (#5627)

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -53,3 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added a new configuration variable `enableExperimentalFeatures`. (#5481)
 
 ## [Unreleased]
+
+### Changed
+
+-   Refactor module exports (#5627)

--- a/packages/web3-core/src/index.ts
+++ b/packages/web3-core/src/index.ts
@@ -14,18 +14,117 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
+/* eslint deprecation/deprecation: 0 */
 
-export * from './web3_config';
-export * from './web3_request_manager';
-export * from './web3_subscription_manager';
-export * from './web3_subscriptions';
-export * from './web3_context';
-export * from './web3_batch_request';
-export * from './utils';
-export * from './types';
-export * from './formatters';
-export * from './web3_promi_event';
-export * from './web3_event_emitter';
+import { Web3ConfigOptions, Web3ConfigEvent, Web3Config } from './web3_config';
+import { Web3RequestManagerEvent, Web3RequestManager } from './web3_request_manager';
+import { Web3SubscriptionManager } from './web3_subscription_manager';
+import { Web3Subscription, Web3SubscriptionConstructor } from './web3_subscriptions';
+import {
+	Web3ContextObject,
+	Web3ContextInitOptions,
+	Web3ContextConstructor,
+	Web3ContextFactory,
+	Web3Context,
+	TransactionBuilder,
+	Web3PluginBase,
+	Web3EthPluginBase,
+} from './web3_context';
+import { DEFAULT_BATCH_REQUEST_TIMEOUT, Web3BatchRequest } from './web3_batch_request';
+import {
+	isWeb3Provider,
+	isLegacyRequestProvider,
+	isEIP1193Provider,
+	isLegacySendProvider,
+	isLegacySendAsyncProvider,
+	isSupportedProvider,
+	isSupportSubscriptions,
+} from './utils';
+import { TransactionTypeParser } from './types';
+import {
+	inputStorageKeysFormatter,
+	outputProofFormatter,
+	outputBigIntegerFormatter,
+	inputBlockNumberFormatter,
+	inputDefaultBlockNumberFormatter,
+	inputAddressFormatter,
+	txInputOptionsFormatter,
+	inputCallFormatter,
+	inputTransactionFormatter,
+	inputSignFormatter,
+	outputTransactionFormatter,
+	inputTopicFormatter,
+	inputLogFormatter,
+	outputLogFormatter,
+	outputTransactionReceiptFormatter,
+	outputBlockFormatter,
+	inputPostFormatter,
+	outputPostFormatter,
+	outputSyncingFormatter,
+} from './formatters';
+import { PromiseExecutor, Web3PromiEvent } from './web3_promi_event';
+import {
+	Web3EventMap,
+	Web3EventKey,
+	Web3EventCallback,
+	Web3Emitter,
+	Web3EventEmitter,
+} from './web3_event_emitter';
+
+export {
+	Web3ConfigOptions,
+	Web3ConfigEvent,
+	Web3Config,
+	Web3RequestManagerEvent,
+	Web3RequestManager,
+	Web3SubscriptionManager,
+	Web3Subscription,
+	Web3SubscriptionConstructor,
+	Web3ContextObject,
+	Web3ContextInitOptions,
+	Web3ContextConstructor,
+	Web3ContextFactory,
+	Web3Context,
+	TransactionBuilder,
+	Web3PluginBase,
+	Web3EthPluginBase,
+	DEFAULT_BATCH_REQUEST_TIMEOUT,
+	Web3BatchRequest,
+	isWeb3Provider,
+	isLegacyRequestProvider,
+	isEIP1193Provider,
+	isLegacySendProvider,
+	isLegacySendAsyncProvider,
+	isSupportedProvider,
+	isSupportSubscriptions,
+	TransactionTypeParser,
+	inputStorageKeysFormatter,
+	outputProofFormatter,
+	outputBigIntegerFormatter,
+	inputBlockNumberFormatter,
+	inputDefaultBlockNumberFormatter,
+	inputAddressFormatter,
+	txInputOptionsFormatter,
+	inputCallFormatter,
+	inputTransactionFormatter,
+	inputSignFormatter,
+	outputTransactionFormatter,
+	inputTopicFormatter,
+	inputLogFormatter,
+	outputLogFormatter,
+	outputTransactionReceiptFormatter,
+	outputBlockFormatter,
+	inputPostFormatter,
+	outputPostFormatter,
+	outputSyncingFormatter,
+	PromiseExecutor,
+	Web3PromiEvent,
+	Web3EventMap,
+	Web3EventKey,
+	Web3EventCallback,
+	Web3Emitter,
+	Web3EventEmitter,
+};
 
 // For backward usability export as namespace
 export * as formatters from './formatters';


### PR DESCRIPTION
Replaces use of `export * from 'file'` to:

```typescript
import { x, y, z } from 'file';
export { x, y, z };
```