### PR TITLE
Add internalType prop to the AbiParameter type.

### DIFF
--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -101,8 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Added `filters` param to the `Filter` type (#6010)
-
 ### Changed
 
 -   Replaced Buffer for Uint8Array (#6004)
 -   types `FMT_BYTES.BUFFER`, `Bytes` and `FormatType` and encryption option types for `salt` and `iv` has replaced support for `Buffer` for `Uint8Array` (#6004)
+-   Added `internalType` property to the `AbiParameter` type.

--- a/packages/web3-types/src/eth_abi_types.ts
+++ b/packages/web3-types/src/eth_abi_types.ts
@@ -81,6 +81,7 @@ export type AbiParameter = {
 	readonly components?: ReadonlyArray<AbiParameter>;
 	readonly arrayLength?: number;
 	readonly arrayChildren?: ReadonlyArray<AbiParameter>;
+	readonly internalType?: string;
 };
 
 type FragmentTypes = 'constructor' | 'event' | 'function' | 'fallback';


### PR DESCRIPTION
## Description

Adding the support of `internalType` property introduced by solidity >= 5

Fixes #6051

## Type of change

<!-- Please delete options that are not relevant. -->

- [ x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run lint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
