### PR TITLE
Release/4.0.1 rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1294,9 +1294,17 @@ should use 4.0.1-alpha.0 for testing.
 
 ### Changed
 
+#### web3
+
+-   No need for polyfilling nodejs `net` and `fs` modules (#5978)
+-   Removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself (#5978)
+
 #### web3-core
 
 -   If a transaction object with a `data` property is passed to `txInputOptionsFormatter`, it will now be replaced with `input` (#5915)
+-   The types `TransactionTypeParser` and `TransactionBuilder` are now utilizing the type `Transaction` for the transaction object. (#5993)
+-   No need for polyfilling nodejs `net` and `fs` modules (#5978)
+-   Removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself (#5978)
 
 #### web3-errors
 
@@ -1307,19 +1315,29 @@ should use 4.0.1-alpha.0 for testing.
 -   `signTransaction` will now return `gas` instead of `gasLimit` for returned transaction object regardless of what property name the provider uses (#5915)
 -   `formatTransaction` will now replace `data` transaction property with `input` (#5915)
 -   `isTransactionCall` will now check if `value.input` `isHexStrict` if provided (#5915)
+-   The functions `defaultTransactionBuilder` and `transactionBuilder` are now utilizing the type `Transaction` for the transaction object. (#5993)
 
 #### web3-eth-accounts
 
 -   Moved @ethereumjs/tx, @ethereumjs/common code to our source code (#5963)
+-   The method `signTransaction` returned by `privateKeyToAccount` is now accepting the type `Transaction` for its argument. (#5993)
 
 #### web3-eth-contract
 
 -   `getSendTxParams` will now return `input` instead of `data` in returned transaction parameters object (#5915)
 -   `Contract` constructor will now thrown new `ContractTransactionDataAndInputError` if both `data` and `input` are passed in `ContractInitOptions` for `Contract` constructor (#5915)
+-   The types `ContractInitOptions`, `NonPayableCallOptions` and `PayableCallOptions` are moved to `web3-types`. (#5993)
 
 #### web3-types
 
 -   `data` property in `TransactionOutput` was renamed to `input` (#5915)
+-   The method `signTransaction` inside `Web3BaseWalletAccount` is now utilizing the type `Transaction` for its argument. (#5993)
+-   The types `FMT_NUMBER`, `NumberTypes`, `FMT_BYTES`, `ByteTypes`, `DataFormat`, `DEFAULT_RETURN_FORMAT`, `ETH_DATA_FORMAT` and `FormatType` moved from `web3-utils`. (#5993)
+-   The types `ContractInitOptions`, `NonPayableCallOptions` and `PayableCallOptions` are moved from `web3-eth-contract`. (#5993)
+
+#### web3-utils
+
+-   The types `FMT_NUMBER`, `NumberTypes`, `FMT_BYTES`, `ByteTypes`, `DataFormat`, `DEFAULT_RETURN_FORMAT`, `ETH_DATA_FORMAT` and `FormatType` moved to `web3-types`. (#5993)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1290,7 +1290,7 @@ should use 4.0.1-alpha.0 for testing.
 -   Fix contract defaults (#5756)
 -   Fixed getPastEventsError (#5819)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Changed
 
@@ -1459,3 +1459,5 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-eth-ens
 
 -   Bug fix of `checkNetwork` in ENS (#5988)
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -83,11 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added rpc exception codes following eip-1474 as an experimental feature (if `useRpcCallSpecification` at `enableExperimentalFeatures` is `true`) (#5525)
 -   Added support of `safe` and `finalized` block tags (#5823)
 
-## [Unreleased]
-
-### Breaking Changes
-
--   removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -98,8 +94,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   If a transaction object with a `data` property is passed to `txInputOptionsFormatter`, it will now be replaced with `input` (#5915)
 -   The types `TransactionTypeParser` and `TransactionBuilder` are now utilizing the type `Transaction` for the transaction object. (#5993)
--   no need for polyfilling nodejs `net` and `fs` modules
+-   No need for polyfilling nodejs `net` and `fs` modules (#5978)
+-   Removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself (#5978)
 
 ### Removed
 
 -   `getConfig` method from `Web3Config` class, `config` is now public and accessible using `Web3Config.config` (#5950)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,16 +42,16 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-eth-iban": "^4.0.1-rc.0",
-		"web3-providers-http": "^4.0.1-rc.0",
-		"web3-providers-ws": "^4.0.1-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-eth-iban": "^4.0.1-rc.1",
+		"web3-providers-http": "^4.0.1-rc.1",
+		"web3-providers-ws": "^4.0.1-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	},
 	"optionalDependencies": {
-		"web3-providers-ipc": "^4.0.1-rc.0"
+		"web3-providers-ipc": "^4.0.1-rc.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `data` property to `TransactionRevertInstructionError` (#5854)
 -   `TransactionRevertWithCustomError` was added to handle custom solidity errors (#5854)
 
-## [Unreleased]
+## [1.0.0-rc.1]
 
 ### Added
 
@@ -96,3 +96,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   `gasLimit` is no longer accepted as a parameter for `MissingGasError` and `TransactionGasMismatchError, and is also no longer included in error message (#5915)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.0.0-rc.0",
+	"version": "1.0.0-rc.1",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.0.0-rc.0"
+		"web3-types": "^1.0.0-rc.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `decodeErrorData` from `web3-eth-contract` is now exported from this package and was renamed to `decodeContractErrorData` (#5844)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -98,3 +98,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 -   Removed `formatDecodedObject` function (#5934)
+
+## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -44,9 +44,9 @@
 	"dependencies": {
 		"@ethersproject/abi": "^5.7.0",
 		"@ethersproject/bignumber": "^5.7.0",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5912)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -82,3 +82,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Moved @ethereumjs/tx, @ethereumjs/common code to our source code (#5963)
 -   The method `signTransaction` returned by `privateKeyToAccount` is now accepting the type `Transaction` for its argument. (#5993)
+
+## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,7 +42,6 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"devDependencies": {
-		"web3-providers-ipc": "^4.0.1-rc.0",
 		"@types/jest": "^28.1.6",
 		"@typescript-eslint/eslint-plugin": "^5.30.7",
 		"@typescript-eslint/parser": "^5.30.7",
@@ -55,15 +54,16 @@
 		"jest-when": "^3.5.1",
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
-		"typescript": "^4.7.4"
+		"typescript": "^4.7.4",
+		"web3-providers-ipc": "^4.0.1-rc.1"
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -235,7 +235,7 @@ const transactionHash = receipt.transactionHash;
 
 -   `decodeErrorData` is no longer exported (method was moved to `web3-eth-abi` and renamed `decodeContractErrorData`) (#5844)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -252,3 +252,5 @@ const transactionHash = receipt.transactionHash;
 ### Removed
 
 -   `data` was removed as a property of `ContractOptions` type (#5915)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.0",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-eth": "^4.0.1-rc.0",
-		"web3-eth-abi": "^4.0.1-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-core": "^4.0.1-rc.1",
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-eth": "^4.0.1-rc.1",
+		"web3-eth-abi": "^4.0.1-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -67,6 +67,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.1-rc.0"
+		"web3-eth-accounts": "^4.0.1-rc.1"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5912)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -81,3 +81,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Bug fix of `checkNetwork` in ENS (#5988)
+
+## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.0.1-rc.0",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-eth": "^4.0.1-rc.0",
-		"web3-eth-contract": "^4.0.1-rc.0",
-		"web3-net": "^4.0.1-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "1.0.0-rc.0"
+		"web3-core": "^4.0.1-rc.1",
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-eth": "^4.0.1-rc.1",
+		"web3-eth-contract": "^4.0.1-rc.1",
+		"web3-net": "^4.0.1-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -65,9 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5912)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "1.0.0-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -81,9 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5912)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,12 +42,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.0",
-		"web3-eth": "^4.0.1-rc.0",
-		"web3-rpc-methods": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-core": "^4.0.1-rc.1",
+		"web3-eth": "^4.0.1-rc.1",
+		"web3-rpc-methods": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -62,6 +62,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.1-rc.0"
+		"web3-providers-ws": "^4.0.1-rc.1"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -106,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `getRevertReason` is no longer exported (#5844)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -120,10 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `isTransactionCall` will now check if `value.input` `isHexStrict` if provided (#5915)
 -   The functions `defaultTransactionBuilder` and `transactionBuilder` are now utilizing the type `Transaction` for the transaction object. (#5993)
 
-### Added
-
--   Added source files (#5956)
-
 ### Removed
 
 -   Removed dependencies @ethereumjs/tx, @ethereumjs/common (#5963)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -57,20 +57,20 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.0.1-rc.0",
-		"web3-providers-http": "^4.0.1-rc.0"
+		"web3-eth-abi": "^4.0.1-rc.1",
+		"web3-providers-http": "^4.0.1-rc.1"
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.0.1-rc.0",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-eth-abi": "^4.0.1-rc.0",
-		"web3-eth-accounts": "^4.0.1-rc.0",
-		"web3-net": "^4.0.1-rc.0",
-		"web3-providers-ws": "^4.0.1-rc.0",
-		"web3-rpc-methods": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-core": "^4.0.1-rc.1",
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-eth-abi": "^4.0.1-rc.1",
+		"web3-eth-accounts": "^4.0.1-rc.1",
+		"web3-net": "^4.0.1-rc.1",
+		"web3-providers-ws": "^4.0.1-rc.1",
+		"web3-rpc-methods": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -81,9 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies (#5912)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.0",
-		"web3-rpc-methods": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0"
+		"web3-core": "^4.0.1-rc.1",
+		"web3-rpc-methods": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -65,9 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added named export for `HttpProvider` (#5771)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,8 +61,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -75,9 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Pass `_socketOptions` from `IpcProvider` constructor to the underlying `Socket` (#5891)
 -   The getter of `SocketConnection` in `IpcProvider` (inherited from `SocketProvider`) returns `net.Socket` (#5891)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -68,9 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added named export for `WebSocketProvider` (#5771)
 -   The getter of `SocketConnection` in `WebSocketProvider` (inherited from `SocketProvider`) returns isomorphic `WebSocket` (#5891)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
 	},
 	"dependencies": {
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -66,9 +66,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `createAccessList` functionality ( #5780 )
 -   Added support of `safe` and `finalized` block tags (#5823)
 
-## [Unreleased]
+## [1.0.0-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.0.0-rc.0",
+	"version": "1.0.0-rc.1",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-core": "^4.0.1-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -78,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added `TypedArray` from `web3-utils` and `web3-validator` (it was defined twice) (#5771)
 -   Added `safe` and `finalized` block tags in `BlockTags` and `BlockTag` types (#5823)
 
-## [Unreleased]
+## [1.0.0-rc.1]
 
 ### Added
 
@@ -91,3 +91,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   The method `signTransaction` inside `Web3BaseWalletAccount` is now utilizing the type `Transaction` for its argument. (#5993)
 -   The types `FMT_NUMBER`, `NumberTypes`, `FMT_BYTES`, `ByteTypes`, `DataFormat`, `DEFAULT_RETURN_FORMAT`, `ETH_DATA_FORMAT` and `FormatType` moved from `web3-utils`. (#5993)
 -   The types `ContractInitOptions`, `NonPayableCallOptions` and `PayableCallOptions` are moved from `web3-eth-contract`. (#5993)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.0.0-rc.0",
+	"version": "1.0.0-rc.1",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -89,7 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `SocketProvider` abstract class now resolves JSON RPC response errors instead of rejecting them (#5844)
 -   Exposes the getter of `SocketConnection` in `SocketProvider` (#5891)
 
-## [Unreleased]
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -103,3 +103,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 -   Removed dependencies @ethereumjs/tx, @ethereumjs/common (#5963)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -60,8 +60,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -79,10 +79,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Added support of `safe` and `finalized` block tags in `isBlockTag` method (#5823)
 
-## [Unreleased]
+## [1.0.0-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 -   Added functions `isHexString`, `isHexPrefixed`, `validateNoLeadingZeroes` (#5963)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "1.0.0-rc.0",
+	"version": "1.0.0-rc.1",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -46,8 +46,8 @@
 	"dependencies": {
 		"ajv": "^8.11.0",
 		"ethereum-cryptography": "^1.1.2",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0"
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -83,11 +83,7 @@ web3.currentProvider.disconnect();
 
 -   Private static `_contracts:Contract[]` and static `setProvider` function was removed (#5792)
 
-## [Unreleased]
-
-### Breaking Changes
-
--   removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself
+## [4.0.1-rc.1]
 
 ### Added
 
@@ -96,4 +92,7 @@ web3.currentProvider.disconnect();
 
 ### Changed
 
--   no need for polyfilling nodejs `net` and `fs` modules
+-   No need for polyfilling nodejs `net` and `fs` modules (#5978)
+-   Removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself (#5978)
+
+## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.1-rc.0",
+	"version": "4.0.1-rc.1",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -58,7 +58,6 @@
 		"test:blackbox:infura:ws": "./scripts/black_box_test.sh infura ws"
 	},
 	"devDependencies": {
-		"web3-providers-ipc": "^4.0.1-rc.0",
 		"@truffle/hdwallet-provider": "^2.0.12",
 		"@types/jest": "^28.1.6",
 		"@typescript-eslint/eslint-plugin": "^5.30.7",
@@ -74,24 +73,25 @@
 		"jest-extended": "^3.0.1",
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
-		"typescript": "^4.7.4"
+		"typescript": "^4.7.4",
+		"web3-providers-ipc": "^4.0.1-rc.1"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.0",
-		"web3-errors": "^1.0.0-rc.0",
-		"web3-eth": "^4.0.1-rc.0",
-		"web3-eth-abi": "^4.0.1-rc.0",
-		"web3-eth-accounts": "^4.0.1-rc.0",
-		"web3-eth-contract": "^4.0.1-rc.0",
-		"web3-eth-ens": "^4.0.1-rc.0",
-		"web3-eth-iban": "^4.0.1-rc.0",
-		"web3-eth-personal": "^4.0.1-rc.0",
-		"web3-net": "^4.0.1-rc.0",
-		"web3-providers-http": "^4.0.1-rc.0",
-		"web3-providers-ws": "^4.0.1-rc.0",
-		"web3-rpc-methods": "^1.0.0-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0",
-		"web3-validator": "^1.0.0-rc.0"
+		"web3-core": "^4.0.1-rc.1",
+		"web3-errors": "^1.0.0-rc.1",
+		"web3-eth": "^4.0.1-rc.1",
+		"web3-eth-abi": "^4.0.1-rc.1",
+		"web3-eth-accounts": "^4.0.1-rc.1",
+		"web3-eth-contract": "^4.0.1-rc.1",
+		"web3-eth-ens": "^4.0.1-rc.1",
+		"web3-eth-iban": "^4.0.1-rc.1",
+		"web3-eth-personal": "^4.0.1-rc.1",
+		"web3-net": "^4.0.1-rc.1",
+		"web3-providers-http": "^4.0.1-rc.1",
+		"web3-providers-ws": "^4.0.1-rc.1",
+		"web3-rpc-methods": "^1.0.0-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1",
+		"web3-validator": "^1.0.0-rc.1"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-rc.0' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-rc.1' };

--- a/tools/web3-packagetemplate/CHANGELOG.md
+++ b/tools/web3-packagetemplate/CHANGELOG.md
@@ -35,9 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [Unreleased]
+## [1.1.1-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
+
+## [Unreleased]

--- a/tools/web3-packagetemplate/package.json
+++ b/tools/web3-packagetemplate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-packagetemplate",
-	"version": "1.1.1-rc.0",
+	"version": "1.1.1-rc.1",
 	"description": "Package template for Web3 4.x.x",
 	"main": "lib/index.js",
 	"repository": "https://github.com/ChainSafe/web3.js",

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -54,8 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Updated dependencies
 
-## [Unreleased]
+## [1.0.0-rc.1]
 
 ### Added
 
 -   Added source files (#5956)
+
+## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.0.0-rc.0",
+	"version": "1.0.0-rc.1",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,18 +45,18 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.0.1-rc.0",
-		"web3-core": "^4.0.1-rc.0",
-		"web3-eth-abi": "^4.0.1-rc.0",
-		"web3-eth-contract": "^4.0.1-rc.0",
-		"web3-types": "^1.0.0-rc.0",
-		"web3-utils": "^4.0.1-rc.0"
+		"web3": "^4.0.1-rc.1",
+		"web3-core": "^4.0.1-rc.1",
+		"web3-eth-abi": "^4.0.1-rc.1",
+		"web3-eth-contract": "^4.0.1-rc.1",
+		"web3-types": "^1.0.0-rc.1",
+		"web3-utils": "^4.0.1-rc.1"
 	},
 	"peerDependencies": {
-		"web3-core": ">= 4.0.1-rc.0 < 5",
-		"web3-eth-abi": ">= 4.0.1-rc.0 < 5",
-		"web3-eth-contract": ">= 4.0.1-rc.0 < 5",
-		"web3-types": ">= 1.0.0-rc.0 < 5",
-		"web3-utils": ">= ^4.0.1-rc.0 < 5"
+		"web3-core": ">= 4.0.1-rc.1 < 5",
+		"web3-eth-abi": ">= 4.0.1-rc.1 < 5",
+		"web3-eth-contract": ">= 4.0.1-rc.1 < 5",
+		"web3-types": ">= 1.0.0-rc.1 < 5",
+		"web3-utils": ">= ^4.0.1-rc.1 < 5"
 	}
 }


### PR DESCRIPTION
### Changed

#### web3

-   No need for polyfilling nodejs `net` and `fs` modules (#5978)
-   Removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself (#5978)

#### web3-core

-   If a transaction object with a `data` property is passed to `txInputOptionsFormatter`, it will now be replaced with `input` (#5915)
-   The types `TransactionTypeParser` and `TransactionBuilder` are now utilizing the type `Transaction` for the transaction object. (#5993)
-   No need for polyfilling nodejs `net` and `fs` modules (#5978)
-   Removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself (#5978)

#### web3-errors

-   `gasLimit` is no longer accepted as a parameter for `MissingGasError` and `TransactionGasMismatchError, and is also no longer included in error message (#5915)

#### web3-eth

-   `signTransaction` will now return `gas` instead of `gasLimit` for returned transaction object regardless of what property name the provider uses (#5915)
-   `formatTransaction` will now replace `data` transaction property with `input` (#5915)
-   `isTransactionCall` will now check if `value.input` `isHexStrict` if provided (#5915)
-   The functions `defaultTransactionBuilder` and `transactionBuilder` are now utilizing the type `Transaction` for the transaction object. (#5993)

#### web3-eth-accounts

-   Moved @ethereumjs/tx, @ethereumjs/common code to our source code (#5963)
-   The method `signTransaction` returned by `privateKeyToAccount` is now accepting the type `Transaction` for its argument. (#5993)

#### web3-eth-contract

-   `getSendTxParams` will now return `input` instead of `data` in returned transaction parameters object (#5915)
-   `Contract` constructor will now thrown new `ContractTransactionDataAndInputError` if both `data` and `input` are passed in `ContractInitOptions` for `Contract` constructor (#5915)
-   The types `ContractInitOptions`, `NonPayableCallOptions` and `PayableCallOptions` are moved to `web3-types`. (#5993)

#### web3-types

-   `data` property in `TransactionOutput` was renamed to `input` (#5915)
-   The method `signTransaction` inside `Web3BaseWalletAccount` is now utilizing the type `Transaction` for its argument. (#5993)
-   The types `FMT_NUMBER`, `NumberTypes`, `FMT_BYTES`, `ByteTypes`, `DataFormat`, `DEFAULT_RETURN_FORMAT`, `ETH_DATA_FORMAT` and `FormatType` moved from `web3-utils`. (#5993)
-   The types `ContractInitOptions`, `NonPayableCallOptions` and `PayableCallOptions` are moved from `web3-eth-contract`. (#5993)

#### web3-utils

-   The types `FMT_NUMBER`, `NumberTypes`, `FMT_BYTES`, `ByteTypes`, `DataFormat`, `DEFAULT_RETURN_FORMAT`, `ETH_DATA_FORMAT` and `FormatType` moved to `web3-types`. (#5993)

### Added

#### web3

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-core

-   Added hybrid build (ESM and CJS) of library (#5904)
-   Added source files (#5956)

#### web3-errors

-   Added hybrid build (ESM and CJS) of library (#5904)
-   Added source files (#5956)

#### web3-eth

-   Added source files (#5956)

#### web3-eth-abi

-   Added hybrid build (ESM and CJS) of library (#5904)
-   Added source files (#5956)

#### web3-eth-accounts

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-eth-contract

-   `input` is now an acceptable property for `ContractInitOptions` in place of `data` (either can be used, but `input` is used withing the `Contract` class) (#5915)
-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-eth-ens

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-eth-iban

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-eth-personal

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-net

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-providers-http

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-providers-ipc

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-providers-ws

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-rpc-methods

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-types

-   Added hybrid build (ESM and CJS) of library (#5904)
-   Added source files (#5956)

#### web3-utils

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)

#### web3-validator

-   Added source files (#5956)
-   Added hybrid build (ESM and CJS) of library (#5904)
-   Added functions `isHexString`, `isHexPrefixed`, `validateNoLeadingZeroes` (#5963)

### Removed

#### web3-core

-   `getConfig` method from `Web3Config` class, `config` is now public and accessible using `Web3Config.config` (#5950)

#### web3-eth

-   Removed dependencies @ethereumjs/tx, @ethereumjs/common (#5963)

#### web3-eth-abi

-   Removed `formatDecodedObject` function (#5934)

#### web3-eth-contract

-   `data` was removed as a property of `ContractOptions` type (#5915)

#### web3-utils

-   Removed dependencies @ethereumjs/tx, @ethereumjs/common (#5963)

### Fixed

#### web3-eth-ens

-   Bug fix of `checkNetwork` in ENS (#5988)

