### PR TITLE
Autotype for contract methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1462,28 +1462,34 @@ should use 4.0.1-alpha.0 for testing.
 
 ## [Unreleased]
 
-### Breaking Changes
-
--   dropped support for NodeJs@14
--   removed non read-only methods from ens package
-
 ### Added
-
-#### web3-eth-contract
-
--   Added support for `getPastEvents` method to filter `allEvents` and specific event (#6010)
-
-#### web3-types
-
--   Added `filters` param to the `Filter` type (#6010)
--   Export for `HardforksOrdered` enum (#6102)
--   Export for `Web3ValidationErrorObject` type (#6102)
 
 #### web3-errors
 
 -   `InvalidPropertiesForTransactionTypeError` with error code `429` (#6102)
 
+#### web3-eth-contract
+
+-   Added support for `getPastEvents` method to filter `allEvents` and specific event (#6010)
+-   Added `maxPriorityFeePerGas` and `maxFeePerGas` in `ContractOptions` type and updated function using it in utils (#6118)
+-   Added method's type autodetection by ABI param (#6137)
+
+#### web3-types
+
+-   Added `filters` param to the `Filter` type (#6010)
+-   Added types `JsonRpcSubscriptionResultOld`, `Web3ProviderMessageEventCallback`. Added `.on('data')` type support for old providers (#6082)
+-   Export for `HardforksOrdered` enum (#6102)
+-   Export for `Web3ValidationErrorObject` type (#6102)
+
+#### web3-utils
+
+-   Optional `hexstrict` parameter added to numberToHex (#6004)
+
 ### Fixed
+
+#### web3-eth
+
+-   Fixed `ignoreGasPricing` bug with wallet in context (#6071)
 
 #### web3-eth-accounts
 
@@ -1492,13 +1498,59 @@ should use 4.0.1-alpha.0 for testing.
 
 ### Changed
 
+#### web3-core
+
+-   Replaced Buffer for Uint8Array (#6004)
+
+#### web3-errors
+
+-   Nested Smart Contract error data is extracted at `Eip838ExecutionError` constructor and the nested error is set at `innerError` (#6045)
+
 #### web3-eth
 
 -   `formatTransaction` no longer throws a `TransactionDataAndInputError` if it's passed a transaction object with both `data` and `input` properties set (as long as they are the same value) (#6064)
 -   Refactored documentation for `rpc_method_wrappers` to point to the previously duplicated documentation found under the `Web3Eth` class documentation (#6054)
+-   Replaced Buffer for Uint8Array (#6004)
 -   Refactored `defaultTransactionTypeParser` to return correct EIP-2718 types, prior implementation was prioritizing `transaction.hardfork` and ignoring the use of `transaction.gasLimit`. `defaultTransactionTypeParser` will now throw `InvalidPropertiesForTransactionTypeError`s for properties are used that are incompatible with `transaction.type` (#6102)
+-   `prepareTransactionForSigning` and `defaultTransactionBuilder` now accepts optional `fillGasPrice` flag and by default will not fill gas(#6071)
+
+#### web3-eth-abi
+
+-   Nested Smart Contract error data hex string is decoded when the error contains the data as object (when the data hex string is inside data.originalError.data or data.data) (#6045)
+
+#### web3-eth-accounts
+
+-   Replaced `Buffer` for `Uint8Array` (#6004)
+-   The methods `recover`, `encrypt`, `privateKeyToAddress` does not support type `Buffer` but supports type `Uint8Array` (#6004)
+-   The method `parseAndValidatePrivateKey` returns a type `Uint8Array` instead of type `Buffer` (#6004)
+
+#### web3-providers-ipc
+
+-   Replaced Buffer for Uint8Array (#6004)
+
+#### web3-types
+
+-   Removed chainId, to, data & input properties from NonPayableCallOptions
+-   Replaced Buffer for Uint8Array (#6004)
+-   types `FMT_BYTES.BUFFER`, `Bytes` and `FormatType` and encryption option types for `salt` and `iv` has replaced support for `Buffer` for `Uint8Array` (#6004)
+-   Added `internalType` property to the `AbiParameter` type.
+
+#### web3-utils
+
+-   Replaced Buffer for Uint8Array (#6004)
+-   The methods `hexToBytes`, `randomBytes` does not return type `Buffer` but type `Uint8Array` (#6004)
+-   The methods `sha3` and `keccak256Wrapper` does not accept type `Buffer` but type `Uint8Array` (#6004)
+-   The method `bytesToBuffer` has been removed for the usage of `bytesToUint8Array` (#6004)
+
+#### web3-validator
+
+-   Replaced Buffer for Uint8Array (#6004)
 
 ### Removed
+
+#### web3-eth-ens
+
+-   Removed non read-only methods (#6084)
 
 #### web3-validator
 

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -259,3 +259,4 @@ const transactionHash = receipt.transactionHash;
 
 -   Added support for `getPastEvents` method to filter `allEvents` and specific event (#6010)
 -   Added `maxPriorityFeePerGas` and `maxFeePerGas` in `ContractOptions` type and updated function using it in utils (#6118)
+-   Added method's type autodetection by ABI param (#6137)

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -797,11 +797,11 @@ export class Contract<Abi extends ContractAbi>
 					...(this._overloadedMethodAbis.get(abi.name) ?? []),
 					abi,
 				]);
-
-				const contractMethod = this._createContractMethod(
-					this._overloadedMethodAbis.get(abi.name) ?? [],
-					errorsAbi,
-				);
+				const abiFragment = this._overloadedMethodAbis.get(abi.name) ?? [];
+				const contractMethod = this._createContractMethod<
+					typeof abiFragment,
+					AbiErrorFragment
+				>(abiFragment, errorsAbi);
 
 				this._functions[methodName] = {
 					signature: methodSignature,

--- a/packages/web3-eth-contract/test/unit/contract.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract.test.ts
@@ -62,6 +62,28 @@ describe('Contract', () => {
 			expect(contract).toBeInstanceOf(Contract);
 		});
 
+		it('method should have correct type by ABI', () => {
+			const contractInstance = new Contract([
+				{
+					inputs: [
+						{
+							internalType: 'uint256',
+							name: 'tokenId',
+							type: 'uint256',
+						},
+					],
+					name: 'tokenURI',
+					outputs: [{ internalType: 'string', name: '', type: 'string' }],
+					stateMutability: 'view',
+					type: 'function',
+				},
+			] as const);
+
+			const method = contractInstance.methods.tokenURI(123);
+
+			expect(method).toBeDefined();
+		});
+
 		it('should init with abi, options and context', () => {
 			const contract = new Contract(
 				[],

--- a/packages/web3-eth-contract/test/unit/contract_typing.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract_typing.test.ts
@@ -18,11 +18,47 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 /* eslint-disable jest/expect-expect */
 
 import { expectTypeOf, typecheck } from '@humeris/espresso-shot';
+import { Numbers } from 'web3-types';
 import { Contract } from '../../src/contract';
 import { erc20Abi, Erc20Interface } from '../fixtures/erc20';
 import { erc721Abi, Erc721Interface } from '../fixtures/erc721';
+import { NonPayableMethodObject, PayableMethodObject } from '../../src';
 
 describe('contract typing', () => {
+	describe('custom abi', () => {
+		const abi = [
+			{
+				inputs: [
+					{
+						internalType: 'string',
+						name: 'tokenId',
+						type: 'string',
+					},
+				],
+				name: 'tokenURI',
+				outputs: [{ internalType: 'string', name: '', type: 'string' }],
+				stateMutability: 'view',
+				type: 'function',
+			},
+		] as const;
+		const contractInstance = new Contract(abi);
+		interface CustomInterface {
+			methods: {
+				[key: string]: (
+					...args: ReadonlyArray<any>
+				) =>
+					| PayableMethodObject<ReadonlyArray<unknown>, ReadonlyArray<unknown>>
+					| NonPayableMethodObject<ReadonlyArray<unknown>, ReadonlyArray<unknown>>;
+				tokenURI: (tokenId: Numbers) => NonPayableMethodObject<[Numbers], [string]>;
+			};
+		}
+
+		typecheck('should contain all methods', () =>
+			expectTypeOf<keyof typeof contractInstance.methods>().toBe<
+				keyof CustomInterface['methods']
+			>(),
+		);
+	});
 	describe('erc20', () => {
 		const contract = new Contract(erc20Abi);
 


### PR DESCRIPTION
## Description

fixes #6128

after this fix code builds without passing `typeof ABI`:

```ts
const contractInstance = new web3.eth.Contract([
        {
            inputs: [
                {
                    internalType: 'uint256',
                    name: 'tokenId',
                    type: 'uint256',
                },
            ],
            name: 'tokenURI',
            outputs: [{ internalType: 'string', name: '', type: 'string' }],
            stateMutability: 'view',
            type: 'function',
        },
    ] as const);

contractInstance.methods.tokenURI(123);
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
