### PR TITLE
hotfix (BatchResponseHandler) pass the inner error to the response ca…

### DIFF
--- a/packages/web3-core-requestmanager/src/batch.js
+++ b/packages/web3-core-requestmanager/src/batch.js
@@ -52,7 +52,7 @@ Batch.prototype.execute = function () {
     this.requestManager.sendBatch(requests, function (err, results) {
         results = sortResponses(results);
         requests.map(function (request, index) {
-            return results[index] || {};
+            return results[index] || { error: err };
         }).forEach(function (result, index) {
             if (requests[index].callback) {
                 if (result && result.error) {
@@ -74,7 +74,7 @@ Batch.prototype.execute = function () {
 };
 
 // Sort responses
-Batch.prototype._sortResponses = function (responses) {    
+Batch.prototype._sortResponses = function (responses) {
     return (responses || []).sort((a, b) => a.id - b.id);
 }
 


### PR DESCRIPTION
Hello Team, 

here is the patch-fix to Batch Response Handler - as for now, it **hides** the initial **Error** passed to the callback, and a generic `InvalidResponse` is passed to the outer listener. This is due to the flow:

- when **`err`** is not null - the `results` is null
- `sortResponses` still creates the array with undefined responses for each request
- `map` method creates **Empty Object**  for each result
-  **Empty Object** is not the valid response
- not helpful error is generated `Invalid JSON RPC response: {}` 

Current snippet:

```javascript
this.requestManager.sendBatch(requests, function (err, results) {
        results = sortResponses(results);
        requests.map(function (request, index) {
            return results[index] || { };
        }).forEach(function (result, index) {
            if (requests[index].callback) {
                if (result && result.error) {
                    return requests[index].callback(errors.ErrorResponse(result));
                }

                if (!Jsonrpc.isValidResponse(result)) {
                    return requests[index].callback(errors.InvalidResponse(result));
                }

                try {
                    requests[index].callback(null, requests[index].format ? requests[index].format(result.result) : result.result);
                } catch (err) {
                    requests[index].callback(err);
                }
            }
        });
    });
```

We should add the `error` field to the object, so it can be handled in `ErrorResponse` and passed back to the caller.