### PR TITLE
Revert "Add `from-package` to `learna publish` for canary"

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"prepare": "husky install",
 		"postinstall": "yarn build",
 		"compile:contracts": "node ./scripts/compile_contracts.js && yarn format && yarn lint:fix",
-		"publish:canary": "lerna publish from-package --canary --dist-tag dev --preid dev.$(git rev-parse --short HEAD) --exact --graph-type all --force-publish \"*\" --no-verify-access --yes"
+		"publish:canary": "lerna publish --canary --dist-tag dev --preid dev.$(git rev-parse --short HEAD) --exact --graph-type all --force-publish \"*\" --no-verify-access --yes"
 	},
 	"devDependencies": {
 		"@cypress/webpack-preprocessor": "^5.12.0",


### PR DESCRIPTION
Reverts web3/web3.js#6172

This will prevent all packages from being published with exact git sha version

