### PR TITLE
A fix at `IpcProvider` and few changes at `SocketProvider` and its descendants

### DIFF
--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -71,3 +71,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added named export for `IpcProvider` (#5771)
+-   Pass `_socketOptions` from `IpcProvider` constructor to the underlying `Socket` (#5891)
+-   The getter of `SocketConnection` in `IpcProvider` (inherited from `SocketProvider`) returns `net.Socket` (#5891)

--- a/packages/web3-providers-ipc/src/index.ts
+++ b/packages/web3-providers-ipc/src/index.ts
@@ -35,7 +35,6 @@ export default class IpcProvider<API extends Web3APISpec = EthExecutionAPI> exte
 > {
 	protected readonly _socketOptions?: SocketConstructorOpts;
 
-	// Message handlers. Due to bounding of `this` and removing the listeners we have to keep it's reference.
 	protected _socketConnection?: Socket;
 
 	public getStatus(): Web3ProviderStatus {

--- a/packages/web3-providers-ipc/src/index.ts
+++ b/packages/web3-providers-ipc/src/index.ts
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Socket } from 'net';
+import { Socket, SocketConstructorOpts } from 'net';
 import { ConnectionNotOpenError, InvalidClientError } from 'web3-errors';
 import { SocketProvider } from 'web3-utils';
 import {
@@ -33,6 +33,8 @@ export default class IpcProvider<API extends Web3APISpec = EthExecutionAPI> exte
 	Error,
 	API
 > {
+	protected readonly _socketOptions?: SocketConstructorOpts;
+
 	// Message handlers. Due to bounding of `this` and removing the listeners we have to keep it's reference.
 	protected _socketConnection?: Socket;
 
@@ -42,12 +44,13 @@ export default class IpcProvider<API extends Web3APISpec = EthExecutionAPI> exte
 		}
 		return this._connectionStatus;
 	}
+
 	protected _openSocketConnection() {
 		if (!existsSync(this._socketPath)) {
 			throw new InvalidClientError(this._socketPath);
 		}
 		if (!this._socketConnection || this.getStatus() === 'disconnected') {
-			this._socketConnection = new Socket();
+			this._socketConnection = new Socket(this._socketOptions);
 		}
 
 		this._socketConnection.connect({ path: this._socketPath });

--- a/packages/web3-providers-ipc/test/unit/ipc_provider.test.ts
+++ b/packages/web3-providers-ipc/test/unit/ipc_provider.test.ts
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+import { Socket } from 'net';
 import * as fs from 'fs';
 import { ConnectionError, InvalidClientError } from 'web3-errors';
 import IpcProvider from '../../src/index';
@@ -34,6 +35,7 @@ describe('IpcProvider', () => {
 		it('should construct the instance of the provider', () => {
 			const provider = new IpcProvider(socketPath);
 			expect(provider).toBeInstanceOf(IpcProvider);
+			expect(provider.SocketConnection).toBeInstanceOf(Socket);
 		});
 
 		it('should try to connect', () => {

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -65,3 +65,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added named export for `WebSocketProvider` (#5771)
+-   The getter of `SocketConnection` in `WebSocketProvider` (inherited from `SocketProvider`) returns isomorphic `WebSocket` (#5891)

--- a/packages/web3-providers-ws/src/index.ts
+++ b/packages/web3-providers-ws/src/index.ts
@@ -34,7 +34,7 @@ export { ClientOptions } from 'isomorphic-ws';
 export default class WebSocketProvider<
 	API extends Web3APISpec = EthExecutionAPI,
 > extends SocketProvider<WebSocket.MessageEvent, WebSocket.CloseEvent, WebSocket.ErrorEvent, API> {
-	protected readonly _providerOptions?: ClientOptions | ClientRequestArgs;
+	protected readonly _socketOptions?: ClientOptions | ClientRequestArgs;
 
 	protected _socketConnection?: WebSocket;
 
@@ -64,9 +64,9 @@ export default class WebSocketProvider<
 		this._socketConnection = new WebSocket(
 			this._socketPath,
 			undefined,
-			this._providerOptions && Object.keys(this._providerOptions).length === 0
+			this._socketOptions && Object.keys(this._socketOptions).length === 0
 				? undefined
-				: this._providerOptions,
+				: this._socketOptions,
 		);
 	}
 

--- a/packages/web3-providers-ws/test/unit/web_socket_provider.test.ts
+++ b/packages/web3-providers-ws/test/unit/web_socket_provider.test.ts
@@ -57,6 +57,7 @@ describe('WebSocketProvider', () => {
 			expect(wsProvider.connect).toBeDefined();
 			expect(wsProvider.disconnect).toBeDefined();
 			expect(wsProvider.reset).toBeDefined();
+			expect(wsProvider.SocketConnection).toBeInstanceOf(WebSocket);
 		});
 
 		it('should allow for providerOptions to be passed upon instantiation', () => {

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -87,3 +87,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `compareBlockNumbers` function now only supports comparison of both blocktags params ( except `earliest` vs number) or both block number params (#5842)
 -   `SocketProvider` abstract class now resolves JSON RPC response errors instead of rejecting them (#5844)
+-   Exposes the getter of `SocketConnection` in `SocketProvider` (#5891)

--- a/packages/web3-utils/src/socket_provider.ts
+++ b/packages/web3-utils/src/socket_provider.ts
@@ -89,6 +89,8 @@ export abstract class SocketProvider<
 	public constructor(socketPath: string, socketOptions?: object, reconnectOptions?: object) {
 		super();
 		this._connectionStatus = 'connecting';
+
+		// Message handlers. Due to bounding of `this` and removing the listeners we have to keep it's reference.
 		this._onMessageHandler = this._onMessage.bind(this);
 		this._onOpenHandler = this._onConnect.bind(this);
 		this._onCloseHandler = this._onCloseEvent.bind(this);

--- a/packages/web3-utils/src/socket_provider.ts
+++ b/packages/web3-utils/src/socket_provider.ts
@@ -74,6 +74,9 @@ export abstract class SocketProvider<
 	protected readonly _socketOptions?: object;
 	protected readonly _reconnectOptions: ReconnectOptions;
 	protected _socketConnection?: unknown;
+	public get SocketConnection() {
+		return this._socketConnection;
+	}
 	protected _connectionStatus: Web3ProviderStatus;
 	protected readonly _onMessageHandler: (event: MessageEvent) => void;
 	protected readonly _onOpenHandler: () => void;

--- a/packages/web3-utils/src/socket_provider.ts
+++ b/packages/web3-utils/src/socket_provider.ts
@@ -71,7 +71,7 @@ export abstract class SocketProvider<
 	/* eslint-disable @typescript-eslint/no-explicit-any */
 	protected readonly _sentRequestsQueue: Map<JsonRpcId, SocketRequestItem<any, any, any>>;
 	protected _reconnectAttempts!: number;
-	protected readonly _providerOptions?: object;
+	protected readonly _socketOptions?: object;
 	protected readonly _reconnectOptions: ReconnectOptions;
 	protected _socketConnection?: unknown;
 	protected _connectionStatus: Web3ProviderStatus;
@@ -83,20 +83,21 @@ export abstract class SocketProvider<
 	/**
 	 * This is an abstract class for implementing a socket provider (e.g. WebSocket, IPC). It extends the EIP-1193 provider {@link EIP1193Provider}.
 	 * @param socketPath - The path to the socket (e.g. /ipc/path or ws://localhost:8546)
-	 * @param options - The options for the socket connection
+	 * @param socketOptions - The options for the socket connection
 	 * @param reconnectOptions - The options for the socket reconnection {@link ReconnectOptions}
 	 */
-	public constructor(socketPath: string, options?: object, reconnectOptions?: object) {
+	public constructor(socketPath: string, socketOptions?: object, reconnectOptions?: object) {
 		super();
 		this._connectionStatus = 'connecting';
 		this._onMessageHandler = this._onMessage.bind(this);
 		this._onOpenHandler = this._onConnect.bind(this);
 		this._onCloseHandler = this._onCloseEvent.bind(this);
 		this._onErrorHandler = this._onError.bind(this);
+
 		if (!this._validateProviderPath(socketPath)) throw new InvalidClientError(socketPath);
 
 		this._socketPath = socketPath;
-		this._providerOptions = options;
+		this._socketOptions = socketOptions;
 
 		const DEFAULT_PROVIDER_RECONNECTION_OPTIONS = {
 			autoReconnect: true,

--- a/packages/web3-utils/test/unit/socket_provider.test.ts
+++ b/packages/web3-utils/test/unit/socket_provider.test.ts
@@ -15,13 +15,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import {
-	Web3APIPayload,
-	EthExecutionAPI,
-	JsonRpcResponse,
-	JsonRpcResult,
-	Web3ProviderStatus,
-} from 'web3-types';
+import { Web3APIPayload, EthExecutionAPI, JsonRpcResponse, Web3ProviderStatus } from 'web3-types';
 import { SocketProvider } from '../../src/socket_provider';
 
 const dummySocketConnection = { dummy: 'dummy' };

--- a/packages/web3-utils/test/unit/socket_provider.test.ts
+++ b/packages/web3-utils/test/unit/socket_provider.test.ts
@@ -1,0 +1,72 @@
+﻿/*
+This file is part of web3.js.
+
+web3.js is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+web3.js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import {
+	Web3APIPayload,
+	EthExecutionAPI,
+	JsonRpcResponse,
+	JsonRpcResult,
+	Web3ProviderStatus,
+} from 'web3-types';
+import { SocketProvider } from '../../src/socket_provider';
+
+const dummySocketConnection = { dummy: 'dummy' };
+
+class TestProvider extends SocketProvider<any, any, any> {
+	protected _socketConnection?: typeof dummySocketConnection;
+
+	protected _openSocketConnection() {
+		this._socketConnection = dummySocketConnection;
+	}
+
+	// Dummy implementation of the abstract base methods
+	// eslint-disable-next-line
+	protected _addSocketListeners(): void {}
+	// eslint-disable-next-line
+	protected _removeSocketListeners(): void {}
+	// eslint-disable-next-line
+	protected _onCloseEvent(_event: unknown): void {}
+	// eslint-disable-next-line
+	protected _sendToSocket(_payload: Web3APIPayload<EthExecutionAPI, any>): void {}
+	// eslint-disable-next-line
+	protected _parseResponses(_event: any): JsonRpcResponse[] {
+		return [] as JsonRpcResponse[];
+	}
+	// eslint-disable-next-line
+	protected _closeSocketConnection(
+		_code?: number | undefined,
+		_data?: string | undefined,
+		// eslint-disable-next-line
+	): void {}
+	// eslint-disable-next-line
+	getStatus(): Web3ProviderStatus {
+		return 'connected';
+	}
+}
+
+describe('SocketProvider', () => {
+	const socketPath = `some_path`;
+	const socketOption = { dummyOption: true } as const;
+
+	describe('constructor', () => {
+		it('should construct the instance of the provider', () => {
+			const provider = new TestProvider(socketPath, socketOption);
+			expect(provider).toBeInstanceOf(SocketProvider);
+			expect(provider.SocketConnection).toEqual(dummySocketConnection);
+		});
+	});
+});


### PR DESCRIPTION
## Description

Fixes #5887

- pass `_socketOptions` from `IpcProvider` constructor to the underlying Socket.
- expose the getter of `SocketConnection` from `SocketProvider`.
- rename protected property `_providerOptions` to `_socketOptions`.
- move a comment to its correct position at `SocketConnection`.
- add extremely simple unit test for `SocketProvider`
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist for 1.x:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` with success.
- [ ] I have tested the built `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.

## Checklist for 4.x:

- [ ] I have selected the correct 4.x base branch.
- [ ] Within the description, the feature or issue is discussed in detail or an issue is linked.   
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added any required tests for the changes I made 
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `yarn` successfully
- [ ] I ran `yarn lint` successfully
- [ ] I ran `yarn build:web` successfully
- [ ] I ran `yarn test:unit` successfully
- [ ] I ran `yarn test:integration` successfully
- [ ] I ran `compile:contracts` successfully
- [ ] I have tested my code.
- [ ] I have updated the corresponding `CHANGELOG.md` file in the packages I have edited.
