### PR TITLE
Fix Webpack Build for `web3-validator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -945,3 +945,9 @@ should use 4.0.1-alpha.0 for testing.
 -   These types were moved from `web3-eth-accounts` to `web3-types` package: Cipher, CipherOptions, ScryptParams, PBKDF2SHA256Params, KeyStore (#5581 )
 
 ## [Unreleased]
+
+### Fixed
+
+#### web3-validator
+
+-   Fix issue when importing `web3-validator` package within browser environments (Webpack minified filename changed from `index.min.js` to `web3-validator.min.js`) (#5710)

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -52,3 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fix `isHex`returning `false` for `-123`, fix `isHexStrict` returning `true` for `-0x`, and fix `isHex` returning `true` for empty strings `` (#5373).
 
 ## [Unreleased]
+
+### Fixed
+
+-   Fix issue when importing `web3-validator` package within browser environments (Webpack minified filename changed from `index.min.js` to `web3-validator.min.js`) (#5710)

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.1-alpha.2",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "dist/index.js",
-	"browser": "dist/index.min.js",
+	"browser": "dist/web3-validator.min.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"author": "ChainSafe Systems",
 	"license": "LGPL-3.0",

--- a/packages/web3-validator/webpack.config.js
+++ b/packages/web3-validator/webpack.config.js
@@ -17,4 +17,9 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 const { getWebPackConfig } = require('../../webpack.base.config');
 
-module.exports = getWebPackConfig(__dirname, 'index.min.js', 'web3-validator', 'src/index.ts');
+module.exports = getWebPackConfig(
+	__dirname,
+	'web3-validator.min.js',
+	'web3-validator',
+	'src/index.ts',
+);

--- a/scripts/verdaccio.sh
+++ b/scripts/verdaccio.sh
@@ -35,7 +35,7 @@ createVerdaccioNPMUser() {
 }
 
 loginNPMUser() {
-    npm-auth-to-token \
+    npx npm-auth-to-token \
         -u test \
         -p test \
         -e test@test.com \
@@ -43,7 +43,7 @@ loginNPMUser() {
 }
 
 lernaUpdatePackageVersions() {
-    lerna version 5.0.0 \
+    npx lerna version 5.0.0 \
         --ignore-scripts \
         --no-push \
         --no-private \
@@ -59,7 +59,7 @@ lernaBuildAndCommit() {
 }
 
 lernaPublish() {
-    lerna publish from-package \
+    npx lerna publish from-package \
         --dist-tag blackbox \
         --no-git-tag-version \
         --no-push \


### PR DESCRIPTION
As suggested by @jdevcs, the minified filename for `web3-validator` Web3pack build was changed from `index.min.js` (which interferes with `web3`'s minified filename) to `web3-validator.min.js`

Additionally, this PR adds `npx` to Verdaccio script to make it easier to run scripts locally

closes #5706