### PR TITLE
Build for 4.0.1-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -957,7 +957,7 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Parameters decoding error for nested components (#5714)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
@@ -1048,3 +1048,5 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-types
 
 -   These types were added: ProviderRpcError, EthSubscription, ProviderMessage, ProviderConnectInfo (#5683)
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -64,8 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -25,14 +25,14 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-eth-iban": "^4.0.1-alpha.3",
-		"web3-providers-http": "^4.0.1-alpha.3",
-		"web3-providers-ipc": "^4.0.1-alpha.3",
-		"web3-providers-ws": "^4.0.1-alpha.3",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3",
-		"web3-validator": "^0.1.1-alpha.3"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-eth-iban": "^4.0.1-alpha.4",
+		"web3-providers-http": "^4.0.1-alpha.4",
+		"web3-providers-ipc": "^4.0.1-alpha.4",
+		"web3-providers-ws": "^4.0.1-alpha.4",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4",
+		"web3-validator": "^0.1.1-alpha.4"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -59,8 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated Web3.js dependencies (#5664)
 
-## [Unreleased]
+## [4.0.1-alpha.3]
 
 ### Changed
 
 -   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "0.1.1-alpha.2",
+	"version": "0.1.1-alpha.3",
 	"description": "This package has web3 error classes",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -25,7 +25,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^0.1.1-alpha.2"
+		"web3-types": "^0.1.1-alpha.3"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -66,8 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ethereum/web3.js/tree/4.x/packages/web3-eth-abi",
@@ -26,9 +26,9 @@
 	},
 	"dependencies": {
 		"@ethersproject/abi": "^5.6.4",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -53,8 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -42,9 +42,9 @@
 	"dependencies": {
 		"@ethereumjs/tx": "^3.5.2",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3",
-		"web3-validator": "^0.1.1-alpha.3"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4",
+		"web3-validator": "^0.1.1-alpha.4"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -202,8 +202,10 @@ const transactionHash = receipt.transactionHash;
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ethereum/web3.js/tree/4.x/packages/web3-eth-contract",
@@ -28,13 +28,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-eth": "^4.0.1-alpha.3",
-		"web3-eth-abi": "^4.0.1-alpha.3",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3",
-		"web3-validator": "^0.1.1-alpha.3"
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-eth": "^4.0.1-alpha.4",
+		"web3-eth-abi": "^4.0.1-alpha.4",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4",
+		"web3-validator": "^0.1.1-alpha.4"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -50,6 +50,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.1-alpha.3"
+		"web3-eth-accounts": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -53,8 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -42,12 +42,12 @@
 	},
 	"dependencies": {
 		"idna-uts46-hx": "^3.5.0",
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-eth": "^4.0.1-alpha.3",
-		"web3-eth-contract": "^4.0.1-alpha.3",
-		"web3-net": "^4.0.1-alpha.3",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-eth": "^4.0.1-alpha.4",
+		"web3-eth-contract": "^4.0.1-alpha.4",
+		"web3-net": "^4.0.1-alpha.4",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -47,8 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -39,8 +39,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -63,8 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -25,12 +25,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-eth": "^4.0.1-alpha.3",
-		"web3-rpc-methods": "^0.1.0-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3",
-		"web3-validator": "^0.1.1-alpha.3"
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-eth": "^4.0.1-alpha.4",
+		"web3-rpc-methods": "^0.1.0-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4",
+		"web3-validator": "^0.1.1-alpha.4"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -45,6 +45,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.1-alpha.3"
+		"web3-providers-ws": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -73,8 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -40,21 +40,21 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.0.1-alpha.3",
-		"web3-providers-http": "^4.0.1-alpha.3"
+		"web3-eth-abi": "^4.0.1-alpha.4",
+		"web3-providers-http": "^4.0.1-alpha.4"
 	},
 	"dependencies": {
 		"@ethereumjs/common": "^2.6.5",
 		"@ethereumjs/tx": "^3.5.2",
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-eth-accounts": "^4.0.1-alpha.3",
-		"web3-net": "^4.0.1-alpha.3",
-		"web3-providers-ws": "^4.0.1-alpha.3",
-		"web3-rpc-methods": "^0.1.0-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3",
-		"web3-validator": "^0.1.1-alpha.3"
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-eth-accounts": "^4.0.1-alpha.4",
+		"web3-net": "^4.0.1-alpha.4",
+		"web3-providers-ws": "^4.0.1-alpha.4",
+		"web3-rpc-methods": "^0.1.0-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4",
+		"web3-validator": "^0.1.1-alpha.4"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -63,8 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -39,9 +39,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-rpc-methods": "^0.1.0-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-rpc-methods": "^0.1.0-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -47,8 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -44,8 +44,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -53,9 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
 -   Refactor to use common SocketProvider class (#5683)
+
+## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -39,8 +39,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -47,9 +47,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)
 -   Refactor to use common SocketProvider class (#5683)
+
+## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -45,9 +45,9 @@
 	},
 	"dependencies": {
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3",
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -47,8 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [0.1.0-alpha.3]
 
 ### Changed
 
 -   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "0.1.0-alpha.2",
+	"version": "0.1.0-alpha.3",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -39,8 +39,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-validator": "^0.1.1-alpha.3"
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-validator": "^0.1.1-alpha.4"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -57,9 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Make the `request` method of `EIP1193Provider` class, compatible with EIP 1193 (#5591)
 
-## [Unreleased]
+## [0.1.1-alpha.3]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
 -   These types were added: ProviderRpcError, EthSubscription, ProviderMessage, ProviderConnectInfo (#5683)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "0.1.1-alpha.2",
+	"version": "0.1.1-alpha.3",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -59,9 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
-## [Unreleased]
+## [4.0.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
 -   Add SocketProvider class and Eip1193Provider abstract class (#5683)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -43,8 +43,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-validator": "^0.1.1-alpha.3"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-validator": "^0.1.1-alpha.4"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -57,8 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fix issue when importing `web3-validator` package within browser environments (Webpack minified filename changed from `index.min.js` to `web3-validator.min.js`) (#5710)
 
-## [Unreleased]
+## [0.1.1-alpha.4]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "0.1.1-alpha.3",
+	"version": "0.1.1-alpha.4",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "lib/index.js",
 	"browser": "dist/web3-validator.min.js",
@@ -30,8 +30,8 @@
 	"dependencies": {
 		"ajv": "^8.11.0",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-types": "^0.1.1-alpha.2"
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-types": "^0.1.1-alpha.3"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -53,8 +53,10 @@ But this internal behavior is not exposed any further. Though you can achieve sa
 web3.currentProvider.disconnect();
 ```
 
-## [Unreleased]
+## [4.0.1-alpha.2]
 
 ### Changed
 
 -   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)
+
+## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.1-alpha.3",
+	"version": "4.0.1-alpha.4",
 	"description": "Ethereum JavaScript API",
 	"main": "lib/index.js",
 	"browser": "dist/web3.min.js",
@@ -59,22 +59,22 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-http": "^4.0.1-alpha.3",
-		"web3-providers-ipc": "^4.0.1-alpha.3",
-		"web3-providers-ws": "^4.0.1-alpha.3"
+		"web3-providers-http": "^4.0.1-alpha.4",
+		"web3-providers-ipc": "^4.0.1-alpha.4",
+		"web3-providers-ws": "^4.0.1-alpha.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-errors": "^0.1.1-alpha.2",
-		"web3-eth": "^4.0.1-alpha.3",
-		"web3-eth-abi": "^4.0.1-alpha.3",
-		"web3-eth-accounts": "^4.0.1-alpha.3",
-		"web3-eth-contract": "^4.0.1-alpha.3",
-		"web3-eth-ens": "^4.0.1-alpha.3",
-		"web3-eth-iban": "^4.0.1-alpha.3",
-		"web3-eth-personal": "^4.0.1-alpha.3",
-		"web3-net": "^4.0.1-alpha.3",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-errors": "^0.1.1-alpha.3",
+		"web3-eth": "^4.0.1-alpha.4",
+		"web3-eth-abi": "^4.0.1-alpha.4",
+		"web3-eth-accounts": "^4.0.1-alpha.4",
+		"web3-eth-contract": "^4.0.1-alpha.4",
+		"web3-eth-ens": "^4.0.1-alpha.4",
+		"web3-eth-iban": "^4.0.1-alpha.4",
+		"web3-eth-personal": "^4.0.1-alpha.4",
+		"web3-net": "^4.0.1-alpha.4",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-alpha.3' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-alpha.4' };

--- a/tools/web3-packagetemplate/package.json
+++ b/tools/web3-packagetemplate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-packagetemplate",
-	"version": "0.1.1-alpha.0",
+	"version": "0.1.1-alpha.1",
 	"description": "Package template for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "0.1.0-alpha.2",
+	"version": "0.1.0-alpha.3",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -43,12 +43,12 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.0.1-alpha.3",
-		"web3-core": "^4.0.1-alpha.3",
-		"web3-eth-abi": "^4.0.1-alpha.3",
-		"web3-eth-contract": "^4.0.1-alpha.3",
-		"web3-types": "^0.1.1-alpha.2",
-		"web3-utils": "^4.0.1-alpha.3"
+		"web3": "^4.0.1-alpha.4",
+		"web3-core": "^4.0.1-alpha.4",
+		"web3-eth-abi": "^4.0.1-alpha.4",
+		"web3-eth-contract": "^4.0.1-alpha.4",
+		"web3-types": "^0.1.1-alpha.3",
+		"web3-utils": "^4.0.1-alpha.4"
 	},
 	"peerDependencies": {
 		"web3-core": ">= 4.0.1-alpha.0 < 5",


### PR DESCRIPTION
### Changed

#### web3

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-core

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-errors

-   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)

#### web3-eth

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-eth-abi

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-eth-accounts

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-eth-contract

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-eth-ens

-   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)

#### web3-eth-iban

-   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)

#### web3-eth-personal

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-net

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-providers-http

-   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)

#### web3-providers-ipc

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-providers-ws

-   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)

#### web3-rpc-methods

-   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)

#### web3-types

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-utils

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-validator

-   `tsc` compiled files moved to `lib/` directory from `dist/` (#5739)

#### web3-providers-ipc

-   Refactor to use common SocketProvider class (#5683)

#### web3-providers-ws

-   Refactor to use common SocketProvider class (#5683)

#### web3-utils

-   Add SocketProvider class and Eip1193Provider abstract class (#5683)

#### web3-types

-   These types were added: ProviderRpcError, EthSubscription, ProviderMessage, ProviderConnectInfo (#5683)