### PR TITLE
Release/4.0.1 rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1460,7 +1460,7 @@ should use 4.0.1-alpha.0 for testing.
 
 -   Bug fix of `checkNetwork` in ENS (#5988)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Added
 
@@ -1555,3 +1555,5 @@ should use 4.0.1-alpha.0 for testing.
 #### web3-validator
 
 -   `Web3ValidationErrorObject` type is now exported from `web3-types` package (#6102)
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -102,8 +102,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   `getConfig` method from `Web3Config` class, `config` is now public and accessible using `Web3Config.config` (#5950)
 -   Error param in the `messageListener` in subscription was removed (triggered by `.on('data')` or `.on('message')`) to properly support all providers. (#6082)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Changed
 
 -   Replaced Buffer for Uint8Array (#6004)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,16 +42,16 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-eth-iban": "^4.0.1-rc.1",
-		"web3-providers-http": "^4.0.1-rc.1",
-		"web3-providers-ws": "^4.0.1-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-eth-iban": "^4.0.1-rc.2",
+		"web3-providers-http": "^4.0.1-rc.2",
+		"web3-providers-ws": "^4.0.1-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	},
 	"optionalDependencies": {
-		"web3-providers-ipc": "^4.0.1-rc.1"
+		"web3-providers-ipc": "^4.0.1-rc.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   `gasLimit` is no longer accepted as a parameter for `MissingGasError` and `TransactionGasMismatchError, and is also no longer included in error message (#5915)
 
-## [Unreleased]
+## [1.0.0-rc.2]
 
 ### Added
 
@@ -106,3 +106,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   Nested Smart Contract error data is extracted at `Eip838ExecutionError` constructor and the nested error is set at `innerError` (#6045)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.0.0-rc.1"
+		"web3-types": "^1.0.0-rc.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -95,8 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Removed `formatDecodedObject` function (#5934)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Changed
 
 -   Nested Smart Contract error data hex string is decoded when the error contains the data as object (when the data hex string is inside data.originalError.data or data.data) (#6045)
+
+## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -44,9 +44,9 @@
 	"dependencies": {
 		"@ethersproject/abi": "^5.7.0",
 		"@ethersproject/bignumber": "^5.7.0",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1"
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Moved @ethereumjs/tx, @ethereumjs/common code to our source code (#5963)
 -   The method `signTransaction` returned by `privateKeyToAccount` is now accepting the type `Transaction` for its argument. (#5993)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Fixed
 
@@ -94,3 +94,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Replaced `Buffer` for `Uint8Array` (#6004)
 -   The methods `recover`, `encrypt`, `privateKeyToAddress` does not support type `Buffer` but supports type `Uint8Array` (#6004)
 -   The method `parseAndValidatePrivateKey` returns a type `Uint8Array` instead of type `Buffer` (#6004)
+
+## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -55,15 +55,15 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.1-rc.1"
+		"web3-providers-ipc": "^4.0.1-rc.2"
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -253,10 +253,12 @@ const transactionHash = receipt.transactionHash;
 
 -   `data` was removed as a property of `ContractOptions` type (#5915)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Added
 
 -   Added support for `getPastEvents` method to filter `allEvents` and specific event (#6010)
 -   Added `maxPriorityFeePerGas` and `maxFeePerGas` in `ContractOptions` type and updated function using it in utils (#6118)
 -   Added method's type autodetection by ABI param (#6137)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.1",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-eth": "^4.0.1-rc.1",
-		"web3-eth-abi": "^4.0.1-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-core": "^4.0.1-rc.2",
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-eth": "^4.0.1-rc.2",
+		"web3-eth-abi": "^4.0.1-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -67,6 +67,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.1-rc.1"
+		"web3-eth-accounts": "^4.0.1-rc.2"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -82,8 +82,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Bug fix of `checkNetwork` in ENS (#5988)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Removed
 
 -   Removed non read-only methods (#6084)
+
+## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.0.1-rc.1",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-eth": "^4.0.1-rc.1",
-		"web3-eth-contract": "^4.0.1-rc.1",
-		"web3-net": "^4.0.1-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-core": "^4.0.1-rc.2",
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-eth": "^4.0.1-rc.2",
+		"web3-eth-contract": "^4.0.1-rc.2",
+		"web3-net": "^4.0.1-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -72,4 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 
+## [4.0.1-rc.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -88,4 +88,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 
+## [4.0.1-rc.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,12 +42,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.1",
-		"web3-eth": "^4.0.1-rc.1",
-		"web3-rpc-methods": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-core": "^4.0.1-rc.2",
+		"web3-eth": "^4.0.1-rc.2",
+		"web3-rpc-methods": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -62,6 +62,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.1-rc.1"
+		"web3-providers-ws": "^4.0.1-rc.2"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -124,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Removed dependencies @ethereumjs/tx, @ethereumjs/common (#5963)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Fixed
 
@@ -137,3 +137,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Replaced Buffer for Uint8Array (#6004)
 -   Refactored `defaultTransactionTypeParser` to return correct EIP-2718 types, prior implementation was prioritizing `transaction.hardfork` and ignoring the use of `transaction.gasLimit`. `defaultTransactionTypeParser` will now throw `InvalidPropertiesForTransactionTypeError`s for properties are used that are incompatible with `transaction.type` (#6102)
 -   `prepareTransactionForSigning` and `defaultTransactionBuilder` now accepts optional `fillGasPrice` flag and by default will not fill gas(#6071)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -57,20 +57,20 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.0.1-rc.1",
-		"web3-providers-http": "^4.0.1-rc.1"
+		"web3-eth-abi": "^4.0.1-rc.2",
+		"web3-providers-http": "^4.0.1-rc.2"
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.0.1-rc.1",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-eth-abi": "^4.0.1-rc.1",
-		"web3-eth-accounts": "^4.0.1-rc.1",
-		"web3-net": "^4.0.1-rc.1",
-		"web3-providers-ws": "^4.0.1-rc.1",
-		"web3-rpc-methods": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-core": "^4.0.1-rc.2",
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-eth-abi": "^4.0.1-rc.2",
+		"web3-eth-accounts": "^4.0.1-rc.2",
+		"web3-net": "^4.0.1-rc.2",
+		"web3-providers-ws": "^4.0.1-rc.2",
+		"web3-rpc-methods": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -88,4 +88,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 
+## [4.0.1-rc.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.1",
-		"web3-rpc-methods": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1"
+		"web3-core": "^4.0.1-rc.2",
+		"web3-rpc-methods": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -72,4 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 
+## [4.0.1-rc.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,8 +61,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1"
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -82,8 +82,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Changed
 
 -   Replaced Buffer for Uint8Array (#6004)
+
+## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1"
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -75,4 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 
+## [4.0.1-rc.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
 	},
 	"dependencies": {
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -73,4 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added source files (#5956)
 -   Added hybrid build (ESM and CJS) of library (#5904)
 
+## [1.0.0-rc.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-core": "^4.0.1-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -92,7 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   The types `FMT_NUMBER`, `NumberTypes`, `FMT_BYTES`, `ByteTypes`, `DataFormat`, `DEFAULT_RETURN_FORMAT`, `ETH_DATA_FORMAT` and `FormatType` moved from `web3-utils`. (#5993)
 -   The types `ContractInitOptions`, `NonPayableCallOptions` and `PayableCallOptions` are moved from `web3-eth-contract`. (#5993)
 
-## [Unreleased]
+## [1.0.0-rc.2]
 
 ### Added
 
@@ -107,3 +107,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Replaced Buffer for Uint8Array (#6004)
 -   types `FMT_BYTES.BUFFER`, `Bytes` and `FormatType` and encryption option types for `salt` and `iv` has replaced support for `Buffer` for `Uint8Array` (#6004)
 -   Added `internalType` property to the `AbiParameter` type.
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -104,7 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Removed dependencies @ethereumjs/tx, @ethereumjs/common (#5963)
 
-## [Unreleased]
+## [4.0.1-rc.2]
 
 ### Added
 
@@ -116,3 +116,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   The methods `hexToBytes`, `randomBytes` does not return type `Buffer` but type `Uint8Array` (#6004)
 -   The methods `sha3` and `keccak256Wrapper` does not accept type `Buffer` but type `Uint8Array` (#6004)
 -   The method `bytesToBuffer` has been removed for the usage of `bytesToUint8Array` (#6004)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -60,8 +60,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added hybrid build (ESM and CJS) of library (#5904)
 -   Added functions `isHexString`, `isHexPrefixed`, `validateNoLeadingZeroes` (#5963)
 
-## [Unreleased]
+## [1.0.0-rc.2]
 
 ### Changed
 
@@ -96,3 +96,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 -   `Web3ValidationErrorObject` type is now exported from `web3-types` package (#6102)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,10 +45,10 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"is-my-json-valid": "^2.20.6",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1"
+		"is-my-json-valid": "^2.20.6",
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -95,4 +95,10 @@ web3.currentProvider.disconnect();
 -   No need for polyfilling nodejs `net` and `fs` modules (#5978)
 -   Removed IPC provider dependency, IPC path is no longer viable provider. If you wanna use IPC, please install `web3-providers-ipc` and instantiate provider yourself (#5978)
 
+## [4.0.1-rc.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.1-rc.1",
+	"version": "4.0.1-rc.2",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -77,24 +77,24 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.1-rc.1"
+		"web3-providers-ipc": "^4.0.1-rc.2"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.1-rc.1",
-		"web3-errors": "^1.0.0-rc.1",
-		"web3-eth": "^4.0.1-rc.1",
-		"web3-eth-abi": "^4.0.1-rc.1",
-		"web3-eth-accounts": "^4.0.1-rc.1",
-		"web3-eth-contract": "^4.0.1-rc.1",
-		"web3-eth-ens": "^4.0.1-rc.1",
-		"web3-eth-iban": "^4.0.1-rc.1",
-		"web3-eth-personal": "^4.0.1-rc.1",
-		"web3-net": "^4.0.1-rc.1",
-		"web3-providers-http": "^4.0.1-rc.1",
-		"web3-providers-ws": "^4.0.1-rc.1",
-		"web3-rpc-methods": "^1.0.0-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1",
-		"web3-validator": "^1.0.0-rc.1"
+		"web3-core": "^4.0.1-rc.2",
+		"web3-errors": "^1.0.0-rc.2",
+		"web3-eth": "^4.0.1-rc.2",
+		"web3-eth-abi": "^4.0.1-rc.2",
+		"web3-eth-accounts": "^4.0.1-rc.2",
+		"web3-eth-contract": "^4.0.1-rc.2",
+		"web3-eth-ens": "^4.0.1-rc.2",
+		"web3-eth-iban": "^4.0.1-rc.2",
+		"web3-eth-personal": "^4.0.1-rc.2",
+		"web3-net": "^4.0.1-rc.2",
+		"web3-providers-http": "^4.0.1-rc.2",
+		"web3-providers-ws": "^4.0.1-rc.2",
+		"web3-rpc-methods": "^1.0.0-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2",
+		"web3-validator": "^1.0.0-rc.2"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-rc.1' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.1-rc.2' };

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -45,12 +45,12 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.0.1-rc.1",
-		"web3-core": "^4.0.1-rc.1",
-		"web3-eth-abi": "^4.0.1-rc.1",
-		"web3-eth-contract": "^4.0.1-rc.1",
-		"web3-types": "^1.0.0-rc.1",
-		"web3-utils": "^4.0.1-rc.1"
+		"web3": "^4.0.1-rc.2",
+		"web3-core": "^4.0.1-rc.2",
+		"web3-eth-abi": "^4.0.1-rc.2",
+		"web3-eth-contract": "^4.0.1-rc.2",
+		"web3-types": "^1.0.0-rc.2",
+		"web3-utils": "^4.0.1-rc.2"
 	},
 	"peerDependencies": {
 		"web3-core": ">= 4.0.1-rc.1 < 5",


### PR DESCRIPTION

## [4.0.1-rc.2]

### Added

#### web3-errors

-   `InvalidPropertiesForTransactionTypeError` with error code `429` (#6102)

#### web3-eth-contract

-   Added support for `getPastEvents` method to filter `allEvents` and specific event (#6010)
-   Added `maxPriorityFeePerGas` and `maxFeePerGas` in `ContractOptions` type and updated function using it in utils (#6118)
-   Added method's type autodetection by ABI param (#6137)

#### web3-types

-   Added `filters` param to the `Filter` type (#6010)
-   Added types `JsonRpcSubscriptionResultOld`, `Web3ProviderMessageEventCallback`. Added `.on('data')` type support for old providers (#6082)
-   Export for `HardforksOrdered` enum (#6102)
-   Export for `Web3ValidationErrorObject` type (#6102)

#### web3-utils

-   Optional `hexstrict` parameter added to numberToHex (#6004)

### Fixed

#### web3-eth

-   Fixed `ignoreGasPricing` bug with wallet in context (#6071)

#### web3-eth-accounts

-   Fixed ESM import bugs reported in (#6032) and (#6034)
-   ESM projects will not need to run --experimental-specifier-resolution=node (#6127)

### Changed

#### web3-core

-   Replaced Buffer for Uint8Array (#6004)

#### web3-errors

-   Nested Smart Contract error data is extracted at `Eip838ExecutionError` constructor and the nested error is set at `innerError` (#6045)

#### web3-eth

-   `formatTransaction` no longer throws a `TransactionDataAndInputError` if it's passed a transaction object with both `data` and `input` properties set (as long as they are the same value) (#6064)
-   Refactored documentation for `rpc_method_wrappers` to point to the previously duplicated documentation found under the `Web3Eth` class documentation (#6054)
-   Replaced Buffer for Uint8Array (#6004)
-   Refactored `defaultTransactionTypeParser` to return correct EIP-2718 types, prior implementation was prioritizing `transaction.hardfork` and ignoring the use of `transaction.gasLimit`. `defaultTransactionTypeParser` will now throw `InvalidPropertiesForTransactionTypeError`s for properties are used that are incompatible with `transaction.type` (#6102)
-   `prepareTransactionForSigning` and `defaultTransactionBuilder` now accepts optional `fillGasPrice` flag and by default will not fill gas(#6071)

#### web3-eth-abi

-   Nested Smart Contract error data hex string is decoded when the error contains the data as object (when the data hex string is inside data.originalError.data or data.data) (#6045)

#### web3-eth-accounts

-   Replaced `Buffer` for `Uint8Array` (#6004)
-   The methods `recover`, `encrypt`, `privateKeyToAddress` does not support type `Buffer` but supports type `Uint8Array` (#6004)
-   The method `parseAndValidatePrivateKey` returns a type `Uint8Array` instead of type `Buffer` (#6004)

#### web3-providers-ipc

-   Replaced Buffer for Uint8Array (#6004)

#### web3-types

-   Removed chainId, to, data & input properties from NonPayableCallOptions
-   Replaced Buffer for Uint8Array (#6004)
-   types `FMT_BYTES.BUFFER`, `Bytes` and `FormatType` and encryption option types for `salt` and `iv` has replaced support for `Buffer` for `Uint8Array` (#6004)
-   Added `internalType` property to the `AbiParameter` type.

#### web3-utils

-   Replaced Buffer for Uint8Array (#6004)
-   The methods `hexToBytes`, `randomBytes` does not return type `Buffer` but type `Uint8Array` (#6004)
-   The methods `sha3` and `keccak256Wrapper` does not accept type `Buffer` but type `Uint8Array` (#6004)
-   The method `bytesToBuffer` has been removed for the usage of `bytesToUint8Array` (#6004)

#### web3-validator

-   Replaced Buffer for Uint8Array (#6004)

### Removed

#### web3-eth-ens

-   Removed non read-only methods (#6084)

#### web3-validator

-   `Web3ValidationErrorObject` type is now exported from `web3-types` package (#6102)

