### PR TITLE
fix: add 'receive' to FragmentTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1603,3 +1603,7 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 #### web3-eth-contract
 
 -   Event filtering using non-indexed and indexed string event arguments (#6167)
+
+#### web3-eth-types
+
+-   Receive fragment type added (#6204)

--- a/packages/web3-types/src/eth_abi_types.ts
+++ b/packages/web3-types/src/eth_abi_types.ts
@@ -84,7 +84,7 @@ export type AbiParameter = {
 	readonly internalType?: string;
 };
 
-type FragmentTypes = 'constructor' | 'event' | 'function' | 'fallback';
+type FragmentTypes = 'constructor' | 'event' | 'function' | 'fallback' | 'receive';
 
 export type AbiBaseFragment = {
 	// type will default to string if passed ABI is declared without "as const"


### PR DESCRIPTION
## Description

Added a missing `receive` FragmentType to web3-types.

1.x excerpt can be found here: https://github.com/web3/web3.js/blob/v1.10.0/packages/web3-utils/types/index.d.ts#L215

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run lint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
