### PR TITLE
Init TransactionWithFromLocalWalletIndex, TransactionWithToLocalWalle…

### DIFF
--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -38,8 +38,10 @@ import {
 	TransactionReceipt,
 	Transaction,
 	TransactionCall,
-	TransactionWithLocalWalletIndex,
 	Web3EthExecutionAPI,
+	TransactionWithFromLocalWalletIndex,
+	TransactionWithToLocalWalletIndex,
+	TransactionWithToAndFromLocalWalletIndex,
 } from 'web3-types';
 import { Web3Context, Web3PromiEvent } from 'web3-core';
 import { ETH_DATA_FORMAT, FormatType, DataFormat, DEFAULT_RETURN_FORMAT, format } from 'web3-utils';
@@ -940,7 +942,7 @@ export async function getTransactionCount<ReturnFormat extends DataFormat>(
 
 /**
  * @param web3Context ({@link Web3Context}) Web3 configuration object that contains things such as the provider, request manager, wallet, etc.
- * @param transaction The {@link Transaction} or {@link TransactionWithLocalWalletIndex} to send.
+ * @param transaction The {@link Transaction}, {@link TransactionWithFromLocalWalletIndex}, {@link TransactionWithToLocalWalletIndex}, or {@link TransactionWithToAndFromLocalWalletIndex} to send.
  * @param returnFormat ({@link DataFormat} defaults to {@link DEFAULT_RETURN_FORMAT}) Specifies how the return data should be formatted.
  * @param options A configuration object used to change the behavior of the `sendTransaction` method.
  * @returns If `await`ed or `.then`d (i.e. the promise resolves), the transaction hash is returned.
@@ -1050,7 +1052,11 @@ export function sendTransaction<
 	ResolveType = FormatType<TransactionReceipt, ReturnFormat>,
 >(
 	web3Context: Web3Context<EthExecutionAPI>,
-	transaction: Transaction | TransactionWithLocalWalletIndex,
+	transaction:
+		| Transaction
+		| TransactionWithFromLocalWalletIndex
+		| TransactionWithToLocalWalletIndex
+		| TransactionWithToAndFromLocalWalletIndex,
 	returnFormat: ReturnFormat,
 	options?: SendTransactionOptions<ResolveType>,
 ): Web3PromiEvent<ResolveType, SendTransactionEvents<ReturnFormat>> {

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -41,7 +41,7 @@ import {
 	Web3EthExecutionAPI,
 	TransactionWithFromLocalWalletIndex,
 	TransactionWithToLocalWalletIndex,
-	TransactionWithToAndFromLocalWalletIndex,
+	TransactionWithFromAndToLocalWalletIndex,
 } from 'web3-types';
 import { Web3Context, Web3PromiEvent } from 'web3-core';
 import { ETH_DATA_FORMAT, FormatType, DataFormat, DEFAULT_RETURN_FORMAT, format } from 'web3-utils';
@@ -942,7 +942,7 @@ export async function getTransactionCount<ReturnFormat extends DataFormat>(
 
 /**
  * @param web3Context ({@link Web3Context}) Web3 configuration object that contains things such as the provider, request manager, wallet, etc.
- * @param transaction The {@link Transaction}, {@link TransactionWithFromLocalWalletIndex}, {@link TransactionWithToLocalWalletIndex}, or {@link TransactionWithToAndFromLocalWalletIndex} to send.
+ * @param transaction The {@link Transaction}, {@link TransactionWithFromLocalWalletIndex}, {@link TransactionWithToLocalWalletIndex}, or {@link TransactionWithFromAndToLocalWalletIndex} to send.
  * @param returnFormat ({@link DataFormat} defaults to {@link DEFAULT_RETURN_FORMAT}) Specifies how the return data should be formatted.
  * @param options A configuration object used to change the behavior of the `sendTransaction` method.
  * @returns If `await`ed or `.then`d (i.e. the promise resolves), the transaction hash is returned.
@@ -1056,7 +1056,7 @@ export function sendTransaction<
 		| Transaction
 		| TransactionWithFromLocalWalletIndex
 		| TransactionWithToLocalWalletIndex
-		| TransactionWithToAndFromLocalWalletIndex,
+		| TransactionWithFromAndToLocalWalletIndex,
 	returnFormat: ReturnFormat,
 	options?: SendTransactionOptions<ResolveType>,
 ): Web3PromiEvent<ResolveType, SendTransactionEvents<ReturnFormat>> {

--- a/packages/web3-eth/src/utils/transaction_builder.ts
+++ b/packages/web3-eth/src/utils/transaction_builder.ts
@@ -30,7 +30,9 @@ import {
 	ValidChains,
 	Hardfork,
 	Transaction,
-	TransactionWithLocalWalletIndex,
+	TransactionWithFromLocalWalletIndex,
+	TransactionWithToLocalWalletIndex,
+	TransactionWithToAndFromLocalWalletIndex,
 	Common,
 	Web3NetAPI,
 	Numbers,
@@ -60,10 +62,14 @@ const isFromAttr = (attr: 'from' | 'to'): attr is 'from' => attr === 'from';
 const getTransactionFromOrToAttr = (
 	attr: 'from' | 'to',
 	web3Context: Web3Context<EthExecutionAPI>,
-	transaction?: Transaction | TransactionWithLocalWalletIndex,
+	transaction?:
+		| Transaction
+		| TransactionWithFromLocalWalletIndex
+		| TransactionWithToLocalWalletIndex
+		| TransactionWithToAndFromLocalWalletIndex,
 	privateKey?: HexString | Buffer,
 ): Address | undefined => {
-	if (transaction?.[attr] !== undefined) {
+	if (transaction !== undefined && attr in transaction && transaction[attr] !== undefined) {
 		if (typeof transaction[attr] === 'string' && isAddress(transaction[attr] as string)) {
 			return transaction[attr] as Address;
 		}

--- a/packages/web3-eth/src/utils/transaction_builder.ts
+++ b/packages/web3-eth/src/utils/transaction_builder.ts
@@ -32,7 +32,7 @@ import {
 	Transaction,
 	TransactionWithFromLocalWalletIndex,
 	TransactionWithToLocalWalletIndex,
-	TransactionWithToAndFromLocalWalletIndex,
+	TransactionWithFromAndToLocalWalletIndex,
 	Common,
 	Web3NetAPI,
 	Numbers,
@@ -66,7 +66,7 @@ const getTransactionFromOrToAttr = (
 		| Transaction
 		| TransactionWithFromLocalWalletIndex
 		| TransactionWithToLocalWalletIndex
-		| TransactionWithToAndFromLocalWalletIndex,
+		| TransactionWithFromAndToLocalWalletIndex,
 	privateKey?: HexString | Buffer,
 ): Address | undefined => {
 	if (transaction !== undefined && attr in transaction && transaction[attr] !== undefined) {

--- a/packages/web3-eth/src/web3_eth.ts
+++ b/packages/web3-eth/src/web3_eth.ts
@@ -33,7 +33,7 @@ import {
 	Web3EthExecutionAPI,
 	TransactionWithFromLocalWalletIndex,
 	TransactionWithToLocalWalletIndex,
-	TransactionWithToAndFromLocalWalletIndex,
+	TransactionWithFromAndToLocalWalletIndex,
 } from 'web3-types';
 import { isSupportedProvider, Web3Context, Web3ContextInitOptions } from 'web3-core';
 import { TransactionNotFound } from 'web3-errors';
@@ -824,7 +824,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 	}
 
 	/**
-	 * @param transaction The {@link Transaction}, {@link TransactionWithFromLocalWalletIndex}, {@link TransactionWithToLocalWalletIndex} or {@link TransactionWithToAndFromLocalWalletIndex} to send.
+	 * @param transaction The {@link Transaction}, {@link TransactionWithFromLocalWalletIndex}, {@link TransactionWithToLocalWalletIndex} or {@link TransactionWithFromAndToLocalWalletIndex} to send.
 	 * @param returnFormat ({@link DataFormat} defaults to {@link DEFAULT_RETURN_FORMAT}) Specifies how the return data should be formatted.
 	 * @param options A configuration object used to change the behavior of the `sendTransaction` method.
 	 * @returns If `await`ed or `.then`d (i.e. the promise resolves), the transaction hash is returned.
@@ -934,7 +934,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 			| Transaction
 			| TransactionWithFromLocalWalletIndex
 			| TransactionWithToLocalWalletIndex
-			| TransactionWithToAndFromLocalWalletIndex,
+			| TransactionWithFromAndToLocalWalletIndex,
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 		options?: SendTransactionOptions,
 	) {

--- a/packages/web3-eth/src/web3_eth.ts
+++ b/packages/web3-eth/src/web3_eth.ts
@@ -30,8 +30,10 @@ import {
 	LogsOutput,
 	Transaction,
 	TransactionCall,
-	TransactionWithLocalWalletIndex,
 	Web3EthExecutionAPI,
+	TransactionWithFromLocalWalletIndex,
+	TransactionWithToLocalWalletIndex,
+	TransactionWithToAndFromLocalWalletIndex,
 } from 'web3-types';
 import { isSupportedProvider, Web3Context, Web3ContextInitOptions } from 'web3-core';
 import { TransactionNotFound } from 'web3-errors';
@@ -822,7 +824,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 	}
 
 	/**
-	 * @param transaction The {@link Transaction} or {@link TransactionWithLocalWalletIndex} to send.
+	 * @param transaction The {@link Transaction}, {@link TransactionWithFromLocalWalletIndex}, {@link TransactionWithToLocalWalletIndex} or {@link TransactionWithToAndFromLocalWalletIndex} to send.
 	 * @param returnFormat ({@link DataFormat} defaults to {@link DEFAULT_RETURN_FORMAT}) Specifies how the return data should be formatted.
 	 * @param options A configuration object used to change the behavior of the `sendTransaction` method.
 	 * @returns If `await`ed or `.then`d (i.e. the promise resolves), the transaction hash is returned.
@@ -928,7 +930,11 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 	 * ```
 	 */
 	public sendTransaction<ReturnFormat extends DataFormat = typeof DEFAULT_RETURN_FORMAT>(
-		transaction: Transaction | TransactionWithLocalWalletIndex,
+		transaction:
+			| Transaction
+			| TransactionWithFromLocalWalletIndex
+			| TransactionWithToLocalWalletIndex
+			| TransactionWithToAndFromLocalWalletIndex,
 		returnFormat: ReturnFormat = DEFAULT_RETURN_FORMAT as ReturnFormat,
 		options?: SendTransactionOptions,
 	) {

--- a/packages/web3-eth/test/integration/web3_eth/send_transaction.test.ts
+++ b/packages/web3-eth/test/integration/web3_eth/send_transaction.test.ts
@@ -15,7 +15,12 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Transaction, TransactionWithLocalWalletIndex } from 'web3-types';
+import {
+	Transaction,
+	TransactionWithFromLocalWalletIndex,
+	TransactionWithToLocalWalletIndex,
+	TransactionWithToAndFromLocalWalletIndex,
+} from 'web3-types';
 import { Wallet } from 'web3-eth-accounts';
 import { isHexStrict } from 'web3-validator';
 
@@ -63,7 +68,7 @@ describe('Web3Eth.sendTransaction', () => {
 
 		web3EthWithWallet.wallet?.add(tempAcc.privateKey);
 
-		const transaction: TransactionWithLocalWalletIndex = {
+		const transaction: TransactionWithFromLocalWalletIndex = {
 			from: 0,
 			to: '0x0000000000000000000000000000000000000000',
 			gas: 21000,
@@ -93,7 +98,7 @@ describe('Web3Eth.sendTransaction', () => {
 
 		web3EthWithWallet.wallet?.add(tempAcc.privateKey);
 
-		const transaction: TransactionWithLocalWalletIndex = {
+		const transaction: TransactionWithToLocalWalletIndex = {
 			from: tempAcc.address,
 			to: 0,
 			gas: 21000,
@@ -127,7 +132,7 @@ describe('Web3Eth.sendTransaction', () => {
 
 		web3EthWithWallet.wallet?.add(tempAcc2.privateKey);
 
-		const transaction: TransactionWithLocalWalletIndex = {
+		const transaction: TransactionWithToAndFromLocalWalletIndex = {
 			from: 0,
 			to: 1,
 			gas: 21000,

--- a/packages/web3-eth/test/integration/web3_eth/send_transaction.test.ts
+++ b/packages/web3-eth/test/integration/web3_eth/send_transaction.test.ts
@@ -19,7 +19,7 @@ import {
 	Transaction,
 	TransactionWithFromLocalWalletIndex,
 	TransactionWithToLocalWalletIndex,
-	TransactionWithToAndFromLocalWalletIndex,
+	TransactionWithFromAndToLocalWalletIndex,
 } from 'web3-types';
 import { Wallet } from 'web3-eth-accounts';
 import { isHexStrict } from 'web3-validator';
@@ -132,7 +132,7 @@ describe('Web3Eth.sendTransaction', () => {
 
 		web3EthWithWallet.wallet?.add(tempAcc2.privateKey);
 
-		const transaction: TransactionWithToAndFromLocalWalletIndex = {
+		const transaction: TransactionWithFromAndToLocalWalletIndex = {
 			from: 0,
 			to: 1,
 			gas: 21000,

--- a/packages/web3-types/src/eth_types.ts
+++ b/packages/web3-types/src/eth_types.ts
@@ -375,7 +375,7 @@ export interface TransactionWithToLocalWalletIndex extends Omit<Transaction, 'to
 	to: Numbers;
 }
 
-export interface TransactionWithToAndFromLocalWalletIndex extends Omit<Transaction, 'to' | 'from'> {
+export interface TransactionWithFromAndToLocalWalletIndex extends Omit<Transaction, 'from' | 'to'> {
 	from: Numbers;
 	to: Numbers;
 }

--- a/packages/web3-types/src/eth_types.ts
+++ b/packages/web3-types/src/eth_types.ts
@@ -338,8 +338,6 @@ interface TransactionBase {
 	value?: Numbers;
 	accessList?: AccessList;
 	common?: Common;
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	to?: Address | null;
 	gas?: Numbers;
 	gasPrice?: Numbers;
 	type?: Numbers;
@@ -361,16 +359,24 @@ interface TransactionBase {
 
 export interface Transaction extends TransactionBase {
 	from?: Address;
+	to?: Address;
 }
 
 export interface TransactionCall extends Transaction {
 	to: Address;
 }
 
-export interface TransactionWithLocalWalletIndex extends Omit<TransactionBase, 'to'> {
-	from?: Numbers;
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	to?: Address | Numbers | null;
+export interface TransactionWithFromLocalWalletIndex extends Omit<Transaction, 'from'> {
+	from: Numbers;
+}
+
+export interface TransactionWithToLocalWalletIndex extends Omit<Transaction, 'to'> {
+	to: Numbers;
+}
+
+export interface TransactionWithToAndFromLocalWalletIndex extends Omit<Transaction, 'to' | 'from'> {
+	from: Numbers;
+	to: Numbers;
 }
 
 export interface TransactionInfo extends Transaction {

--- a/packages/web3-types/src/eth_types.ts
+++ b/packages/web3-types/src/eth_types.ts
@@ -359,7 +359,8 @@ interface TransactionBase {
 
 export interface Transaction extends TransactionBase {
 	from?: Address;
-	to?: Address;
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	to?: Address | null;
 }
 
 export interface TransactionCall extends Transaction {


### PR DESCRIPTION
Init the following types:

```typescript
export interface TransactionWithFromLocalWalletIndex extends Omit<Transaction, 'from'> {
	from: Numbers;
}

export interface TransactionWithToLocalWalletIndex extends Omit<Transaction, 'to'> {
	to: Numbers;
}

export interface TransactionWithFromAndToLocalWalletIndex extends Omit<Transaction, 'to' | 'from'> {
	from: Numbers;
	to: Numbers;
}
```