### PR TITLE
Remove erroneous set provider code for Contract constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -935,4 +935,4 @@ should use 4.0.1-alpha.0 for testing.
 
 #### web3-eth-contract
 
--   Erroneous set `provider` logic in Contract constructor (#5669)
+-   Remove erroneous `addressOrOptionsOrContext !== 'string'` check  in Contract constructor (#5669)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -932,3 +932,7 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth-accounts
 
 -   These types were moved from `web3-eth-accounts` to `web3-types` package: Cipher, CipherOptions, ScryptParams, PBKDF2SHA256Params, KeyStore (#5581 )
+
+#### web3-eth-contract
+
+-   Erroneous set `provider` logic in Contract constructor (#5669)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -914,6 +914,7 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Emit past contract events based on `fromBlock` when passed to `contract.events.someEventName` (#5201)
 -   Use different types for `ContractOptions` -> `jsonInterface` setter and getter (#5474)
+-   An issue within the `Contract` constructor where `provider` wasn't being set when provided within the `optionsOrContextOrReturnFormat` argument (#5669)
 
 #### web3-types
 
@@ -932,7 +933,3 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth-accounts
 
 -   These types were moved from `web3-eth-accounts` to `web3-types` package: Cipher, CipherOptions, ScryptParams, PBKDF2SHA256Params, KeyStore (#5581 )
-
-#### web3-eth-contract
-
--   Remove erroneous `addressOrOptionsOrContext !== 'string'` check  in Contract constructor (#5669)

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -190,3 +190,7 @@ const transactionHash = receipt.transactionHash;
 
 -   Emit past contract events based on `fromBlock` when passed to `contract.events.someEventName` (#5201)
 -   Use different types for `ContractOptions` -> `jsonInterface` setter and getter (#5474)
+
+### Removed
+
+-   Erroneous set `provider` logic in Contract constructor (#5669)

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -193,4 +193,4 @@ const transactionHash = receipt.transactionHash;
 
 ### Removed
 
--   Erroneous set `provider` logic in Contract constructor (#5669)
+-   Remove erroneous `addressOrOptionsOrContext !== 'string'` check  in Contract constructor (#5669)

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -190,7 +190,4 @@ const transactionHash = receipt.transactionHash;
 
 -   Emit past contract events based on `fromBlock` when passed to `contract.events.someEventName` (#5201)
 -   Use different types for `ContractOptions` -> `jsonInterface` setter and getter (#5474)
-
-### Removed
-
--   Remove erroneous `addressOrOptionsOrContext !== 'string'` check  in Contract constructor (#5669)
+-   An issue within the `Contract` constructor where `provider` wasn't being set when provided within the `optionsOrContextOrReturnFormat` argument (#5669)

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -363,18 +363,16 @@ export class Contract<Abi extends ContractAbi>
 		) {
 			provider = addressOrOptionsOrContext.provider;
 		} else if (
-			provider === undefined &&
 			typeof optionsOrContextOrReturnFormat === 'object' &&
 			'provider' in optionsOrContextOrReturnFormat
 		) {
 			provider = optionsOrContextOrReturnFormat.provider;
 		} else if (
-			provider === undefined &&
 			typeof contextOrReturnFormat === 'object' &&
 			'provider' in contextOrReturnFormat
 		) {
 			provider = contextOrReturnFormat.provider;
-		} else if (provider === undefined && Contract.givenProvider !== undefined) {
+		} else {
 			provider = Contract.givenProvider;
 		}
 

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -347,25 +347,40 @@ export class Contract<Abi extends ContractAbi>
 		contextOrReturnFormat?: Web3ContractContext | DataFormat,
 		returnFormat?: DataFormat,
 	) {
+		let contractContext;
+		if (isWeb3ContractContext(addressOrOptionsOrContext)) {
+			contractContext = addressOrOptionsOrContext;
+		} else if (isWeb3ContractContext(optionsOrContextOrReturnFormat)) {
+			contractContext = optionsOrContextOrReturnFormat;
+		} else {
+			contractContext = contextOrReturnFormat;
+		}
+
+		let provider;
+		if (
+			typeof addressOrOptionsOrContext === 'object' &&
+			'provider' in addressOrOptionsOrContext
+		) {
+			provider = addressOrOptionsOrContext.provider;
+		} else if (
+			provider === undefined &&
+			typeof optionsOrContextOrReturnFormat === 'object' &&
+			'provider' in optionsOrContextOrReturnFormat
+		) {
+			provider = optionsOrContextOrReturnFormat.provider;
+		} else if (
+			provider === undefined &&
+			typeof contextOrReturnFormat === 'object' &&
+			'provider' in contextOrReturnFormat
+		) {
+			provider = contextOrReturnFormat.provider;
+		} else if (provider === undefined && Contract.givenProvider !== undefined) {
+			provider = Contract.givenProvider;
+		}
+
 		super({
-			// Due to abide by the rule that super must be first call in constructor
-			// Have to do this complex ternary conditions
-			// eslint-disable-next-line no-nested-ternary
-			...(isWeb3ContractContext(addressOrOptionsOrContext)
-				? addressOrOptionsOrContext
-				: isWeb3ContractContext(optionsOrContextOrReturnFormat)
-				? optionsOrContextOrReturnFormat
-				: contextOrReturnFormat),
-			provider:
-				(addressOrOptionsOrContext as Web3ContractContext)?.provider ??
-				// eslint-disable-next-line no-nested-ternary
-				(typeof optionsOrContextOrReturnFormat === 'object' &&
-				'provider' in optionsOrContextOrReturnFormat
-					? optionsOrContextOrReturnFormat.provider
-					: typeof contextOrReturnFormat === 'object' &&
-					  'provider' in contextOrReturnFormat
-					? contextOrReturnFormat?.provider
-					: Contract.givenProvider),
+			...contractContext,
+			provider,
 			registeredSubscriptions: contractSubscriptions,
 		});
 

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -356,18 +356,6 @@ export class Contract<Abi extends ContractAbi>
 				: isWeb3ContractContext(optionsOrContextOrReturnFormat)
 				? optionsOrContextOrReturnFormat
 				: contextOrReturnFormat),
-			provider:
-				typeof addressOrOptionsOrContext !== 'string'
-					? addressOrOptionsOrContext?.provider ??
-					  // eslint-disable-next-line no-nested-ternary
-					  (typeof optionsOrContextOrReturnFormat === 'object' &&
-					  'provider' in optionsOrContextOrReturnFormat
-							? optionsOrContextOrReturnFormat.provider
-							: typeof contextOrReturnFormat === 'object' &&
-							  'provider' in contextOrReturnFormat
-							? contextOrReturnFormat?.provider
-							: Contract.givenProvider)
-					: undefined,
 			registeredSubscriptions: contractSubscriptions,
 		});
 

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -356,6 +356,16 @@ export class Contract<Abi extends ContractAbi>
 				: isWeb3ContractContext(optionsOrContextOrReturnFormat)
 				? optionsOrContextOrReturnFormat
 				: contextOrReturnFormat),
+			provider:
+				(addressOrOptionsOrContext as Web3ContractContext)?.provider ??
+				// eslint-disable-next-line no-nested-ternary
+				(typeof optionsOrContextOrReturnFormat === 'object' &&
+				'provider' in optionsOrContextOrReturnFormat
+					? optionsOrContextOrReturnFormat.provider
+					: typeof contextOrReturnFormat === 'object' &&
+					  'provider' in contextOrReturnFormat
+					? contextOrReturnFormat?.provider
+					: Contract.givenProvider),
 			registeredSubscriptions: contractSubscriptions,
 		});
 

--- a/packages/web3-eth-contract/test/unit/contract.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract.test.ts
@@ -21,6 +21,7 @@ import { Contract } from '../../src';
 import { sampleStorageContractABI } from '../fixtures/storage';
 import { GreeterAbi, GreeterBytecode } from '../shared_fixtures/build/Greeter';
 import { AllGetPastEventsData, getLogsData, getPastEventsData } from '../fixtures/unitTestFixtures';
+import { getSystemTestProvider } from '../fixtures/system_test_utils';
 
 jest.mock('web3-eth');
 
@@ -74,7 +75,7 @@ describe('Contract', () => {
 		});
 
 		it('should set the provider upon instantiation', () => {
-			const provider = 'http://127.0.0.1:8545';
+			const provider = getSystemTestProvider();
 			const contract = new Contract([], '', {
 				provider,
 			});

--- a/packages/web3-eth-contract/test/unit/contract.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract.test.ts
@@ -72,6 +72,18 @@ describe('Contract', () => {
 
 			expect(contract).toBeInstanceOf(Contract);
 		});
+
+		it('should set the provider upon instantiation', () => {
+			const provider = 'http://127.0.0.1:8545';
+			const contract = new Contract([], '', {
+				provider,
+			});
+
+			expect(contract.provider).toEqual({
+				clientUrl: provider,
+				httpProviderOptions: undefined,
+			});
+		});
 	});
 
 	describe('Contract functions and defaults', () => {


### PR DESCRIPTION
Removes erroneous `addressOrOptionsOrContext !== 'string'` check  in Contract constructor

closes #5433 

When instantiating `Contract` with the following, `addressOrOptionsOrContext` was something other than `string` causing the ternary to use the falsey path setting `undefined` for the `provider`

```typescript
const provider = 'http://127.0.0.1:8545';
const contract = new Contract([], '', {
    provider,
});
```