### PR TITLE
Add `.on('error')` test for reverted contract methods

### DIFF
--- a/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
@@ -81,7 +81,7 @@ describe('contract errors', () => {
 				code: 310,
 				receipt: undefined,
 				innerError: {
-					code: 3,
+					code: ERR_CONTRACT_EXECUTION_REVERTED,
 					data: '0x82b42900',
 					errorName: 'Unauthorized',
 					errorSignature: 'Unauthorized()',

--- a/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
@@ -126,7 +126,7 @@ describe('contract errors', () => {
 		it('should catch error with parameter using PromiEvent.on("error")', async () => {
 			const expectedThrownError = {
 				name: 'ContractExecutionError',
-				code: 310,
+				code: ERR_CONTRACT_EXECUTION_REVERTED,
 				receipt: undefined,
 				innerError: {
 					code: 3,

--- a/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
@@ -101,5 +101,27 @@ describe('contract errors', () => {
 				},
 			});
 		});
+
+		it('should catch error with parameter using PromiEvent.on("error")', async () => {
+			const expectedThrownError = {
+				name: 'ContractExecutionError',
+				code: 310,
+				receipt: undefined,
+				innerError: {
+					code: 3,
+					data: '0x8d6ea8be0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001b7265766572746564207573696e6720637573746f6d204572726f720000000000',
+					errorName: 'CustomError',
+					errorSignature: 'CustomError(string)',
+					errorArgs: { '0': 'reverted using custom Error' },
+				},
+			};
+
+			await expect(
+				deployedContract.methods
+					.badRequire()
+					.send(sendOptions)
+					.on('error', error => expect(error).toMatchObject(expectedThrownError)),
+			).rejects.toMatchObject(expectedThrownError);
+		});
 	});
 });

--- a/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
@@ -75,6 +75,27 @@ describe('contract errors', () => {
 			});
 		});
 
+		it('should catch Unauthorized error PromiEvent.on("error")', async () => {
+			const expectedThrownError = {
+				name: 'ContractExecutionError',
+				code: 310,
+				receipt: undefined,
+				innerError: {
+					code: 3,
+					data: '0x82b42900',
+					errorName: 'Unauthorized',
+					errorSignature: 'Unauthorized()',
+				},
+			};
+
+			await expect(
+				deployedContract.methods
+					.unauthorize()
+					.send(sendOptions)
+					.on('error', error => expect(error).toMatchObject(expectedThrownError)),
+			).rejects.toMatchObject(expectedThrownError);
+		});
+
 		it('Error with parameter', async () => {
 			let error: ContractExecutionError | undefined;
 			try {

--- a/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
+++ b/packages/web3-eth-contract/test/integration/contract_methods_errors.test.ts
@@ -78,10 +78,10 @@ describe('contract errors', () => {
 		it('should catch Unauthorized error PromiEvent.on("error")', async () => {
 			const expectedThrownError = {
 				name: 'ContractExecutionError',
-				code: 310,
+				code: ERR_CONTRACT_EXECUTION_REVERTED,
 				receipt: undefined,
 				innerError: {
-					code: ERR_CONTRACT_EXECUTION_REVERTED,
+					code: 3,
 					data: '0x82b42900',
 					errorName: 'Unauthorized',
 					errorSignature: 'Unauthorized()',


### PR DESCRIPTION
This PR just adds two tests that verify we receive the revert error using `.on('error')` when calling a contract method that reverts

related to #5670