### PR TITLE
better handle of the revert raison of a call (issue #4454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -662,3 +662,7 @@ Released with 1.0.0-beta.37 code base.
   - Updated dependencies (#5885)
 
 ## [Unreleased]
+
+### Fixed
+
+  - Fixed "Uncaught TypeError" calling a contract function that revert using MetaMask (#4454)

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -653,7 +653,13 @@ Method.prototype.buildCall = function () {
                 if (!err && method.isRevertReasonString(result)){
                     reasonData = result.substring(10);
                 } else if (err && err.data){
-                    reasonData = err.data.substring(10);
+                    // workaround embedded error details got from some providers like MetaMask
+                    if (typeof err.data === 'object') {
+                        reasonData = err.data.data.substring(10);
+                    }
+                    else {
+                        reasonData = err.data.substring(10);
+                    }
                 }
 
                 if (reasonData){

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -655,7 +655,9 @@ Method.prototype.buildCall = function () {
                 } else if (err && err.data){
                     // workaround embedded error details got from some providers like MetaMask
                     if (typeof err.data === 'object') {
-                        reasonData = err.data.data.substring(10);
+                        // Ganache has no `originalError` sub-object unlike others
+                        var originalError = err.data.originalError ?? err.data;
+                        reasonData = originalError.data.substring(10);
                     }
                     else {
                         reasonData = err.data.substring(10);

--- a/test/eth.call.revert.js
+++ b/test/eth.call.revert.js
@@ -26,7 +26,6 @@ describe('call revert', function () {
           }
         });
         provider.injectValidation(function (payload) {
-            console.log("val1");
             assert.equal(payload.jsonrpc, '2.0');
             assert.equal(payload.method, 'eth_call');
             assert.deepEqual(
@@ -68,7 +67,6 @@ describe('call revert', function () {
             }
         });
         provider.injectValidation(function (payload) {
-            console.log("val1");
             assert.equal(payload.jsonrpc, '2.0');
             assert.equal(payload.method, 'eth_call');
             assert.deepEqual(

--- a/test/eth.call.revert.js
+++ b/test/eth.call.revert.js
@@ -1,0 +1,100 @@
+var chai = require('chai');
+var assert = chai.assert;
+var FakeIpcProvider = require('./helpers/FakeIpcProvider');
+var Web3 = require('../packages/web3');
+
+describe('call revert', function () {
+    var provider;
+    var web3;
+
+    beforeEach(function () {
+        provider = new FakeIpcProvider();
+        web3 = new Web3(provider);
+        web3.eth.handleRevert = true;
+    });
+
+    it('Errors with revert reason string through MetaMask', async function() {
+        provider.injectRawError({
+          "code": -32603,
+          "message": "execution reverted: DeadlineExpired",
+          "data": {
+            "originalError": {
+              "code": 3,
+              "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f446561646c696e65457870697265640000000000000000000000000000000000",
+              "message": "execution reverted: DeadlineExpired"
+            }
+          }
+        });
+        provider.injectValidation(function (payload) {
+            console.log("val1");
+            assert.equal(payload.jsonrpc, '2.0');
+            assert.equal(payload.method, 'eth_call');
+            assert.deepEqual(
+                payload.params,
+                [{
+                    to: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+                    data: '0x23455654',
+                    gas: '0xb',
+                    gasPrice: '0xb'
+                }, 'latest']
+            );
+        });
+
+        var options = {
+            to: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+            data: '0x23455654',
+            gas: 11,
+            gasPrice: 11
+        };
+
+        try {
+            await web3.eth.call(options, 'latest');
+            assert.fail('call should have failed!');
+        } catch (error) {
+            assert.equal(error.reason, 'DeadlineExpired');
+        }
+    });
+
+    it('Errors with revert reason string from Ganache through MetaMask', async function() {
+        provider.injectRawError({
+            "code": -32603,
+            "message": "Internal JSON-RPC error.",
+            "data": {
+              "message": "VM Exception while processing transaction: revert ImproperState",
+              "stack": "CallError: VM Exception while processing transaction: revert ImproperState\n    at Blockchain.simulateTransaction (C:\\Users\\nicos\\AppData\\Roaming\\npm\\node_modules\\ganache\\dist\\node\\1.js:2:82786)",
+              "code": -32000,
+              "name": "CallError",
+              "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d496d70726f706572537461746500000000000000000000000000000000000000"
+            }
+        });
+        provider.injectValidation(function (payload) {
+            console.log("val1");
+            assert.equal(payload.jsonrpc, '2.0');
+            assert.equal(payload.method, 'eth_call');
+            assert.deepEqual(
+                payload.params,
+                [{
+                    to: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+                    data: '0x23455654',
+                    gas: '0xb',
+                    gasPrice: '0xb'
+                }, 'latest']
+            );
+        });
+
+        var options = {
+            to: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+            data: '0x23455654',
+            gas: 11,
+            gasPrice: 11
+        };
+
+        try {
+            await web3.eth.call(options, 'latest');
+            assert.fail('call should have failed!');
+        } catch (error) {
+            assert.equal(error.reason, 'ImproperState');
+        }
+    });
+    
+});

--- a/test/helpers/FakeIpcProvider.js
+++ b/test/helpers/FakeIpcProvider.js
@@ -142,6 +142,11 @@ FakeIpcProvider.prototype.injectError = function (error) {
     this.error.push(errorStub);
 };
 
+// to simulate strange behavior of MetaMask
+FakeIpcProvider.prototype.injectRawError = function (error) {
+    this.error.push(error);
+};
+
 FakeIpcProvider.prototype.injectValidation = function (callback) {
     this.validation.push(callback);
 };


### PR DESCRIPTION
## Description

Improvement of `web3-core-method.buildCall.sendTxCallback(err, result)` to manage various object data structures when looking for the revert reason info got from some providers like MetaMask. See [this comment](https://github.com/web3/web3.js/issues/4454#issuecomment-1485953455) to know what err.data looks like in MetaMask.

Fixes #4454. I am aware that this is not realy a bug of web3 and that the problem should be corrected at the source, however as the error generated breaks the promise system (uncaught exception) and that this was well handled until version 1.2.9, I considers that it is necessary to adapt the code to better strengthen the library. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist for 1.x:

- [X] I have selected the correct base branch.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run dtslint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:cov` and my test cases cover all the lines and branches of the added code.
- [X] I ran `npm run build` with success.
- [X] I have tested the built `dist/web3.min.js` in a browser.
- [X] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [X] I have updated the `CHANGELOG.md` file in the root folder.

