### PR TITLE
Update CHANGELOG version headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -891,7 +891,7 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Removed direct function `toJSON()` in `Web3ValidatorError` class as its available via base class (#5435)
 
-## [Unreleased]
+## [4.0.1-alpha.2]
 
 ### Added
 
@@ -923,3 +923,5 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth-accounts
 
 -   These types were moved from `web3-eth-accounts` to `web3-types` package: Cipher, CipherOptions, ScryptParams, PBKDF2SHA256Params, KeyStore (#5581 )
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -52,8 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added validation when `defaultChain` and `defaultCommon.basechain` are different in web3config
 -   Added a new configuration variable `enableExperimentalFeatures`. (#5481)
 
-## [Unreleased]
+## [4.0.1-alpha.2]
 
 ### Fixed
 
 -   Make the `request` method of `EIP1193Provider` class, compatible with EIP 1193 (#5591)
+
+## [Unreleased]

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -41,8 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `signTransaction` and `privateKeyToAccount` will throw `TransactionSigningError` instead of `SignerError` now (#5462)
 
-## [Unreleased]
+## [4.0.1-alpha.2]
 
 ### Removed
 
 -   These types were moved to `web3-types` package: Cipher, CipherOptions, ScryptParams, PBKDF2SHA256Params, KeyStore (#5581)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -182,9 +182,11 @@ const transactionHash = receipt.transactionHash;
 
 -   According to the latest change in `web3-eth-abi`, the decoded values of the large numbers, returned from function calls or events, are now available as `BigInt`. (#5435)
 
-## [Unreleased]
+## [4.0.1-alpha.2]
 
 ### Fixed
 
 -   Emit past contract events based on `fromBlock` when passed to `contract.events.someEventName` (#5201)
 -   Use different types for `ContractOptions` -> `jsonInterface` setter and getter (#5474)
+
+## [Unreleased]

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `Web3APISpec`, `Web3APIMethod`, and `Web3APIParams` now supports `unknown` APIs (#5393)
 
-## [Unreleased]
+## [0.1.1-alpha.2]
 
 ### Added
 
@@ -56,3 +56,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Make the `request` method of `EIP1193Provider` class, compatible with EIP 1193 (#5591)
+
+## [Unreleased]

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added and exported three reusable utility functions: `pollTillDefined`, `rejectIfTimeout` and `rejectIfConditionAtInterval` which are useful when dealing with promises that involves polling, rejecting after timeout or rejecting if a condition was met when calling repeatably at every time intervals.
 
-## [Unreleased]
+## [4.0.1-alpha.2]
 
 ### Added
 
@@ -50,3 +50,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Use Uuid for the response id, to fix the issue "Responses get mixed up due to conflicting payload IDs" (#5373).
+
+## [Unreleased]

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -35,9 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [0.1.0-alpha.1]
 
 ### Added
 
 -   Example plugin for wrapping contract methods to provide custom functionality (#5393)
 -   Example plugin for custom RPC methods using the `requestManager` (#5393)
+
+## [Unreleased]


### PR DESCRIPTION
Point of discussion:

- Packages such as `web3-errors`, `web3-eth`, `web3-eth-ens` and few more had their versions bumped, but no changes were listed in their `CHANGELOG.md`s because the only changes made were Web3 related version bumps - this results in a missing version number in the `CHANGELOG.md` i.e. for these packages, `4.0.1-alpha.2` won't be listed (or any version number until a change is made to the package)