### PR TITLE
fix types default export (#5852)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -646,3 +646,4 @@ Released with 1.0.0-beta.37 code base.
 
   - Fixed skipped ws-ganache tests (#5759)
   - Fixed "provider started to reconnect error" in web3-provider-ws (#5820)
+  - Fixed types for packages which have default exports but not declared default export in .d.ts

--- a/packages/web3-bzz/types/index.d.ts
+++ b/packages/web3-bzz/types/index.d.ts
@@ -38,3 +38,5 @@ export interface Pick {
     directory: () => Promise<any>;
     data: () => Promise<any>;
 }
+
+export default Bzz

--- a/packages/web3-bzz/types/tests/bzz-test.ts
+++ b/packages/web3-bzz/types/tests/bzz-test.ts
@@ -17,7 +17,10 @@
  * @date 2018
  */
 
-import { Bzz } from 'web3-bzz';
+import BzzDefault, { Bzz } from 'web3-bzz';
+
+// $ExpectType Bzz
+const bzz_default_empty = new BzzDefault();
 
 // $ExpectType Bzz
 const bzz_empty = new Bzz();

--- a/packages/web3-core-method/types/index.d.ts
+++ b/packages/web3-core-method/types/index.d.ts
@@ -32,3 +32,5 @@ export interface Method {
     abiCoder?: any;
     handleRevert?: boolean;
 }
+
+export default Method

--- a/packages/web3-eth-accounts/types/index.d.ts
+++ b/packages/web3-eth-accounts/types/index.d.ts
@@ -36,3 +36,5 @@ export interface SignatureObject {
     s: string;
     v: string;
 }
+
+export default Accounts

--- a/packages/web3-eth-accounts/types/tests/accounts-tests.ts
+++ b/packages/web3-eth-accounts/types/tests/accounts-tests.ts
@@ -16,7 +16,10 @@
  * @author Josh Stevens <joshstevens19@hotmail.co.uk>
  * @date 2018
  */
-import { Accounts, SignedTransaction } from 'web3-eth-accounts';
+import AccountsDefault, { Accounts, SignedTransaction } from 'web3-eth-accounts';
+
+// $ExpectType Accounts
+const accounts_default_empty = new AccountsDefault();
 
 // $ExpectType Accounts
 const accounts_empty = new Accounts();

--- a/packages/web3-eth-contract/types/index.d.ts
+++ b/packages/web3-eth-contract/types/index.d.ts
@@ -177,3 +177,5 @@ export interface EventData {
     blockNumber: number;
     address: string;
 }
+
+export default Contract

--- a/packages/web3-eth-contract/types/tests/contract-test.ts
+++ b/packages/web3-eth-contract/types/tests/contract-test.ts
@@ -18,8 +18,12 @@
  * @date 2018
  */
 
-import { Contract } from 'web3-eth-contract';
+import ContractDefault, { Contract } from 'web3-eth-contract';
 
+// $ExpectType Contract
+const contract_default = new ContractDefault([]);
+
+// $ExpectType Contract
 const contract = new Contract([]);
 
 // $ExpectType string | null

--- a/packages/web3-eth-ens/types/index.d.ts
+++ b/packages/web3-eth-ens/types/index.d.ts
@@ -402,3 +402,5 @@ export class Registry {
         callback?: (error: Error | TransactionRevertInstructionError, receipt: TransactionReceipt) => void
     ): PromiEvent<TransactionReceipt | TransactionRevertInstructionError>
 }
+
+export default Ens

--- a/packages/web3-eth-ens/types/tests/ens-test.ts
+++ b/packages/web3-eth-ens/types/tests/ens-test.ts
@@ -20,9 +20,13 @@
 import { TransactionRevertInstructionError } from 'web3-core-helpers';
 import { TransactionReceipt } from 'web3-core';
 import { Contract } from 'web3-eth-contract';
-import { Ens, ContentHash } from 'web3-eth-ens';
+import EnsDefault, { Ens, ContentHash } from 'web3-eth-ens';
 import { Eth } from 'web3-eth';
 
+// $ExpectType Ens
+const ens_default = new EnsDefault(new Eth('http://localhost:8545'));
+
+// $ExpectType Ens
 const ens = new Ens(new Eth('http://localhost:8545'));
 
 // $ExpectType string | null

--- a/packages/web3-eth-iban/types/index.d.ts
+++ b/packages/web3-eth-iban/types/index.d.ts
@@ -58,3 +58,5 @@ export interface IndirectOptions {
     institution: string;
     identifier: string;
 }
+
+export default Iban

--- a/packages/web3-eth-iban/types/tests/iban-tests.ts
+++ b/packages/web3-eth-iban/types/tests/iban-tests.ts
@@ -20,10 +20,13 @@
  * @date 2018
  */
 
-import { Iban, IndirectOptions } from 'web3-eth-iban';
+import IbanDefault, { Iban, IndirectOptions } from 'web3-eth-iban';
 
 const iban = 'XE7338O073KYGTWWZN0F2WZ0R8PX5ZPPZS';
 const address = '0x45cd08334aeedd8a06265b2ae302e3597d8faa28';
+
+// $ExpectType Iban
+const iban_default = new IbanDefault(iban);
 
 // $ExpectType Iban
 const ibanClass = new Iban(iban);

--- a/packages/web3-eth-personal/types/index.d.ts
+++ b/packages/web3-eth-personal/types/index.d.ts
@@ -93,3 +93,5 @@ export class Personal {
         callback?: (error: Error, result: string) => void
     ): Promise<string>;
 }
+
+export default Personal

--- a/packages/web3-eth-personal/types/tests/personal-tests.ts
+++ b/packages/web3-eth-personal/types/tests/personal-tests.ts
@@ -20,7 +20,10 @@
  */
 
 import { RLPEncodedTransaction } from 'web3-core';
-import { Personal } from 'web3-eth-personal';
+import PersonalDefault, { Personal } from 'web3-eth-personal';
+
+// $ExpectType Personal
+const personal_default_empty = new PersonalDefault();
 
 // $ExpectType Personal
 const personal_empty = new Personal();

--- a/packages/web3-eth/types/index.d.ts
+++ b/packages/web3-eth/types/index.d.ts
@@ -485,3 +485,5 @@ export interface FeeHistoryResult {
     oldestBlock: number;
     reward: string[][];
 }
+
+export default Eth

--- a/packages/web3-eth/types/tests/eth.tests.ts
+++ b/packages/web3-eth/types/tests/eth.tests.ts
@@ -19,7 +19,7 @@
  */
 
 import {Log} from 'web3-core';
-import {
+import EthDefault, {
     BlockTransactionObject,
     BlockTransactionString,
     BlockHeader,
@@ -37,6 +37,9 @@ import {
 } from 'web3-eth';
 import BN = require('bn.js');
 import BigNumber from 'bignumber.js';
+
+// $ExpectType Eth
+const eth_default_empty = new EthDefault();
 
 // $ExpectType Eth
 const eth_empty = new Eth();

--- a/packages/web3-net/types/index.d.ts
+++ b/packages/web3-net/types/index.d.ts
@@ -20,3 +20,5 @@
 import { NetworkBase } from 'web3-core';
 
 export class Network extends NetworkBase {}
+
+export default Network

--- a/packages/web3-net/types/tests/network-test.ts
+++ b/packages/web3-net/types/tests/network-test.ts
@@ -17,7 +17,10 @@
  * @date 2018
  */
 
-import { Network } from 'web3-net';
+import NetworkDefault, { Network } from 'web3-net';
+
+// $ExpectType Network
+const network_default_empty = new NetworkDefault();
 
 // $ExpectType Network
 const network_empty = new Network();

--- a/packages/web3-providers-http/types/index.d.ts
+++ b/packages/web3-providers-http/types/index.d.ts
@@ -63,3 +63,5 @@ export class HttpProvider extends HttpProviderBase {
     disconnect(): boolean;
     supportsSubscriptions(): boolean;
 }
+
+export default HttpProvider

--- a/packages/web3-providers-http/types/tests/web3-provider-http-tests.ts
+++ b/packages/web3-providers-http/types/tests/web3-provider-http-tests.ts
@@ -22,9 +22,16 @@
 
 import * as http from 'http';
 import * as https from 'https';
-import { HttpProvider } from 'web3-providers';
+import HttpProviderDefault, { HttpProvider } from 'web3-providers';
 import { JsonRpcResponse } from 'web3-core-helpers';
 
+// $ExpectType HttpProvider
+const http_provider_default_empty = new HttpProviderDefault();
+
+// $ExpectType HttpProvider
+const http_provider_empty = new HttpProvider();
+
+// $ExpectType HttpProvider
 const httpProvider = new HttpProvider('http://localhost:8545', {
     timeout: 20000,
     headers: [

--- a/packages/web3-providers-ipc/types/index.d.ts
+++ b/packages/web3-providers-ipc/types/index.d.ts
@@ -23,3 +23,5 @@
 import { IpcProviderBase } from 'web3-core-helpers';
 
 export class IpcProvider extends IpcProviderBase { }
+
+export default IpcProvider

--- a/packages/web3-providers-ipc/types/tests/web3-provider-ipc-tests.ts
+++ b/packages/web3-providers-ipc/types/tests/web3-provider-ipc-tests.ts
@@ -21,9 +21,16 @@
  */
 
 import * as net from 'net';
-import { IpcProvider } from 'web3-providers';
+import IpcProviderDefault, { IpcProvider } from 'web3-providers';
 import { JsonRpcResponse } from 'web3-core-helpers';
 
+// $ExpectType IpcProvider
+const ipc_provider_default = new IpcProviderDefault(
+    '/Users/myuser/Library/Ethereum/geth.ipc',
+    new net.Server()
+);
+
+// $ExpectType IpcProvider
 const ipcProvider = new IpcProvider(
     '/Users/myuser/Library/Ethereum/geth.ipc',
     new net.Server()

--- a/packages/web3-providers-ws/types/index.d.ts
+++ b/packages/web3-providers-ws/types/index.d.ts
@@ -23,3 +23,5 @@
 import { WebsocketProviderBase } from 'web3-core-helpers';
 
 export class WebsocketProvider extends WebsocketProviderBase { }
+
+export default WebsocketProvider

--- a/packages/web3-providers-ws/types/tests/web3-provider-ws-tests.ts
+++ b/packages/web3-providers-ws/types/tests/web3-provider-ws-tests.ts
@@ -21,7 +21,7 @@
  */
 
 import { WebsocketProviderOptions, JsonRpcResponse } from 'web3-core-helpers';
-import { WebsocketProvider } from 'web3-providers';
+import WebsocketProviderDefault, { WebsocketProvider } from 'web3-providers';
 
 const options: WebsocketProviderOptions = {
     timeout: 30000,
@@ -30,6 +30,10 @@ const options: WebsocketProviderOptions = {
     }
 };
 
+// $ExpectType WebsocketProvider
+const ws_provider_default = new WebsocketProviderDefault('ws://localhost:8545', options);
+
+// $ExpectType WebsocketProvider
 const wsProvider = new WebsocketProvider('ws://localhost:8545', options);
 
 // $ExpectType boolean

--- a/packages/web3-shh/types/index.d.ts
+++ b/packages/web3-shh/types/index.d.ts
@@ -197,3 +197,5 @@ export interface Subscribe {
 
     on(type: 'error', handler: (data: Error) => void): void;
 }
+
+export default Shh

--- a/packages/web3-shh/types/tests/shh-test.ts
+++ b/packages/web3-shh/types/tests/shh-test.ts
@@ -17,7 +17,10 @@
  * @date 2018
  */
 
-import { Info, Notification, Shh } from 'web3-shh';
+import ShhDefault, { Info, Notification, Shh } from 'web3-shh';
+
+// $ExpectType Shh
+const shh_default_empty = new ShhDefault();
 
 // $ExpectType Shh
 const shh_empty = new Shh();


### PR DESCRIPTION
## Description
A replacement of the MR https://github.com/web3/web3.js/pull/5852. Original description:

> Some packages export their classes as default, but .d.ts definitions don't have default export. So it is fixed it by adding `export default` to .d.ts files
> This PR only fixes .d.ts and types tests, so it doesn't affect actual code and can't break anything
> 
> Fixes #5543
> 
> ## Type of change
> 
> - [x] Bug fix (non-breaking change which fixes an issue)
> 
> ## Checklist for 1.x:
> 
> - [x] I have selected the correct base branch.
> - [x] I have performed a self-review of my own code.
> - [ ] I have commented my code, particularly in hard-to-understand areas.
> - [ ] I have made corresponding changes to the documentation.
> - [x] My changes generate no new warnings.
> - [ ] Any dependent changes have been merged and published in downstream modules.
> - [x] I ran `npm run dtslint` with success and extended the tests and types if necessary.
> - [x] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
> - [x] I ran `npm run build` with success.
> - [ ] I have tested the built `dist/web3.min.js` in a browser.
> - [ ] I have tested my code on the live network.
> - [ ] I have checked the Deploy Preview and it looks correct.
> - [x] I have updated the `CHANGELOG.md` file in the root folder.
> 

Please, check https://github.com/web3/web3.js/issues/5543#issuecomment-1443428744 for more insights.