### PR TITLE
Release/4.0.1 rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1135,7 +1135,7 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Add `TransactionWithFromLocalWalletIndex`, `TransactionWithToLocalWalletIndex` and `TransactionWithFromAndToLocalWalletIndex` types (#5731)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Added
 
@@ -1289,3 +1289,5 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Fix contract defaults (#5756)
 -   Fixed getPastEventsError (#5819)
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1182,10 +1182,13 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-providers-ipc
 
 -   Added named export for `IpcProvider` (#5771)
+-   Pass `_socketOptions` from `IpcProvider` constructor to the underlying `Socket` (#5891)
+-   The getter of `SocketConnection` in `IpcProvider` (inherited from `SocketProvider`) returns `net.Socket` (#5891)
 
 #### web3-providers-ws
 
 -   Added named export for `WebSocketProvider` (#5771)
+-   The getter of `SocketConnection` in `WebSocketProvider` (inherited from `SocketProvider`) returns isomorphic `WebSocket` (#5891)
 
 #### web3-rpc-methods
 
@@ -1215,21 +1218,43 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-errors
 
 -   The abstract class `Web3Error` is renamed to `BaseWeb3Error` (#5771)
--   Renamed `TransactionRevertError` to `TransactionRevertInstructionError` to remain consistent with `1.x` (#5854)
+-   Renamed TransactionRevertError to TransactionRevertInstructionError to remain consistent with 1.x
+-   Using `MaxAttemptsReachedOnReconnectingError` with the same message for 1.x but also adding the `maxAttempts` (#5894)
 
 #### web3-eth
 
 -   Update imports statements for objects that was moved between web3 packages (#5771)
 -   `sendTransaction` and `sendSignedTransaction` now errors with (and `error` event emits) the following possible errors: `TransactionRevertedWithoutReasonError`, `TransactionRevertInstructionError`, `TransactionRevertWithCustomError`, `InvalidResponseError`, or `ContractExecutionError` (#5854)
 
+#### web3-eth-accounts
+
+-   Updated dependencies
+
 #### web3-eth-contract
 
 -   Update imports statements for objects that was moved between web3 packages (#5771)
+
+#### web3-eth-ens
+
+-   Updated dependencies
+
+#### web3-eth-iban
+
+-   Updated dependencies
+
+#### web3-eth-personal
+
+-   Updated dependencies
+
+#### web3-net
+
+-   Updated dependencies
 
 #### web3-utils
 
 -   `compareBlockNumbers` function now only supports comparison of both blocktags params ( except `earliest` vs number) or both block number params (#5842)
 -   `SocketProvider` abstract class now resolves JSON RPC response errors instead of rejecting them (#5844)
+-   Exposes the getter of `SocketConnection` in `SocketProvider` (#5891)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1228,7 +1228,7 @@ should use 4.0.1-alpha.0 for testing.
 
 #### web3-eth-accounts
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 #### web3-eth-contract
 
@@ -1236,19 +1236,19 @@ should use 4.0.1-alpha.0 for testing.
 
 #### web3-eth-ens
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 #### web3-eth-iban
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 #### web3-eth-personal
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 #### web3-net
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 #### web3-utils
 

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -76,9 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Added
 
 -   Added rpc exception codes following eip-1474 as an experimental feature (if `useRpcCallSpecification` at `enableExperimentalFeatures` is `true`) (#5525)
 -   Added support of `safe` and `finalized` block tags (#5823)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -30,14 +30,14 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-eth-iban": "^4.0.1-alpha.5",
-		"web3-providers-http": "^4.0.1-alpha.5",
-		"web3-providers-ipc": "^4.0.1-alpha.5",
-		"web3-providers-ws": "^4.0.1-alpha.5",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-eth-iban": "^4.0.1-rc.0",
+		"web3-providers-http": "^4.0.1-rc.0",
+		"web3-providers-ipc": "^4.0.1-rc.0",
+		"web3-providers-ws": "^4.0.1-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -53,25 +53,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Corrected the error code for `JSONRPC_ERR_UNAUTHORIZED` to be `4100` (#5462)
 -   Moved `SignerError` from `web3-errors/src/errors/signature_errors.ts` to `web3-errors/src/errors/transaction_errors.ts`, and renamed it to `TransactionSigningError` (#5462)
 
-## [4.0.1-alpha.2]
+## [0.1.1-alpha.2]
 
 ### Changed
 
 -   Updated Web3.js dependencies (#5664)
 
-## [4.0.1-alpha.3]
+## [0.1.1-alpha.3]
 
 ### Changed
 
 -   `main` and `files` entries in `package.json` changed to `lib/` directory from `dist/` (#5739)
 
-## [4.0.1-alpha.5]
+## [0.1.1-alpha.4]
 
 ### Changed
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [1.0.0-rc.0]
 
 ### Changed
 
@@ -85,3 +85,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `request` property to `ResponseError` (#5854)
 -   `data` property to `TransactionRevertInstructionError` (#5854)
 -   `TransactionRevertWithCustomError` was added to handle custom solidity errors (#5854)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "0.1.1-alpha.4",
+	"version": "1.0.0-rc.0",
 	"description": "This package has web3 error classes",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -29,7 +29,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^0.1.1-alpha.4"
+		"web3-types": "^1.0.0-rc.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -78,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Removed
 
@@ -87,3 +87,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   `decodeErrorData` from `web3-eth-contract` is now exported from this package and was renamed to `decodeContractErrorData` (#5844)
+
+## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ethereum/web3.js/tree/4.x/packages/web3-eth-abi",
@@ -31,9 +31,9 @@
 	},
 	"dependencies": {
 		"@ethersproject/abi": "^5.6.4",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -65,8 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Changed
 
 -   Updated dependencies
+
+## [Unreleased]

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -69,6 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 ## [Unreleased]

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -66,3 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   web3.js dependencies (#5757)
 
 ## [Unreleased]
+
+### Changed
+
+-   Updated dependencies

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -47,9 +47,9 @@
 	"dependencies": {
 		"@ethereumjs/tx": "^3.5.2",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -214,7 +214,7 @@ const transactionHash = receipt.transactionHash;
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Fixed
 
@@ -234,3 +234,5 @@ const transactionHash = receipt.transactionHash;
 ### Removed
 
 -   `decodeErrorData` is no longer exported (method was moved to `web3-eth-abi` and renamed `decodeContractErrorData`) (#5844)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ethereum/web3.js/tree/4.x/packages/web3-eth-contract",
@@ -33,13 +33,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-eth": "^4.0.1-alpha.5",
-		"web3-eth-abi": "^4.0.1-alpha.5",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-core": "^4.0.1-rc.0",
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-eth": "^4.0.1-rc.0",
+		"web3-eth-abi": "^4.0.1-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -55,6 +55,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.1-alpha.5"
+		"web3-eth-accounts": "^4.0.1-rc.0"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -65,8 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Changed
 
 -   Updated dependencies
+
+## [Unreleased]

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -69,6 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 ## [Unreleased]

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -66,3 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   web3.js dependencies (#5757)
 
 ## [Unreleased]
+
+### Changed
+
+-   Updated dependencies

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -47,12 +47,12 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-eth": "^4.0.1-alpha.5",
-		"web3-eth-contract": "^4.0.1-alpha.5",
-		"web3-net": "^4.0.1-alpha.5",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5"
+		"web3-core": "^4.0.1-rc.0",
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-eth": "^4.0.1-rc.0",
+		"web3-eth-contract": "^4.0.1-rc.0",
+		"web3-net": "^4.0.1-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -59,8 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Changed
 
 -   Updated dependencies
+
+## [Unreleased]

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -60,3 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   web3.js dependencies (#5757)
 
 ## [Unreleased]
+
+### Changed
+
+-   Updated dependencies

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -63,6 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 ## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -44,8 +44,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -79,6 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 ## [Unreleased]

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -76,3 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   web3.js dependencies (#5757)
 
 ## [Unreleased]
+
+### Changed
+
+-   Updated dependencies

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -75,8 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Changed
 
 -   Updated dependencies
+
+## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -30,12 +30,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-eth": "^4.0.1-alpha.5",
-		"web3-rpc-methods": "^0.1.0-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-core": "^4.0.1-rc.0",
+		"web3-eth": "^4.0.1-rc.0",
+		"web3-rpc-methods": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -50,6 +50,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.1-alpha.5"
+		"web3-providers-ws": "^4.0.1-rc.0"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -89,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Enable transaction with local wallet index in the `to` field (#5731)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Changed
 
@@ -105,3 +105,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 -   `getRevertReason` is no longer exported (#5844)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -45,22 +45,22 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.0.1-alpha.5",
-		"web3-providers-http": "^4.0.1-alpha.5"
+		"web3-eth-abi": "^4.0.1-rc.0",
+		"web3-providers-http": "^4.0.1-rc.0"
 	},
 	"dependencies": {
 		"@ethereumjs/common": "^2.6.5",
 		"@ethereumjs/tx": "^3.5.2",
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-eth-abi": "^4.0.1-alpha.5",
-		"web3-eth-accounts": "^4.0.1-alpha.5",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-net": "^4.0.1-alpha.5",
-		"web3-providers-ws": "^4.0.1-alpha.5",
-		"web3-rpc-methods": "^0.1.0-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-core": "^4.0.1-rc.0",
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-eth-abi": "^4.0.1-rc.0",
+		"web3-eth-accounts": "^4.0.1-rc.0",
+		"web3-net": "^4.0.1-rc.0",
+		"web3-providers-ws": "^4.0.1-rc.0",
+		"web3-rpc-methods": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -79,6 +79,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Updated dependencies
+-   Updated dependencies (#5912)
 
 ## [Unreleased]

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -76,3 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   web3.js dependencies (#5757)
 
 ## [Unreleased]
+
+### Changed
+
+-   Updated dependencies

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -75,8 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Changed
 
 -   Updated dependencies
+
+## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -44,9 +44,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-rpc-methods": "^0.1.0-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5"
+		"web3-core": "^4.0.1-rc.0",
+		"web3-rpc-methods": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -59,8 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Added
 
 -   Added named export for `HttpProvider` (#5771)
+
+## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -49,8 +49,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -66,10 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Added
 
 -   Added named export for `IpcProvider` (#5771)
 -   Pass `_socketOptions` from `IpcProvider` constructor to the underlying `Socket` (#5891)
 -   The getter of `SocketConnection` in `IpcProvider` (inherited from `SocketProvider`) returns `net.Socket` (#5891)
+
+## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -44,8 +44,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -60,9 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Added
 
 -   Added named export for `WebSocketProvider` (#5771)
 -   The getter of `SocketConnection` in `WebSocketProvider` (inherited from `SocketProvider`) returns isomorphic `WebSocket` (#5891)
+
+## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -50,9 +50,9 @@
 	},
 	"dependencies": {
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5",
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -59,9 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [1.0.0-rc.0]
 
 ### Added
 
 -   Added `createAccessList` functionality ( #5780 )
 -   Added support of `safe` and `finalized` block tags (#5823)
+
+## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "0.1.0-alpha.4",
+	"version": "1.0.0-rc.0",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -44,8 +44,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-core": "^4.0.1-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -70,10 +70,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add `TransactionWithFromLocalWalletIndex`, `TransactionWithToLocalWalletIndex` and `TransactionWithFromAndToLocalWalletIndex` types (#5731)
 
-## [Unreleased]
+## [1.0.0-rc.0]
 
 ### Added
 
 -   Added types from `web3-eth-abi` and `TypedArray` from (#5771)
 -   Added `TypedArray` from `web3-utils` and `web3-validator` (it was defined twice) (#5771)
 -   Added `safe` and `finalized` block tags in `BlockTags` and `BlockTag` types (#5823)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "0.1.1-alpha.4",
+	"version": "1.0.0-rc.0",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -72,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   web3.js dependencies (#5757)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Removed
 
@@ -88,3 +88,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `compareBlockNumbers` function now only supports comparison of both blocktags params ( except `earliest` vs number) or both block number params (#5842)
 -   `SocketProvider` abstract class now resolves JSON RPC response errors instead of rejecting them (#5844)
 -   Exposes the getter of `SocketConnection` in `SocketProvider` (#5891)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -48,8 +48,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `build` entry from `package.json` (#5755)
 
-## [Unreleased]
+## [1.0.0-rc.0]
 
 ### Removed
 
@@ -78,3 +78,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added support of `safe` and `finalized` block tags in `isBlockTag` method (#5823)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "0.1.1-alpha.5",
+	"version": "1.0.0-rc.0",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -34,8 +34,8 @@
 	"dependencies": {
 		"ajv": "^8.11.0",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-types": "^0.1.1-alpha.4"
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -65,7 +65,7 @@ web3.currentProvider.disconnect();
 
 -   `build` entry from `package.json` (#5755)
 
-## [Unreleased]
+## [4.0.1-rc.0]
 
 ### Added
 
@@ -82,3 +82,5 @@ web3.currentProvider.disconnect();
 ### Removed
 
 -   Private static `_contracts:Contract[]` and static `setProvider` function was removed (#5792)
+
+## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.1-alpha.5",
+	"version": "4.0.1-rc.0",
 	"description": "Ethereum JavaScript API",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
@@ -64,22 +64,22 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-errors": "^0.1.1-alpha.4",
-		"web3-eth": "^4.0.1-alpha.5",
-		"web3-eth-abi": "^4.0.1-alpha.5",
-		"web3-eth-accounts": "^4.0.1-alpha.5",
-		"web3-eth-contract": "^4.0.1-alpha.5",
-		"web3-eth-ens": "^4.0.1-alpha.5",
-		"web3-eth-iban": "^4.0.1-alpha.5",
-		"web3-eth-personal": "^4.0.1-alpha.5",
-		"web3-net": "^4.0.1-alpha.5",
-		"web3-providers-http": "^4.0.1-alpha.5",
-		"web3-providers-ipc": "^4.0.1-alpha.5",
-		"web3-providers-ws": "^4.0.1-alpha.5",
-		"web3-rpc-methods": "^0.1.0-alpha.4",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5",
-		"web3-validator": "^0.1.1-alpha.5"
+		"web3-core": "^4.0.1-rc.0",
+		"web3-errors": "^1.0.0-rc.0",
+		"web3-eth": "^4.0.1-rc.0",
+		"web3-eth-abi": "^4.0.1-rc.0",
+		"web3-eth-accounts": "^4.0.1-rc.0",
+		"web3-eth-contract": "^4.0.1-rc.0",
+		"web3-eth-ens": "^4.0.1-rc.0",
+		"web3-eth-iban": "^4.0.1-rc.0",
+		"web3-eth-personal": "^4.0.1-rc.0",
+		"web3-net": "^4.0.1-rc.0",
+		"web3-providers-http": "^4.0.1-rc.0",
+		"web3-providers-ipc": "^4.0.1-rc.0",
+		"web3-providers-ws": "^4.0.1-rc.0",
+		"web3-rpc-methods": "^1.0.0-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0",
+		"web3-validator": "^1.0.0-rc.0"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-alpha.5' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-rc.0' };

--- a/packages/web3/test/black_box/test/web3-eth-contract/erc20.test.ts
+++ b/packages/web3/test/black_box/test/web3-eth-contract/erc20.test.ts
@@ -66,7 +66,6 @@ describeIf(getSystemTestBackend() === 'geth' || getSystemTestBackend() === 'gana
 				deployedContract = await new web3.eth.Contract(ERC20TokenAbi)
 					.deploy({
 						data: ERC20TokenBytecode,
-						// @ts-expect-error Type 'string' is not assignable to type 'undefined'.
 						arguments: ['420'],
 					})
 					.send({ from: account.address, gas: '10000000' });

--- a/tools/web3-packagetemplate/package.json
+++ b/tools/web3-packagetemplate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-packagetemplate",
-	"version": "1.1.1-alpha.2",
+	"version": "1.1.1-rc.0",
 	"description": "Package template for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -48,4 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5725)
 
+## [1.0.0-rc.0]
+
+### Changed
+
+-   Updated dependencies
+
 ## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -52,10 +52,10 @@
 		"web3-utils": "^4.0.1-rc.0"
 	},
 	"peerDependencies": {
-		"web3-core": ">= 4.0.1-alpha.0 < 5",
-		"web3-eth-abi": ">= 4.0.1-alpha.0 < 5",
-		"web3-eth-contract": ">= 4.0.1-alpha.0 < 5",
-		"web3-types": ">= 0.1.1-alpha.0 < 5",
-		"web3-utils": ">= ^4.0.1-alpha.0 < 5"
+		"web3-core": ">= 4.0.1-rc.0 < 5",
+		"web3-eth-abi": ">= 4.0.1-rc.0 < 5",
+		"web3-eth-contract": ">= 4.0.1-rc.0 < 5",
+		"web3-types": ">= 1.0.0-rc.0 < 5",
+		"web3-utils": ">= ^4.0.1-rc.0 < 5"
 	}
 }

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "0.1.0-alpha.4",
+	"version": "1.0.0-rc.0",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -44,12 +44,12 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.0.1-alpha.5",
-		"web3-core": "^4.0.1-alpha.5",
-		"web3-eth-abi": "^4.0.1-alpha.5",
-		"web3-eth-contract": "^4.0.1-alpha.5",
-		"web3-types": "^0.1.1-alpha.4",
-		"web3-utils": "^4.0.1-alpha.5"
+		"web3": "^4.0.1-rc.0",
+		"web3-core": "^4.0.1-rc.0",
+		"web3-eth-abi": "^4.0.1-rc.0",
+		"web3-eth-contract": "^4.0.1-rc.0",
+		"web3-types": "^1.0.0-rc.0",
+		"web3-utils": "^4.0.1-rc.0"
 	},
 	"peerDependencies": {
 		"web3-core": ">= 4.0.1-alpha.0 < 5",


### PR DESCRIPTION
## [4.0.1-rc.0]

### Added

#### web3

-   `registeredSubscriptions` was added by default in web3 constructor (#5792)
-   Add named exports for all objects which are the default-exported-object in their packages (#5771)
-   Export all packages' objects organized by namespaces (#5771)
-   Add Additional flat exports for all types and constants from `web3-types`, `web3-errors` and `web3`. (#5771)
-   Fix few issues with `new Web3().eth.contract` (#5824)

#### web3-core

-   Added rpc exception codes following eip-1474 as an experimental feature (if `useRpcCallSpecification` at `enableExperimentalFeatures` is `true`) (#5525)
-   Added support of `safe` and `finalized` block tags (#5823)

#### web3-errors

-   Added error class `InvalidMethodParamsError` and error code `ERR_INVALID_METHOD_PARAMS = 207` (#5824)
-   `request` property to `ResponseError` (#5854)
-   `data` property to `TransactionRevertInstructionError` (#5854)
-   `TransactionRevertWithCustomError` was added to handle custom solidity errors (#5854)

#### web3-eth

-   Added `createAccessList` functionality ( #5780 )
-   Added support of `safe` and `finalized` block tags (#5823)
-   `contractAbi` option to `SendTransactionOptions` and `SendSignedTransactionOptions` to added the ability to parse custom solidity errors (#5854)

#### web3-eth-abi

-   `decodeErrorData` from `web3-eth-contract` is now exported from this package and was renamed to `decodeContractErrorData` (#5844)

#### web3-eth-contract

-   Added functionality of `createAccessList` for contracts ( #5780 )
-   An instance of `Contract` will `subscribeToContextEvents` upon instantiation if `syncWithContext` is set to `true` and the constructor is passed an instance of `Web3Context` (#5833)
-   Added support of `safe` and `finalized` block tags (#5823)

#### web3-providers-http

-   Added named export for `HttpProvider` (#5771)

#### web3-providers-ipc

-   Added named export for `IpcProvider` (#5771)
-   Pass `_socketOptions` from `IpcProvider` constructor to the underlying `Socket` (#5891)
-   The getter of `SocketConnection` in `IpcProvider` (inherited from `SocketProvider`) returns `net.Socket` (#5891)

#### web3-providers-ws

-   Added named export for `WebSocketProvider` (#5771)
-   The getter of `SocketConnection` in `WebSocketProvider` (inherited from `SocketProvider`) returns isomorphic `WebSocket` (#5891)

#### web3-rpc-methods

-   Added `createAccessList` functionality ( #5780 )
-   Added support of `safe` and `finalized` block tags (#5823)

#### web3-types

-   Added types from `web3-eth-abi` and `TypedArray` from (#5771)
-   Added `TypedArray` from `web3-utils` and `web3-validator` (it was defined twice) (#5771)
-   Added `safe` and `finalized` block tags in `BlockTags` and `BlockTag` types (#5823)

#### web3-utils

-   Added support of `safe` and `finalized` block tags (#5823)

#### web3-validator

-   Added support of `safe` and `finalized` block tags in `isBlockTag` method (#5823)

### Changed

#### web3

-   `require('web3')` will now return all web3 exported-objects organized in namespaces . (#5771)

#### web3-errors

-   The abstract class `Web3Error` is renamed to `BaseWeb3Error` (#5771)
-   Renamed TransactionRevertError to TransactionRevertInstructionError to remain consistent with 1.x
-   Using `MaxAttemptsReachedOnReconnectingError` with the same message for 1.x but also adding the `maxAttempts` (#5894)

#### web3-eth

-   Update imports statements for objects that was moved between web3 packages (#5771)
-   `sendTransaction` and `sendSignedTransaction` now errors with (and `error` event emits) the following possible errors: `TransactionRevertedWithoutReasonError`, `TransactionRevertInstructionError`, `TransactionRevertWithCustomError`, `InvalidResponseError`, or `ContractExecutionError` (#5854)

#### web3-eth-accounts

-   Updated dependencies

#### web3-eth-contract

-   Update imports statements for objects that was moved between web3 packages (#5771)

#### web3-eth-ens

-   Updated dependencies

#### web3-eth-iban

-   Updated dependencies

#### web3-eth-personal

-   Updated dependencies

#### web3-net

-   Updated dependencies

#### web3-utils

-   `compareBlockNumbers` function now only supports comparison of both blocktags params ( except `earliest` vs number) or both block number params (#5842)
-   `SocketProvider` abstract class now resolves JSON RPC response errors instead of rejecting them (#5844)
-   Exposes the getter of `SocketConnection` in `SocketProvider` (#5891)

### Removed

#### web3

-   Private static `_contracts:Contract[]` and static `setProvider` function was removed (#5792)

#### web3-eth

-   `getRevertReason` is no longer exported (#5844)

#### web3-eth-abi

-   Moved all types and interfaces to `web3-types` (#5771)

#### web3-eth-contract

-   `decodeErrorData` is no longer exported (method was moved to `web3-eth-abi` and renamed `decodeContractErrorData`) (#5844)

#### web3-utils

-   Moved `TypedArray` to `web3-types` (was also duplicated at `web3-validator`) (#5771)
-   Removed support of `genesis` tag in `compareBlockNumbers` function (#5823)

#### web3-validator

-   Moved `TypedArray` to `web3-types` (was also duplicated at `web3-utils`) (#5771)

### Fixed

#### web3-eth-contract

-   Fix contract defaults (#5756)
-   Fixed getPastEventsError (#5819)
