### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Automatically assigns members of the web3.js team to new pending PRs as reviewers
-* @web3/web3-js
+* @avkos @jdevcs @luu-alex @Muhammad-Altabba @nikoulai @spacesailor24


### PR DESCRIPTION
Using `@web3/web3-js` doesn't assign all code owners as reviewers, as was intended by the use of `@web3/web3-js`. Specifying all of usernames will ensure everyone is request as a reviewer for each PR that is made [example](https://github.com/ethereum/ethereum-org-website/blob/e85a13a64a70c9df2f74ecc5f433061b245f387a/.github/CODEOWNERS#L8) of this approach