### PR TITLE
Format `transaction.type` to hex. Add empty `accessList` is `tx.type === '0x1'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -666,3 +666,8 @@ Released with 1.0.0-beta.37 code base.
 ### Fixed
 
   - Improved the error propagation in `web3-providers-http` package to effectively propagate useful error infomation about failed HTTP connections (#5955)
+
+### Changed
+
+  - `transaction.type` is now formatted to a hex string before being send to provider (#5979)
+  - When sending a transaction, if `transaction.type === '0x1' && transaction.accessList === []`, then `transaction.accessList` is set to `[]` (#5979)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -670,4 +670,4 @@ Released with 1.0.0-beta.37 code base.
 ### Changed
 
   - `transaction.type` is now formatted to a hex string before being send to provider (#5979)
-  - When sending a transaction, if `transaction.type === '0x1' && transaction.accessList === []`, then `transaction.accessList` is set to `[]` (#5979)
+  - When sending a transaction, if `transaction.type === '0x1' && transaction.accessList === undefined`, then `transaction.accessList` is set to `[]` (#5979)

--- a/packages/web3-core-helpers/src/formatters.js
+++ b/packages/web3-core-helpers/src/formatters.js
@@ -162,7 +162,7 @@ var _txInputFormatter = function (options) {
         delete options.gasPrice;
     }
 
-    ['gasPrice', 'gas', 'value', 'maxPriorityFeePerGas', 'maxFeePerGas', 'nonce'].filter(function (key) {
+    ['gasPrice', 'gas', 'value', 'maxPriorityFeePerGas', 'maxFeePerGas', 'nonce', 'type'].filter(function (key) {
         return options[key] !== undefined;
     }).forEach(function (key) {
         options[key] = utils.numberToHex(options[key]);

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -799,14 +799,13 @@ Method.prototype.buildCall = function () {
             && !!payload.params[0]
             && typeof payload.params[0] === 'object';
 
-        if (hasSendTxObject) {
-            if (
+        if (hasSendTxObject &&
                 payload.params[0].type === '0x1'
-                &&typeof payload.params[0].accessList === 'undefined'
+                && typeof payload.params[0].accessList === 'undefined'
             ) {
                 payload.params[0].accessList = [];
             }
-        }
+      
 
         // Send the actual transaction
         if (hasSendTxObject

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -795,10 +795,21 @@ Method.prototype.buildCall = function () {
             return method.requestManager.send(payload, sendTxCallback);
         };
 
-        // Send the actual transaction
-        if (isSendTx
+        const hasSendTxObject = isSendTx
             && !!payload.params[0]
-            && typeof payload.params[0] === 'object'
+            && typeof payload.params[0] === 'object';
+
+        if (hasSendTxObject) {
+            if (
+                payload.params[0].type === '0x1'
+                &&typeof payload.params[0].accessList === 'undefined'
+            ) {
+                payload.params[0].accessList = [];
+            }
+        }
+
+        // Send the actual transaction
+        if (hasSendTxObject
             && (
                 typeof payload.params[0].gasPrice === 'undefined'
                 && (

--- a/test/e2e.method.send.js
+++ b/test/e2e.method.send.js
@@ -39,6 +39,27 @@ describe('method.send [ @E2E ]', function () {
             assert(web3.utils.isHexStrict(receipt.transactionHash));
         });
 
+        it('should yield 0x1 for type and add accessList property', async function() {
+            // ganache does not support eth_signTransaction
+            if (process.env.GANACHE || global.window ) return
+
+            var nonceVal = await web3.eth.getTransactionCount(accounts[0]);
+            var receipt = await web3.eth.sendTransaction({
+                to: accounts[1],
+                from: accounts[0],
+                nonce: nonceVal,
+                value: web3.utils.toHex(web3.utils.toWei('0.1', 'ether')),
+                gas: web3.utils.toHex(21000),
+                type: 1
+            });
+
+            assert(receipt.status === true);
+            assert(receipt.type === '0x1');
+            
+            var fetchedTransaction = await web3.eth.getTransaction(receipt.transactionHash);
+            assert(fetchedTransaction.accessList.length === 0);
+        });
+
         it('returns a receipt (EIP-1559, maxFeePerGas and maxPriorityFeePerGas specified)', async function () {
             // ganache does not support eth_signTransaction
             if (process.env.GANACHE || global.window ) return

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -36,6 +36,119 @@ var tests = [{
     },
     call: 'eth_'+ method
 },
+// test type
+{
+    args: [{
+        from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        value: '1234567654321',
+        gasPrice: '324234234234',
+        type: 10
+    }],
+    formattedArgs: [{
+        from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        to: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        value: "0x11f71f76bb1",
+        gasPrice: "0x4b7dddc97a",
+        type: '0xa'
+    }],
+    result: '0x1234567',
+    formattedResult: '0x1234567',
+    notification: {
+        method: 'eth_subscription',
+        params: {
+            subscription: '0x1234567',
+            result: {
+                blockNumber: '0x10'
+            }
+        }
+    },
+    call: 'eth_'+ method
+},
+{
+    args: [{
+        from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        value: '1234567654321',
+        gasPrice: '324234234234',
+        type: '10'
+    }],
+    formattedArgs: [{
+        from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        to: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        value: "0x11f71f76bb1",
+        gasPrice: "0x4b7dddc97a",
+        type: '0xa'
+    }],
+    result: '0x1234567',
+    formattedResult: '0x1234567',
+    notification: {
+        method: 'eth_subscription',
+        params: {
+            subscription: '0x1234567',
+            result: {
+                blockNumber: '0x10'
+            }
+        }
+    },
+    call: 'eth_'+ method
+},
+{
+    args: [{
+        from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        value: '1234567654321',
+        gasPrice: '324234234234',
+        type: 0x10
+    }],
+    formattedArgs: [{
+        from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        to: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        value: "0x11f71f76bb1",
+        gasPrice: "0x4b7dddc97a",
+        type: '0x10'
+    }],
+    result: '0x1234567',
+    formattedResult: '0x1234567',
+    notification: {
+        method: 'eth_subscription',
+        params: {
+            subscription: '0x1234567',
+            result: {
+                blockNumber: '0x10'
+            }
+        }
+    },
+    call: 'eth_'+ method
+},
+{
+    args: [{
+        from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        value: '1234567654321',
+        gasPrice: '324234234234',
+        type: 1
+    }],
+    formattedArgs: [{
+        from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        to: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        value: "0x11f71f76bb1",
+        gasPrice: "0x4b7dddc97a",
+        type: '0x1'
+    }],
+    result: '0x1234567',
+    formattedResult: '0x1234567',
+    notification: {
+        method: 'eth_subscription',
+        params: {
+            subscription: '0x1234567',
+            result: {
+                blockNumber: '0x10'
+            }
+        }
+    },
+    call: 'eth_'+ method
+},
 // test with gasPrice missing
 {
     args: [{

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -43,6 +43,7 @@ var tests = [{
         to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
         value: '1234567654321',
         gasPrice: '324234234234',
+        // Testing 10 is formatted to '0xa'
         type: 10
     }],
     formattedArgs: [{
@@ -71,6 +72,7 @@ var tests = [{
         to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
         value: '1234567654321',
         gasPrice: '324234234234',
+        // Testing '10' is formatted to '0xa'
         type: '10'
     }],
     formattedArgs: [{
@@ -99,6 +101,7 @@ var tests = [{
         to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
         value: '1234567654321',
         gasPrice: '324234234234',
+        // Testing 0x10 is formatted to '0x10'
         type: 0x10
     }],
     formattedArgs: [{
@@ -127,6 +130,7 @@ var tests = [{
         to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
         value: '1234567654321',
         gasPrice: '324234234234',
+        // Testing 1 is formatted to '0x1'
         type: 1
     }],
     formattedArgs: [{
@@ -135,6 +139,35 @@ var tests = [{
         value: "0x11f71f76bb1",
         gasPrice: "0x4b7dddc97a",
         type: '0x1'
+    }],
+    result: '0x1234567',
+    formattedResult: '0x1234567',
+    notification: {
+        method: 'eth_subscription',
+        params: {
+            subscription: '0x1234567',
+            result: {
+                blockNumber: '0x10'
+            }
+        }
+    },
+    call: 'eth_'+ method
+},
+{
+    args: [{
+        from: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        to: '0xdbdbdB2cBD23b783741e8d7fcF51e459b497e4a6', // checksum address
+        value: '1234567654321',
+        gasPrice: '324234234234',
+        // Testing "0xc0" is formatted to '0xc0'
+        type: "0xc0"
+    }],
+    formattedArgs: [{
+        from: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        to: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
+        value: "0x11f71f76bb1",
+        gasPrice: "0x4b7dddc97a",
+        type: '0xc0'
     }],
     result: '0x1234567',
     formattedResult: '0x1234567',

--- a/test/eth.sendTransaction.js
+++ b/test/eth.sendTransaction.js
@@ -138,7 +138,8 @@ var tests = [{
         to: "0xdbdbdb2cbd23b783741e8d7fcf51e459b497e4a6",
         value: "0x11f71f76bb1",
         gasPrice: "0x4b7dddc97a",
-        type: '0x1'
+        type: '0x1',
+        accessList: []
     }],
     result: '0x1234567',
     formattedResult: '0x1234567',

--- a/test/formatters.inputTransactionFormatter.js
+++ b/test/formatters.inputTransactionFormatter.js
@@ -150,6 +150,78 @@ var tests = [{
         gas: '0x3e8',
         maxPriorityFeePerGas: '0x3e8',
         maxFeePerGas: '0x3e8'
+    },
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: new bn(1000),
+        maxFeePerGas: new bn(1000),
+        type: 10
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8',
+        type: '0xa'
+    },
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: new bn(1000),
+        maxFeePerGas: new bn(1000),
+        type: '10'
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8',
+        type: '0xa'
+    },
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: new bn(1000),
+        maxFeePerGas: new bn(1000),
+        type: 0x10
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8',
+        type: '0x10'
+    },
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: new bn(1000),
+        maxFeePerGas: new bn(1000),
+        type: 1
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8',
+        type: '0x1'
     }
 }];
 

--- a/test/formatters.inputTransactionFormatter.js
+++ b/test/formatters.inputTransactionFormatter.js
@@ -212,6 +212,24 @@ var tests = [{
         gas: '0x3e8',
         maxPriorityFeePerGas: new bn(1000),
         maxFeePerGas: new bn(1000),
+        type: "0xc0"
+    },
+    result: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: '0x3e8',
+        maxFeePerGas: '0x3e8',
+        type: '0xc0'
+    },
+    input: {
+        data: '0x34234bf23bf4234',
+        value: '0x64',
+        from: '0x00c5496aee77c1ba1f0854206a26dda82a81d6d8',
+        gas: '0x3e8',
+        maxPriorityFeePerGas: new bn(1000),
+        maxFeePerGas: new bn(1000),
         type: 1
     },
     result: {


### PR DESCRIPTION
- `transaction.type` is now formatted to a hex string before being sent to provider
- When sending a transaction, if `transaction.type === '0x1' && transaction.accessList === 'undefined'`, then `transaction.accessList` is set to `[]`

Added test cases for Steps to Reproduce examples from [here](https://github.com/web3/web3.js/issues/4597#issue-1070998729). With these changes everything is formatted as expected, however, we do not throw an error for `tx.type` exceededing bounds of `0x0` to `0x7f`

closes #4597