### PR TITLE
Refactor subscription's logic

### DIFF
--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -134,4 +134,4 @@ Documentation:
 -   Fixed Batch requests erroring out on one request (#6164)
 -   Fixed the issue: Subscribing to multiple blockchain events causes every listener to be fired for every registered event (#6210)
 -   Fixed the issue: Unsubscribe at a Web3Subscription class will still have the id of the subscription at the Web3SubscriptionManager (#6210)
--   Fixed the issue: A call to the provider is made for every subscription object. This means multiple subscription is made at the provider for each subscription object (#6210)
+-   Fixed the issue: A call to the provider is made for every subscription object (#6210)

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -121,7 +121,17 @@ Documentation:
 
 ## [Unreleased]
 
+### Added
+
+-   Web3Subscription constructor accept a Subscription Manager (as an alternative to accepting Request Manager that is now marked marked as deprecated) (#6210)
+
+### Changed
+
+-   Web3Subscription constructor overloading that accept a Request Manager is marked as deprecated (#6210)
+
 ### Fixed
 
 -   Fixed Batch requests erroring out on one request (#6164)
--   Fixed the issue: Subscribing to multiple blockchain events causes every listener to be fired for every registered event (#6210).
+-   Fixed the issue: Subscribing to multiple blockchain events causes every listener to be fired for every registered event (#6210)
+-   Fixed the issue: Unsubscribe at a Web3Subscription class will still have the id of the subscription at the Web3SubscriptionManager (#6210)
+-   Fixed the issue: A call to the provider is made for every subscription object. This means multiple subscription is made at the provider for each subscription object (#6210)

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -124,3 +124,4 @@ Documentation:
 ### Fixed
 
 -   Fixed Batch requests erroring out on one request (#6164)
+-   Fixed the issue: Subscribing to multiple blockchain events causes every listener to be fired for every registered event (#6210).

--- a/packages/web3-core/src/utils.ts
+++ b/packages/web3-core/src/utils.ts
@@ -54,7 +54,8 @@ export const isLegacySendAsyncProvider = <API extends Web3APISpec>(
 export const isSupportedProvider = <API extends Web3APISpec>(
 	provider: SupportedProviders<API>,
 ): provider is SupportedProviders<API> =>
-	Web3BaseProvider.isWeb3Provider(provider) ||
+	isWeb3Provider(provider) ||
+	isEIP1193Provider(provider) ||
 	isLegacyRequestProvider(provider) ||
 	isLegacySendAsyncProvider(provider) ||
 	isLegacySendProvider(provider);

--- a/packages/web3-core/src/web3_context.ts
+++ b/packages/web3-core/src/web3_context.ts
@@ -96,7 +96,7 @@ export class Web3Context<
 	public static givenProvider?: SupportedProviders<never>;
 	public readonly providers = Web3RequestManager.providers;
 	protected _requestManager: Web3RequestManager<API>;
-	protected _subscriptionManager?: Web3SubscriptionManager<API, RegisteredSubs>;
+	protected _subscriptionManager: Web3SubscriptionManager<API, RegisteredSubs>;
 	protected _accountProvider?: Web3AccountProvider<Web3BaseWalletAccount>;
 	protected _wallet?: Web3BaseWallet<Web3BaseWalletAccount>;
 
@@ -146,10 +146,10 @@ export class Web3Context<
 
 		if (subscriptionManager) {
 			this._subscriptionManager = subscriptionManager;
-		} else if (registeredSubscriptions) {
+		} else {
 			this._subscriptionManager = new Web3SubscriptionManager(
 				this.requestManager,
-				registeredSubscriptions,
+				registeredSubscriptions ?? ({} as RegisteredSubs),
 			);
 		}
 
@@ -195,8 +195,7 @@ export class Web3Context<
 			provider: this.provider,
 			requestManager: this.requestManager,
 			subscriptionManager: this.subscriptionManager,
-			registeredSubscriptions: this.subscriptionManager
-				?.registeredSubscriptions as RegisteredSubs,
+			registeredSubscriptions: this.subscriptionManager?.registeredSubscriptions,
 			providers: this.providers,
 			wallet: this.wallet,
 			accountProvider: this.accountProvider,
@@ -231,6 +230,7 @@ export class Web3Context<
 		this.setConfig(parentContext.config);
 		this._requestManager = parentContext.requestManager;
 		this.provider = parentContext.provider;
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		this._subscriptionManager = parentContext.subscriptionManager;
 		this._wallet = parentContext.wallet;
 		this._accountProvider = parentContext._accountProvider;

--- a/packages/web3-core/src/web3_subscription_manager.ts
+++ b/packages/web3-core/src/web3_subscription_manager.ts
@@ -15,11 +15,22 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { DataFormat, DEFAULT_RETURN_FORMAT, Web3APISpec } from 'web3-types';
+import {
+	DataFormat,
+	DEFAULT_RETURN_FORMAT,
+	EIP1193Provider,
+	JsonRpcNotification,
+	JsonRpcSubscriptionResult,
+	JsonRpcSubscriptionResultOld,
+	Log,
+	Web3APISpec,
+	Web3BaseProvider,
+} from 'web3-types';
 import { ProviderError, SubscriptionError } from 'web3-errors';
-import { isNullish } from 'web3-utils';
+import { jsonRpc, isNullish } from 'web3-utils';
 import { isSupportSubscriptions } from './utils.js';
 import { Web3RequestManager, Web3RequestManagerEvent } from './web3_request_manager.js';
+// eslint-disable-next-line import/no-cycle
 import { Web3SubscriptionConstructor } from './web3_subscriptions.js';
 
 type ShouldUnsubscribeCondition = ({
@@ -31,8 +42,10 @@ type ShouldUnsubscribeCondition = ({
 }) => boolean | undefined;
 
 export class Web3SubscriptionManager<
-	API extends Web3APISpec,
-	RegisteredSubs extends { [key: string]: Web3SubscriptionConstructor<API> },
+	API extends Web3APISpec = Web3APISpec,
+	RegisteredSubs extends { [key: string]: Web3SubscriptionConstructor<API> } = {
+		[key: string]: Web3SubscriptionConstructor<API>;
+	},
 > {
 	private readonly _subscriptions: Map<
 		string,
@@ -60,9 +73,71 @@ export class Web3SubscriptionManager<
 
 		this.requestManager.on(Web3RequestManagerEvent.PROVIDER_CHANGED, () => {
 			this.clear();
+			this.listenToProviderEvents();
 		});
+
+		this.listenToProviderEvents();
 	}
 
+	private listenToProviderEvents() {
+		const providerAsWebProvider = this.requestManager.provider as Web3BaseProvider;
+		if (
+			!this.requestManager.provider ||
+			(typeof providerAsWebProvider?.supportsSubscriptions === 'function' &&
+				!providerAsWebProvider?.supportsSubscriptions())
+		) {
+			return;
+		}
+
+		if (typeof (this.requestManager.provider as EIP1193Provider<API>).on === 'function') {
+			if (
+				typeof (this.requestManager.provider as EIP1193Provider<API>).request === 'function'
+			) {
+				// Listen to provider messages and data
+				(this.requestManager.provider as EIP1193Provider<API>).on(
+					'message',
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+					(message: any) => this.messageListener(message),
+				);
+			} else {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+				providerAsWebProvider.on<Log>('data', (data: any) => this.messageListener(data));
+			}
+		}
+	}
+
+	protected messageListener(
+		data?:
+			| JsonRpcSubscriptionResult
+			| JsonRpcSubscriptionResultOld<Log>
+			| JsonRpcNotification<Log>,
+	) {
+		if (!data) {
+			throw new SubscriptionError('Should not call messageListener with no data. Type was');
+		}
+		const subscriptionId =
+			(data as JsonRpcNotification).params?.subscription ||
+			(data as JsonRpcSubscriptionResultOld).data?.subscription ||
+			(data as JsonRpcSubscriptionResult).id?.toString(16);
+
+		// Process if the received data is related to a subscription
+		if (subscriptionId) {
+			const sub = this._subscriptions.get(subscriptionId);
+			if (sub) {
+				// for EIP-1193 provider
+				if (data?.data) {
+					sub.processSubscriptionResult(data?.data?.result ?? data?.data);
+				} else if (
+					data &&
+					jsonRpc.isResponseWithNotification(
+						data as unknown as JsonRpcSubscriptionResult | JsonRpcNotification<Log>,
+					)
+				) {
+					sub.processSubscriptionResult(data?.params.result);
+				}
+			}
+		}
+	}
 	/**
 	 * Will create a new subscription
 	 *
@@ -78,19 +153,19 @@ export class Web3SubscriptionManager<
 		args?: ConstructorParameters<RegisteredSubs[T]>[0],
 		returnFormat: DataFormat = DEFAULT_RETURN_FORMAT,
 	): Promise<InstanceType<RegisteredSubs[T]>> {
-		if (!this.requestManager.provider) {
-			throw new ProviderError('Provider not available');
-		}
-
 		const Klass: RegisteredSubs[T] = this.registeredSubscriptions[name];
 		if (!Klass) {
 			throw new SubscriptionError('Invalid subscription type');
 		}
 
-		const subscription = new Klass(args ?? undefined, {
-			requestManager: this.requestManager,
-			returnFormat,
-		}) as InstanceType<RegisteredSubs[T]>;
+		const subscription = new Klass(
+			args ?? undefined,
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+			this as Web3SubscriptionManager<API, any>,
+			{
+				returnFormat,
+			},
+		) as InstanceType<RegisteredSubs[T]>;
 
 		await this.addSubscription(subscription);
 
@@ -111,6 +186,10 @@ export class Web3SubscriptionManager<
 	 * @param sub - A {@link Web3Subscription} object
 	 */
 	public async addSubscription(sub: InstanceType<RegisteredSubs[keyof RegisteredSubs]>) {
+		if (!this.requestManager.provider) {
+			throw new ProviderError('Provider not available');
+		}
+
 		if (!this.supportsSubscriptions()) {
 			throw new SubscriptionError('The current provider does not support subscriptions');
 		}
@@ -119,34 +198,38 @@ export class Web3SubscriptionManager<
 			throw new SubscriptionError(`Subscription with id "${sub.id}" already exists`);
 		}
 
-		await sub.subscribe();
+		await sub.sendSubscriptionRequest();
 
 		if (isNullish(sub.id)) {
 			throw new SubscriptionError('Subscription is not subscribed yet.');
 		}
 
 		this._subscriptions.set(sub.id, sub);
+
+		return sub.id;
 	}
+
 	/**
 	 * Will clear a subscription
 	 *
 	 * @param id - The subscription of type {@link Web3Subscription}  to remove
 	 */
-
 	public async removeSubscription(sub: InstanceType<RegisteredSubs[keyof RegisteredSubs]>) {
-		if (isNullish(sub.id)) {
+		const { id } = sub;
+
+		if (isNullish(id)) {
 			throw new SubscriptionError(
 				'Subscription is not subscribed yet. Or, had already been unsubscribed but not through the Subscription Manager.',
 			);
 		}
 
-		if (!this._subscriptions.has(sub.id)) {
+		if (!this._subscriptions.has(id)) {
 			throw new SubscriptionError(
-				`Subscription with id "${sub.id.toString()}" does not exists`,
+				`Failed to remove Subscription. Subscription with id "${id.toString()}" does not exists`,
 			);
 		}
-		const { id } = sub;
-		await sub.unsubscribe();
+
+		await sub.sendUnsubscribeRequest();
 		this._subscriptions.delete(id);
 		return id;
 	}

--- a/packages/web3-core/src/web3_subscription_manager.ts
+++ b/packages/web3-core/src/web3_subscription_manager.ts
@@ -212,9 +212,7 @@ export class Web3SubscriptionManager<
 		}
 
 		if (!this._subscriptions.has(id)) {
-			throw new SubscriptionError(
-				`Failed to remove Subscription. Subscription with id "${id.toString()}" does not exists`,
-			);
+			throw new SubscriptionError(`Subscription with id "${id.toString()}" does not exists`);
 		}
 
 		await sub.sendUnsubscribeRequest();

--- a/packages/web3-core/src/web3_subscription_manager.ts
+++ b/packages/web3-core/src/web3_subscription_manager.ts
@@ -159,11 +159,11 @@ export class Web3SubscriptionManager<
 			throw new SubscriptionError('Invalid subscription type');
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		const subscription = new Klass(args ?? undefined, {
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-			subscriptionManager: this as Web3SubscriptionManager<API, any>,
+			subscriptionManager: this as Web3SubscriptionManager<API, RegisteredSubs>,
 			returnFormat,
-		}) as InstanceType<RegisteredSubs[T]>;
+		} as any) as InstanceType<RegisteredSubs[T]>;
 
 		await this.addSubscription(subscription);
 

--- a/packages/web3-core/src/web3_subscription_manager.ts
+++ b/packages/web3-core/src/web3_subscription_manager.ts
@@ -27,7 +27,7 @@ import {
 	Web3BaseProvider,
 } from 'web3-types';
 import { ProviderError, SubscriptionError } from 'web3-errors';
-import { jsonRpc, isNullish } from 'web3-utils';
+import { isNullish } from 'web3-utils';
 import { isSupportSubscriptions } from './utils.js';
 import { Web3RequestManager, Web3RequestManagerEvent } from './web3_request_manager.js';
 // eslint-disable-next-line import/no-cycle
@@ -123,19 +123,7 @@ export class Web3SubscriptionManager<
 		// Process if the received data is related to a subscription
 		if (subscriptionId) {
 			const sub = this._subscriptions.get(subscriptionId);
-			if (sub) {
-				// for EIP-1193 provider
-				if (data?.data) {
-					sub._processSubscriptionResult(data?.data?.result ?? data?.data);
-				} else if (
-					data &&
-					jsonRpc.isResponseWithNotification(
-						data as unknown as JsonRpcSubscriptionResult | JsonRpcNotification<Log>,
-					)
-				) {
-					sub._processSubscriptionResult(data?.params.result);
-				}
-			}
+			sub?.processSubscriptionData(data);
 		}
 	}
 	/**

--- a/packages/web3-core/src/web3_subscription_manager.ts
+++ b/packages/web3-core/src/web3_subscription_manager.ts
@@ -126,14 +126,14 @@ export class Web3SubscriptionManager<
 			if (sub) {
 				// for EIP-1193 provider
 				if (data?.data) {
-					sub.processSubscriptionResult(data?.data?.result ?? data?.data);
+					sub._processSubscriptionResult(data?.data?.result ?? data?.data);
 				} else if (
 					data &&
 					jsonRpc.isResponseWithNotification(
 						data as unknown as JsonRpcSubscriptionResult | JsonRpcNotification<Log>,
 					)
 				) {
-					sub.processSubscriptionResult(data?.params.result);
+					sub._processSubscriptionResult(data?.params.result);
 				}
 			}
 		}

--- a/packages/web3-core/src/web3_subscription_manager.ts
+++ b/packages/web3-core/src/web3_subscription_manager.ts
@@ -54,8 +54,8 @@ export class Web3SubscriptionManager<
 
 	/**
 	 *
-	 * @param requestManager
-	 * @param registeredSubscriptions
+	 * @param - requestManager
+	 * @param - registeredSubscriptions
 	 *
 	 * @example
 	 * ```ts
@@ -143,8 +143,8 @@ export class Web3SubscriptionManager<
 	 * Will create a new subscription
 	 *
 	 * @param name - The subscription you want to subscribe to
-	 * @param args (optional) - Optional additional parameters, depending on the subscription type
-	 * @param returnFormat ({@link DataFormat} defaults to {@link DEFAULT_RETURN_FORMAT}) - Specifies how the return data from the call should be formatted.
+	 * @param args - Optional additional parameters, depending on the subscription type
+	 * @param returnFormat- ({@link DataFormat} defaults to {@link DEFAULT_RETURN_FORMAT}) - Specifies how the return data from the call should be formatted.
 	 *
 	 * Will subscribe to a specific topic (note: name)
 	 * @returns The subscription object

--- a/packages/web3-core/src/web3_subscriptions.ts
+++ b/packages/web3-core/src/web3_subscriptions.ts
@@ -103,7 +103,7 @@ export abstract class Web3Subscription<
 	}
 
 	// eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
-	public processSubscriptionError(_err: Error) {
+	protected _processSubscriptionError(_err: Error) {
 		// Do nothing - This should be overridden in subclass.
 	}
 

--- a/packages/web3-core/src/web3_subscriptions.ts
+++ b/packages/web3-core/src/web3_subscriptions.ts
@@ -62,15 +62,15 @@ export abstract class Web3Subscription<
 	public constructor(
 		public readonly args: ArgsType,
 		options: (
-			| { subscriptionManager: Web3SubscriptionManager; requestManager: never }
-			| { requestManager: Web3RequestManager<API>; subscriptionManager: never }
+			| { subscriptionManager: Web3SubscriptionManager }
+			| { requestManager: Web3RequestManager<API> }
 		) & {
 			returnFormat?: DataFormat;
 		},
 	) {
 		super();
-		const { requestManager } = options;
-		const { subscriptionManager } = options;
+		const { requestManager } = options as { requestManager: Web3RequestManager<API> };
+		const { subscriptionManager } = options as { subscriptionManager: Web3SubscriptionManager };
 		if (requestManager && subscriptionManager) {
 			throw new SubscriptionError(
 				'Only requestManager or subscriptionManager should be provided at Subscription constructor',
@@ -175,14 +175,23 @@ export type Web3SubscriptionConstructor<
 	API extends Web3APISpec,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	SubscriptionType extends Web3Subscription<any, any, API> = Web3Subscription<any, any, API>,
-> = new (
-	// We accept any type of arguments here and don't deal with this type internally
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	args: any,
-	options: (
-		| { subscriptionManager: Web3SubscriptionManager }
-		| { requestManager: Web3RequestManager<API> }
-	) & {
-		returnFormat?: DataFormat;
-	},
-) => SubscriptionType;
+> =
+	| (new (
+			// We accept any type of arguments here and don't deal with this type internally
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			args: any,
+			options:
+				| { subscriptionManager: Web3SubscriptionManager<API>; returnFormat?: DataFormat }
+				| { requestManager: Web3RequestManager<API>; returnFormat?: DataFormat },
+	  ) => SubscriptionType)
+	| (new (
+			args: any,
+			options: {
+				subscriptionManager: Web3SubscriptionManager<API>;
+				returnFormat?: DataFormat;
+			},
+	  ) => SubscriptionType)
+	| (new (
+			args: any,
+			options: { requestManager: Web3RequestManager<API>; returnFormat?: DataFormat },
+	  ) => SubscriptionType);

--- a/packages/web3-core/src/web3_subscriptions.ts
+++ b/packages/web3-core/src/web3_subscriptions.ts
@@ -17,24 +17,18 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 // eslint-disable-next-line max-classes-per-file
 import {
-	HexString,
 	BlockOutput,
-	Web3BaseProvider,
-	Web3APISpec,
-	Web3APIParams,
-	EthExecutionAPI,
-	Log,
-	JsonRpcNotification,
-	JsonRpcSubscriptionResult,
-	DataFormat,
 	DEFAULT_RETURN_FORMAT,
-	JsonRpcSubscriptionResultOld,
-	EIP1193Provider,
+	DataFormat,
+	EthExecutionAPI,
+	HexString,
+	Web3APIParams,
+	Web3APISpec,
 } from 'web3-types';
-import { jsonRpc } from 'web3-utils';
 import { Web3EventEmitter, Web3EventMap } from './web3_event_emitter.js';
 
-import { Web3RequestManager } from './web3_request_manager.js';
+// eslint-disable-next-line import/no-cycle
+import { Web3SubscriptionManager } from './web3_subscription_manager.js';
 
 export abstract class Web3Subscription<
 	EventMap extends Web3EventMap,
@@ -42,20 +36,21 @@ export abstract class Web3Subscription<
 	ArgsType = any,
 	API extends Web3APISpec = EthExecutionAPI,
 > extends Web3EventEmitter<EventMap> {
-	private readonly _requestManager: Web3RequestManager<API>;
+	private readonly _subscriptionManager: Web3SubscriptionManager<API>;
 	private readonly _lastBlock?: BlockOutput;
 	private readonly _returnFormat: DataFormat;
-	private _id?: HexString;
-	private _messageListener?: (data?: JsonRpcNotification<Log>) => void;
+	protected _id?: HexString;
 
 	public constructor(
 		public readonly args: ArgsType,
-
-		options: { requestManager: Web3RequestManager<API>; returnFormat?: DataFormat },
+		subscriptionManager: Web3SubscriptionManager,
+		options?: {
+			returnFormat?: DataFormat;
+		},
 	) {
 		super();
-		this._requestManager = options.requestManager;
-		this._returnFormat = options.returnFormat ?? (DEFAULT_RETURN_FORMAT as DataFormat);
+		this._subscriptionManager = subscriptionManager;
+		this._returnFormat = options?.returnFormat ?? (DEFAULT_RETURN_FORMAT as DataFormat);
 	}
 
 	public get id() {
@@ -67,41 +62,17 @@ export abstract class Web3Subscription<
 	}
 
 	public async subscribe() {
-		this._id = await this._requestManager.send({
+		return this._subscriptionManager.addSubscription(this);
+	}
+
+	public async sendSubscriptionRequest(): Promise<string> {
+		this._id = await this._subscriptionManager.requestManager.send({
 			method: 'eth_subscribe',
 			params: this._buildSubscriptionParams(),
 		});
-
-		const messageListener = (
-			data?:
-				| JsonRpcSubscriptionResult
-				| JsonRpcSubscriptionResultOld<Log>
-				| JsonRpcNotification<Log>,
-		) => {
-			// for EIP-1193 provider
-			if (data?.data) {
-				this._processSubscriptionResult(data?.data?.result ?? data?.data);
-				return;
-			}
-
-			if (
-				data &&
-				jsonRpc.isResponseWithNotification(
-					data as unknown as JsonRpcSubscriptionResult | JsonRpcNotification<Log>,
-				)
-			) {
-				this._processSubscriptionResult(data?.params.result);
-			}
-		};
-
-		if (typeof (this._requestManager.provider as EIP1193Provider<API>).request === 'function') {
-			(this._requestManager.provider as Web3BaseProvider).on<Log>('message', messageListener);
-		} else {
-			(this._requestManager.provider as Web3BaseProvider).on<Log>('data', messageListener);
-		}
-
-		this._messageListener = messageListener;
+		return this._id;
 	}
+
 	protected get returnFormat() {
 		return this._returnFormat;
 	}
@@ -115,25 +86,24 @@ export abstract class Web3Subscription<
 			return;
 		}
 
-		await this._requestManager.send({
+		await this._subscriptionManager.removeSubscription(this);
+	}
+
+	public async sendUnsubscribeRequest() {
+		await this._subscriptionManager.requestManager.send({
 			method: 'eth_unsubscribe',
 			params: [this.id] as Web3APIParams<API, 'eth_unsubscribe'>,
 		});
-
 		this._id = undefined;
-		(this._requestManager.provider as Web3BaseProvider).removeListener(
-			'message',
-			this._messageListener as never,
-		);
 	}
 
 	// eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
-	protected _processSubscriptionResult(_data: unknown) {
+	public processSubscriptionResult(_data: unknown) {
 		// Do nothing - This should be overridden in subclass.
 	}
 
 	// eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
-	protected _processSubscriptionError(_err: Error) {
+	public processSubscriptionError(_err: Error) {
 		// Do nothing - This should be overridden in subclass.
 	}
 
@@ -152,5 +122,8 @@ export type Web3SubscriptionConstructor<
 	// We accept any type of arguments here and don't deal with this type internally
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	args: any,
-	options: { requestManager: Web3RequestManager<API>; returnFormat?: DataFormat },
+	subscriptionManager: Web3SubscriptionManager<API>,
+	options: {
+		returnFormat?: DataFormat;
+	},
 ) => SubscriptionType;

--- a/packages/web3-core/src/web3_subscriptions.ts
+++ b/packages/web3-core/src/web3_subscriptions.ts
@@ -98,7 +98,7 @@ export abstract class Web3Subscription<
 	}
 
 	// eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
-	public processSubscriptionResult(_data: unknown) {
+	protected _processSubscriptionResult(_data: unknown) {
 		// Do nothing - This should be overridden in subclass.
 	}
 

--- a/packages/web3-core/test/unit/__snapshots__/web3_context.test.ts.snap
+++ b/packages/web3-core/test/unit/__snapshots__/web3_context.test.ts.snap
@@ -73,6 +73,7 @@ Object {
       },
       "useRpcCallSpecification": undefined,
     },
+    "tolerateUnlinkedSubscription": false,
   },
   "wallet": undefined,
 }

--- a/packages/web3-core/test/unit/web3_subscription_manager.test.ts
+++ b/packages/web3-core/test/unit/web3_subscription_manager.test.ts
@@ -122,9 +122,10 @@ describe('Web3SubscriptionManager', () => {
 
 			expect(result).toBeInstanceOf(ExampleSubscription);
 			expect(ExampleSubscription).toHaveBeenCalledTimes(1);
-			expect(ExampleSubscription).toHaveBeenCalledWith({ test1: 'test1' }, subManager, {
-				returnFormat: DEFAULT_RETURN_FORMAT,
-			});
+			expect(ExampleSubscription).toHaveBeenCalledWith(
+				{ test1: 'test1' },
+				{ subscriptionManager: subManager, returnFormat: DEFAULT_RETURN_FORMAT },
+			);
 		});
 	});
 
@@ -134,7 +135,10 @@ describe('Web3SubscriptionManager', () => {
 		beforeEach(() => {
 			subManager = new Web3SubscriptionManager(requestManager, subscriptions);
 			jest.spyOn(subManager, 'supportsSubscriptions').mockReturnValue(true);
-			sub = new ExampleSubscription({ param1: 'param1' }, subManager);
+			sub = new ExampleSubscription(
+				{ param1: 'param1' },
+				{ subscriptionManager: subManager },
+			);
 
 			(sub as any).id = '123';
 		});
@@ -148,7 +152,10 @@ describe('Web3SubscriptionManager', () => {
 		});
 
 		it('should try to subscribe the subscription', async () => {
-			sub = new ExampleSubscription({ param1: 'param1' }, subManager);
+			sub = new ExampleSubscription(
+				{ param1: 'param1' },
+				{ subscriptionManager: subManager },
+			);
 			jest.spyOn(sub, 'sendSubscriptionRequest').mockImplementation(async () => {
 				(sub as any).id = 'value';
 				return Promise.resolve(sub.id as string);
@@ -174,7 +181,10 @@ describe('Web3SubscriptionManager', () => {
 		beforeEach(async () => {
 			subManager = new Web3SubscriptionManager(requestManager, subscriptions);
 			jest.spyOn(subManager, 'supportsSubscriptions').mockReturnValue(true);
-			sub = new ExampleSubscription({ param1: 'param1' }, subManager);
+			sub = new ExampleSubscription(
+				{ param1: 'param1' },
+				{ subscriptionManager: subManager },
+			);
 
 			(sub as any).id = '123';
 			await subManager.addSubscription(sub);

--- a/packages/web3-core/test/unit/web3_subscription_manager.test.ts
+++ b/packages/web3-core/test/unit/web3_subscription_manager.test.ts
@@ -26,35 +26,54 @@ const subscriptions = { example: ExampleSubscription as never };
 
 describe('Web3SubscriptionManager', () => {
 	let requestManager: any;
+	let subManager: Web3SubscriptionManager<any, any>;
 
 	beforeEach(() => {
-		requestManager = { send: jest.fn(), on: jest.fn(), provider: jest.fn() };
+		requestManager = {
+			send: jest.fn().mockImplementation(async () => {
+				return 'sub-id';
+			}),
+			on: jest.fn(),
+			provider: { on: jest.fn() },
+		};
+		subManager = new Web3SubscriptionManager(requestManager, subscriptions);
 		(ExampleSubscription as jest.Mock).mockClear();
 	});
 
 	describe('constructor', () => {
 		it('should create subscription manager object', () => {
-			const subManager = new Web3SubscriptionManager(requestManager, {});
+			subManager = new Web3SubscriptionManager(requestManager, {});
 			expect(subManager).toBeInstanceOf(Web3SubscriptionManager);
 		});
 
 		it('should create register events for request manager', () => {
-			const subManager = new Web3SubscriptionManager(requestManager, {});
+			const requestMan: any = {
+				send: jest.fn(),
+				on: jest.fn(),
+				provider: {
+					on: jest
+						.fn()
+						.mockImplementation((_: string, callback: (a: string) => unknown) =>
+							callback('something'),
+						),
+				},
+			};
+			const subscriptionMan = new Web3SubscriptionManager(requestMan, {});
 
-			expect(subManager).toBeDefined();
-			expect(requestManager.on).toHaveBeenCalledTimes(2);
-			expect(requestManager.on).toHaveBeenCalledWith(
+			expect(subscriptionMan).toBeDefined();
+			expect(requestMan.on).toHaveBeenCalledTimes(2);
+			expect(requestMan.on).toHaveBeenCalledWith(
 				Web3RequestManagerEvent.BEFORE_PROVIDER_CHANGE,
 				expect.any(Function),
 			);
-			expect(requestManager.on).toHaveBeenCalledWith(
+			expect(requestMan.on).toHaveBeenCalledWith(
 				Web3RequestManagerEvent.PROVIDER_CHANGED,
 				expect.any(Function),
 			);
 		});
 
 		it('should register the subscription types', () => {
-			const subManager = new Web3SubscriptionManager(requestManager, {
+			subManager = new Web3SubscriptionManager(requestManager, {
 				example: ExampleSubscription as never,
 			});
 
@@ -63,8 +82,6 @@ describe('Web3SubscriptionManager', () => {
 	});
 
 	describe('subscribe', () => {
-		let subManager: Web3SubscriptionManager<any, any>;
-
 		beforeEach(() => {
 			subManager = new Web3SubscriptionManager(requestManager, subscriptions);
 
@@ -93,33 +110,31 @@ describe('Web3SubscriptionManager', () => {
 		});
 
 		it('should return valid subscription type if subscribed', async () => {
-			jest.spyOn(subManager, 'addSubscription').mockResolvedValue();
+			jest.spyOn(subManager, 'addSubscription').mockResolvedValue('123');
 			const result = await subManager.subscribe('example');
 
 			expect(result).toBeInstanceOf(ExampleSubscription);
 		});
 
 		it('should initialize subscription with valid args', async () => {
-			jest.spyOn(subManager, 'addSubscription').mockResolvedValue();
+			jest.spyOn(subManager, 'addSubscription').mockResolvedValue('456');
 			const result = await subManager.subscribe('example', { test1: 'test1' });
 
 			expect(result).toBeInstanceOf(ExampleSubscription);
 			expect(ExampleSubscription).toHaveBeenCalledTimes(1);
-			expect(ExampleSubscription).toHaveBeenCalledWith(
-				{ test1: 'test1' },
-				{ requestManager, returnFormat: DEFAULT_RETURN_FORMAT },
-			);
+			expect(ExampleSubscription).toHaveBeenCalledWith({ test1: 'test1' }, subManager, {
+				returnFormat: DEFAULT_RETURN_FORMAT,
+			});
 		});
 	});
 
 	describe('addSubscription', () => {
-		let subManager: Web3SubscriptionManager<any, any>;
 		let sub: ExampleSubscription;
 
 		beforeEach(() => {
 			subManager = new Web3SubscriptionManager(requestManager, subscriptions);
 			jest.spyOn(subManager, 'supportsSubscriptions').mockReturnValue(true);
-			sub = new ExampleSubscription({ param1: 'param1' }, { requestManager });
+			sub = new ExampleSubscription({ param1: 'param1' }, subManager);
 
 			(sub as any).id = '123';
 		});
@@ -133,10 +148,15 @@ describe('Web3SubscriptionManager', () => {
 		});
 
 		it('should try to subscribe the subscription', async () => {
+			sub = new ExampleSubscription({ param1: 'param1' }, subManager);
+			jest.spyOn(sub, 'sendSubscriptionRequest').mockImplementation(async () => {
+				(sub as any).id = 'value';
+				return Promise.resolve(sub.id as string);
+			});
 			await subManager.addSubscription(sub);
 
-			expect(sub.subscribe).toHaveBeenCalledTimes(1);
-			expect(sub.subscribe).toHaveBeenCalledWith();
+			expect(sub.sendSubscriptionRequest).toHaveBeenCalledTimes(1);
+			expect(sub.sendSubscriptionRequest).toHaveBeenCalledWith();
 		});
 
 		it('should set the subscription to the map', async () => {
@@ -149,13 +169,12 @@ describe('Web3SubscriptionManager', () => {
 	});
 
 	describe('removeSubscription', () => {
-		let subManager: Web3SubscriptionManager<any, any>;
 		let sub: ExampleSubscription;
 
 		beforeEach(async () => {
 			subManager = new Web3SubscriptionManager(requestManager, subscriptions);
 			jest.spyOn(subManager, 'supportsSubscriptions').mockReturnValue(true);
-			sub = new ExampleSubscription({ param1: 'param1' }, { requestManager });
+			sub = new ExampleSubscription({ param1: 'param1' }, subManager);
 
 			(sub as any).id = '123';
 			await subManager.addSubscription(sub);
@@ -180,8 +199,8 @@ describe('Web3SubscriptionManager', () => {
 		it('should try to unsubscribe the subscription', async () => {
 			await subManager.removeSubscription(sub);
 
-			expect(sub.unsubscribe).toHaveBeenCalledTimes(1);
-			expect(sub.unsubscribe).toHaveBeenCalledWith();
+			expect(sub.sendUnsubscribeRequest).toHaveBeenCalledTimes(1);
+			expect(sub.sendUnsubscribeRequest).toHaveBeenCalledWith();
 		});
 
 		it('should remove the subscription to the map', async () => {

--- a/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
+++ b/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
@@ -63,7 +63,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
-			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
+			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			provider.emit('data', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data.result);
 		});
@@ -79,7 +79,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
-			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
+			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			provider.emit('data', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data);
 		});
@@ -97,7 +97,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
-			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
+			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			eipProvider.emit('message', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data.result);
 		});
@@ -116,7 +116,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
-			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
+			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			eipProvider.emit('message', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data);
 		});

--- a/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
+++ b/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
@@ -17,10 +17,13 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 import { ExampleSubscription } from './fixtures/example_subscription';
 import { Web3EventEmitter } from '../../src/web3_event_emitter';
+import { Web3SubscriptionManager } from '../../src';
 
 describe('Web3Subscription', () => {
 	let requestManager: any;
+	let subscriptionManager: Web3SubscriptionManager<any, any>;
 	let eipRequestManager: any;
+	let subscriptionManagerWithEipReqMan: Web3SubscriptionManager<any, any>;
 	let provider: Web3EventEmitter<any>;
 	let eipProvider: Web3EventEmitter<any>;
 
@@ -29,76 +32,91 @@ describe('Web3Subscription', () => {
 		eipProvider = new Web3EventEmitter();
 		// @ts-expect-error add to test eip providers
 		eipProvider.request = jest.fn();
-		requestManager = { send: jest.fn(), on: jest.fn(), provider };
-		eipRequestManager = { send: jest.fn(), on: jest.fn(), provider: eipProvider };
+		requestManager = {
+			send: jest.fn().mockImplementation(async () => {
+				return 'sub-id';
+			}),
+			on: jest.fn(),
+			provider,
+		};
+		subscriptionManager = new Web3SubscriptionManager(requestManager, {});
+
+		eipRequestManager = {
+			send: jest.fn().mockImplementation(async () => {
+				return 'sub-id';
+			}),
+			on: jest.fn(),
+			provider: eipProvider,
+		};
+		subscriptionManagerWithEipReqMan = new Web3SubscriptionManager(eipRequestManager, {});
 	});
 
 	describe('providers response for old provider', () => {
 		it('data with result', async () => {
+			const sub = new ExampleSubscription({ param1: 'param1' }, subscriptionManager);
+			await sub.subscribe();
 			const testData = {
 				data: {
+					subscription: sub.id,
 					result: {
 						some: 1,
 					},
 				},
 			};
-			const sub = new ExampleSubscription({ param1: 'param1' }, { requestManager });
-			await sub.subscribe();
-			// @ts-expect-error spy on protected method
-			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
+			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
 			provider.emit('data', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data.result);
 		});
 
 		it('data without result for old provider', async () => {
+			const sub = new ExampleSubscription({ param1: 'param1' }, subscriptionManager);
+			await sub.subscribe();
 			const testData = {
 				data: {
+					subscription: sub.id,
 					other: {
 						some: 1,
 					},
 				},
 			};
-			const sub = new ExampleSubscription({ param1: 'param1' }, { requestManager });
-			await sub.subscribe();
-			// @ts-expect-error spy on protected method
-			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
+			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
 			provider.emit('data', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data);
 		});
 		it('data with result for eipProvider', async () => {
+			const sub = new ExampleSubscription(
+				{ param1: 'param1' },
+				subscriptionManagerWithEipReqMan,
+			);
+			await sub.subscribe();
 			const testData = {
 				data: {
+					subscription: sub.id,
 					result: {
 						some: 1,
 					},
 				},
 			};
-			const sub = new ExampleSubscription(
-				{ param1: 'param1' },
-				{ requestManager: eipRequestManager },
-			);
-			await sub.subscribe();
-			// @ts-expect-error spy on protected method
-			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
+			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
 			eipProvider.emit('message', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data.result);
 		});
 
 		it('data without result for eipProvider', async () => {
+			const sub = new ExampleSubscription(
+				{ param1: 'param1' },
+				subscriptionManagerWithEipReqMan,
+			);
+			await sub.subscribe();
 			const testData = {
 				data: {
+					subscription: sub.id,
 					other: {
 						some: 1,
 					},
 				},
 			};
-			const sub = new ExampleSubscription(
-				{ param1: 'param1' },
-				{ requestManager: eipRequestManager },
-			);
-			await sub.subscribe();
-			// @ts-expect-error spy on protected method
-			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
+			const processResult = jest.spyOn(sub, 'processSubscriptionResult');
 			eipProvider.emit('message', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data);
 		});

--- a/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
+++ b/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
@@ -63,6 +63,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
+			// @ts-expect-error spy on protected method
 			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			provider.emit('data', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data.result);
@@ -79,6 +80,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
+			// @ts-expect-error spy on protected method
 			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			provider.emit('data', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data);
@@ -97,6 +99,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
+			// @ts-expect-error spy on protected method
 			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			eipProvider.emit('message', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data.result);
@@ -116,6 +119,7 @@ describe('Web3Subscription', () => {
 					},
 				},
 			};
+			// @ts-expect-error spy on protected method
 			const processResult = jest.spyOn(sub, '_processSubscriptionResult');
 			eipProvider.emit('message', testData);
 			expect(processResult).toHaveBeenCalledWith(testData.data);

--- a/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
+++ b/packages/web3-core/test/unit/web3_subscription_old_providers.test.ts
@@ -53,7 +53,7 @@ describe('Web3Subscription', () => {
 
 	describe('providers response for old provider', () => {
 		it('data with result', async () => {
-			const sub = new ExampleSubscription({ param1: 'param1' }, subscriptionManager);
+			const sub = new ExampleSubscription({ param1: 'param1' }, { subscriptionManager });
 			await sub.subscribe();
 			const testData = {
 				data: {
@@ -70,7 +70,7 @@ describe('Web3Subscription', () => {
 		});
 
 		it('data without result for old provider', async () => {
-			const sub = new ExampleSubscription({ param1: 'param1' }, subscriptionManager);
+			const sub = new ExampleSubscription({ param1: 'param1' }, { subscriptionManager });
 			await sub.subscribe();
 			const testData = {
 				data: {
@@ -88,7 +88,7 @@ describe('Web3Subscription', () => {
 		it('data with result for eipProvider', async () => {
 			const sub = new ExampleSubscription(
 				{ param1: 'param1' },
-				subscriptionManagerWithEipReqMan,
+				{ subscriptionManager: subscriptionManagerWithEipReqMan },
 			);
 			await sub.subscribe();
 			const testData = {
@@ -108,7 +108,7 @@ describe('Web3Subscription', () => {
 		it('data without result for eipProvider', async () => {
 			const sub = new ExampleSubscription(
 				{ param1: 'param1' },
-				subscriptionManagerWithEipReqMan,
+				{ subscriptionManager: subscriptionManagerWithEipReqMan },
 			);
 			await sub.subscribe();
 			const testData = {

--- a/packages/web3-eth-accounts/test/config/setup.js
+++ b/packages/web3-eth-accounts/test/config/setup.js
@@ -22,3 +22,7 @@ require('jest-extended');
 // @todo extend jest to have "toHaveBeenCalledOnceWith" matcher.
 
 process.env.NODE_ENV = 'test';
+
+const jestTimeout = 10000;
+
+jest.setTimeout(jestTimeout);

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -15,7 +15,13 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Web3Context, Web3EventEmitter, Web3PromiEvent, Web3ConfigEvent } from 'web3-core';
+import {
+	Web3Context,
+	Web3EventEmitter,
+	Web3PromiEvent,
+	Web3ConfigEvent,
+	Web3SubscriptionManager,
+} from 'web3-core';
 import {
 	ContractExecutionError,
 	ContractTransactionDataAndInputError,
@@ -1140,7 +1146,11 @@ export class Contract<Abi extends ContractAbi>
 					abi,
 					jsonInterface: this._jsonInterface,
 				},
-				{ requestManager: this.requestManager, returnFormat },
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+				this.subscriptionManager as Web3SubscriptionManager<any, any>,
+				{
+					returnFormat,
+				},
 			);
 			if (!isNullish(fromBlock)) {
 				// emit past events when fromBlock is defined

--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -1146,9 +1146,12 @@ export class Contract<Abi extends ContractAbi>
 					abi,
 					jsonInterface: this._jsonInterface,
 				},
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-				this.subscriptionManager as Web3SubscriptionManager<any, any>,
 				{
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+					subscriptionManager: this.subscriptionManager as Web3SubscriptionManager<
+						unknown,
+						any
+					>,
 					returnFormat,
 				},
 			);

--- a/packages/web3-eth-contract/src/log_subscription.ts
+++ b/packages/web3-eth-contract/src/log_subscription.ts
@@ -132,7 +132,7 @@ export class LogsSubscription extends Web3Subscription<
 		];
 	}
 
-	public processSubscriptionResult(data: LogsInput): void {
+	public _processSubscriptionResult(data: LogsInput): void {
 		const decoded = decodeEventABI(this.abi, data, this.jsonInterface, super.returnFormat);
 		this.emit('data', decoded);
 	}

--- a/packages/web3-eth-contract/src/log_subscription.ts
+++ b/packages/web3-eth-contract/src/log_subscription.ts
@@ -16,7 +16,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { AbiEventFragment, LogsInput, HexString, Topic, DataFormat } from 'web3-types';
-import { Web3RequestManager, Web3Subscription } from 'web3-core';
+import { Web3Subscription, Web3SubscriptionManager } from 'web3-core';
 // eslint-disable-next-line import/no-cycle
 import { decodeEventABI } from './encoding.js';
 // eslint-disable-next-line import/no-cycle
@@ -112,12 +112,12 @@ export class LogsSubscription extends Web3Subscription<
 			abi: AbiEventFragment & { signature: HexString };
 			jsonInterface: ContractAbiWithSignature;
 		},
+		subscriptionManager: Web3SubscriptionManager,
 		options: {
-			requestManager: Web3RequestManager;
 			returnFormat?: DataFormat;
 		},
 	) {
-		super(args, options);
+		super(args, subscriptionManager, options);
 
 		this.address = args.address;
 		this.topics = args.topics;
@@ -132,7 +132,7 @@ export class LogsSubscription extends Web3Subscription<
 		];
 	}
 
-	protected _processSubscriptionResult(data: LogsInput): void {
+	public processSubscriptionResult(data: LogsInput): void {
 		const decoded = decodeEventABI(this.abi, data, this.jsonInterface, super.returnFormat);
 		this.emit('data', decoded);
 	}

--- a/packages/web3-eth-contract/src/log_subscription.ts
+++ b/packages/web3-eth-contract/src/log_subscription.ts
@@ -132,7 +132,7 @@ export class LogsSubscription extends Web3Subscription<
 		];
 	}
 
-	public _processSubscriptionResult(data: LogsInput): void {
+	protected _processSubscriptionResult(data: LogsInput): void {
 		const decoded = decodeEventABI(this.abi, data, this.jsonInterface, super.returnFormat);
 		this.emit('data', decoded);
 	}

--- a/packages/web3-eth-contract/src/log_subscription.ts
+++ b/packages/web3-eth-contract/src/log_subscription.ts
@@ -16,7 +16,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { AbiEventFragment, LogsInput, HexString, Topic, DataFormat } from 'web3-types';
-import { Web3Subscription, Web3SubscriptionManager } from 'web3-core';
+import { Web3RequestManager, Web3Subscription, Web3SubscriptionManager } from 'web3-core';
 // eslint-disable-next-line import/no-cycle
 import { decodeEventABI } from './encoding.js';
 // eslint-disable-next-line import/no-cycle
@@ -112,12 +112,14 @@ export class LogsSubscription extends Web3Subscription<
 			abi: AbiEventFragment & { signature: HexString };
 			jsonInterface: ContractAbiWithSignature;
 		},
-		subscriptionManager: Web3SubscriptionManager,
-		options: {
+		options: (
+			| { subscriptionManager: Web3SubscriptionManager }
+			| { requestManager: Web3RequestManager }
+		) & {
 			returnFormat?: DataFormat;
 		},
 	) {
-		super(args, subscriptionManager, options);
+		super(args, options);
 
 		this.address = args.address;
 		this.topics = args.topics;

--- a/packages/web3-eth-contract/src/log_subscription.ts
+++ b/packages/web3-eth-contract/src/log_subscription.ts
@@ -112,6 +112,29 @@ export class LogsSubscription extends Web3Subscription<
 			abi: AbiEventFragment & { signature: HexString };
 			jsonInterface: ContractAbiWithSignature;
 		},
+		options: { subscriptionManager: Web3SubscriptionManager; returnFormat?: DataFormat },
+	);
+	/**
+	 * @deprecated This constructor overloading should not be used
+	 */
+	public constructor(
+		args: {
+			address?: HexString;
+			// eslint-disable-next-line @typescript-eslint/ban-types
+			topics?: (Topic | Topic[] | null)[];
+			abi: AbiEventFragment & { signature: HexString };
+			jsonInterface: ContractAbiWithSignature;
+		},
+		options: { requestManager: Web3RequestManager; returnFormat?: DataFormat },
+	);
+	public constructor(
+		args: {
+			address?: HexString;
+			// eslint-disable-next-line @typescript-eslint/ban-types
+			topics?: (Topic | Topic[] | null)[];
+			abi: AbiEventFragment & { signature: HexString };
+			jsonInterface: ContractAbiWithSignature;
+		},
 		options: (
 			| { subscriptionManager: Web3SubscriptionManager }
 			| { requestManager: Web3RequestManager }
@@ -119,7 +142,8 @@ export class LogsSubscription extends Web3Subscription<
 			returnFormat?: DataFormat;
 		},
 	) {
-		super(args, options);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+		super(args, options as any);
 
 		this.address = args.address;
 		this.topics = args.topics;

--- a/packages/web3-eth/src/web3_eth.ts
+++ b/packages/web3-eth/src/web3_eth.ts
@@ -1602,7 +1602,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 				this.getPastLogs(args)
 					.then(logs => {
 						for (const log of logs) {
-							subscription.processSubscriptionResult(log as LogsOutput);
+							subscription._processSubscriptionResult(log as LogsOutput);
 						}
 					})
 					.catch(e => {

--- a/packages/web3-eth/src/web3_eth.ts
+++ b/packages/web3-eth/src/web3_eth.ts
@@ -1590,11 +1590,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 		args?: ConstructorParameters<RegisteredSubscription[T]>[0],
 		returnFormat: ReturnType = DEFAULT_RETURN_FORMAT as ReturnType,
 	): Promise<InstanceType<RegisteredSubscription[T]>> {
-		const subscription = (await this.subscriptionManager?.subscribe(
-			name,
-			args,
-			returnFormat,
-		)) as InstanceType<RegisteredSubscription[T]>;
+		const subscription = await this.subscriptionManager?.subscribe(name, args, returnFormat);
 		if (
 			subscription instanceof LogsSubscription &&
 			name === 'logs' &&
@@ -1606,11 +1602,11 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 				this.getPastLogs(args)
 					.then(logs => {
 						for (const log of logs) {
-							subscription._processSubscriptionResult(log as LogsOutput);
+							subscription.processSubscriptionResult(log as LogsOutput);
 						}
 					})
 					.catch(e => {
-						subscription._processSubscriptionError(e as Error);
+						subscription.processSubscriptionError(e as Error);
 					});
 			});
 		}

--- a/packages/web3-eth/src/web3_eth.ts
+++ b/packages/web3-eth/src/web3_eth.ts
@@ -1606,7 +1606,7 @@ export class Web3Eth extends Web3Context<Web3EthExecutionAPI, RegisteredSubscrip
 						}
 					})
 					.catch(e => {
-						subscription.processSubscriptionError(e as Error);
+						subscription._processSubscriptionError(e as Error);
 					});
 			});
 		}

--- a/packages/web3-eth/src/web3_subscriptions.ts
+++ b/packages/web3-eth/src/web3_subscriptions.ts
@@ -58,11 +58,11 @@ export class LogsSubscription extends Web3Subscription<
 		return ['logs', this.args] as ['logs', any];
 	}
 
-	public _processSubscriptionResult(data: LogsOutput) {
+	public processSubscriptionResult(data: LogsOutput) {
 		this.emit('data', format(logSchema, data, super.returnFormat));
 	}
 
-	public _processSubscriptionError(error: Error) {
+	public processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }
@@ -87,11 +87,11 @@ export class NewPendingTransactionsSubscription extends Web3Subscription<
 		return ['newPendingTransactions'] as ['newPendingTransactions'];
 	}
 
-	protected _processSubscriptionResult(data: string) {
+	public processSubscriptionResult(data: string) {
 		this.emit('data', format({ format: 'string' }, data, super.returnFormat));
 	}
 
-	protected _processSubscriptionError(error: Error) {
+	public processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }
@@ -135,11 +135,11 @@ export class NewHeadsSubscription extends Web3Subscription<
 		return ['newHeads'] as ['newHeads'];
 	}
 
-	protected _processSubscriptionResult(data: BlockHeaderOutput) {
+	public processSubscriptionResult(data: BlockHeaderOutput) {
 		this.emit('data', format(blockHeaderSchema, data, super.returnFormat));
 	}
 
-	protected _processSubscriptionError(error: Error) {
+	public processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }
@@ -174,7 +174,7 @@ export class SyncingSubscription extends Web3Subscription<
 		return ['syncing'] as ['syncing'];
 	}
 
-	protected _processSubscriptionResult(
+	public processSubscriptionResult(
 		data:
 			| {
 					syncing: boolean;
@@ -197,7 +197,7 @@ export class SyncingSubscription extends Web3Subscription<
 		}
 	}
 
-	protected _processSubscriptionError(error: Error) {
+	public processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }

--- a/packages/web3-eth/src/web3_subscriptions.ts
+++ b/packages/web3-eth/src/web3_subscriptions.ts
@@ -62,7 +62,7 @@ export class LogsSubscription extends Web3Subscription<
 		this.emit('data', format(logSchema, data, super.returnFormat));
 	}
 
-	public processSubscriptionError(error: Error) {
+	protected _processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }
@@ -91,7 +91,7 @@ export class NewPendingTransactionsSubscription extends Web3Subscription<
 		this.emit('data', format({ format: 'string' }, data, super.returnFormat));
 	}
 
-	public processSubscriptionError(error: Error) {
+	protected _processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }
@@ -139,7 +139,7 @@ export class NewHeadsSubscription extends Web3Subscription<
 		this.emit('data', format(blockHeaderSchema, data, super.returnFormat));
 	}
 
-	public processSubscriptionError(error: Error) {
+	protected _processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }
@@ -197,7 +197,7 @@ export class SyncingSubscription extends Web3Subscription<
 		}
 	}
 
-	public processSubscriptionError(error: Error) {
+	protected _processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }

--- a/packages/web3-eth/src/web3_subscriptions.ts
+++ b/packages/web3-eth/src/web3_subscriptions.ts
@@ -58,11 +58,11 @@ export class LogsSubscription extends Web3Subscription<
 		return ['logs', this.args] as ['logs', any];
 	}
 
-	public processSubscriptionResult(data: LogsOutput) {
+	public _processSubscriptionResult(data: LogsOutput) {
 		this.emit('data', format(logSchema, data, super.returnFormat));
 	}
 
-	protected _processSubscriptionError(error: Error) {
+	public _processSubscriptionError(error: Error) {
 		this.emit('error', error);
 	}
 }
@@ -87,7 +87,7 @@ export class NewPendingTransactionsSubscription extends Web3Subscription<
 		return ['newPendingTransactions'] as ['newPendingTransactions'];
 	}
 
-	public processSubscriptionResult(data: string) {
+	protected _processSubscriptionResult(data: string) {
 		this.emit('data', format({ format: 'string' }, data, super.returnFormat));
 	}
 
@@ -135,7 +135,7 @@ export class NewHeadsSubscription extends Web3Subscription<
 		return ['newHeads'] as ['newHeads'];
 	}
 
-	public processSubscriptionResult(data: BlockHeaderOutput) {
+	protected _processSubscriptionResult(data: BlockHeaderOutput) {
 		this.emit('data', format(blockHeaderSchema, data, super.returnFormat));
 	}
 
@@ -174,7 +174,7 @@ export class SyncingSubscription extends Web3Subscription<
 		return ['syncing'] as ['syncing'];
 	}
 
-	public processSubscriptionResult(
+	protected _processSubscriptionResult(
 		data:
 			| {
 					syncing: boolean;

--- a/packages/web3-eth/test/integration/setup.js
+++ b/packages/web3-eth/test/integration/setup.js
@@ -19,6 +19,6 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('../config/setup');
 
-const jestTimeout = process.env.WEB3_SYSTEM_TEST_PROVIDER.includes('ipc') ? 30000 : 20000;
+const jestTimeout = process.env.WEB3_SYSTEM_TEST_PROVIDER.includes('ipc') ? 60000 : 50000;
 
 jest.setTimeout(jestTimeout);

--- a/packages/web3-eth/test/integration/subscription_heads.test.ts
+++ b/packages/web3-eth/test/integration/subscription_heads.test.ts
@@ -43,9 +43,9 @@ describeIf(isSocket)('subscription', () => {
 			let times = 0;
 			const pr = new Promise((resolve: Resolve, reject) => {
 				sub.on('data', (data: BlockHeaderOutput) => {
-					if (data.parentHash) {
-						times += 1;
-					}
+					expect(typeof data.parentHash).toBe('string');
+
+					times += 1;
 					expect(times).toBeGreaterThanOrEqual(times);
 					if (times >= checkTxCount) {
 						resolve();
@@ -65,12 +65,25 @@ describeIf(isSocket)('subscription', () => {
 			await web3.eth.subscriptionManager?.removeSubscription(sub);
 			await closeOpenConnection(web3.eth);
 		});
-		it(`clear`, async () => {
+		it(`remove at subscriptionManager`, async () => {
 			const web3Eth = new Web3Eth(clientUrl);
 			await waitForOpenConnection(web3Eth);
 			const sub: NewHeadsSubscription = await web3Eth.subscribe('newHeads');
 			expect(sub.id).toBeDefined();
+			const subId = sub.id as string;
 			await web3Eth.subscriptionManager?.removeSubscription(sub);
+			expect(web3Eth.subscriptionManager.subscriptions.has(subId)).toBe(false);
+			expect(sub.id).toBeUndefined();
+			await closeOpenConnection(web3Eth);
+		});
+		it(`remove at subscribe object`, async () => {
+			const web3Eth = new Web3Eth(clientUrl);
+			await waitForOpenConnection(web3Eth);
+			const sub: NewHeadsSubscription = await web3Eth.subscribe('newHeads');
+			expect(sub.id).toBeDefined();
+			const subId = sub.id as string;
+			await sub.unsubscribe();
+			expect(web3Eth.subscriptionManager.subscriptions.has(subId)).toBe(false);
 			expect(sub.id).toBeUndefined();
 			await closeOpenConnection(web3Eth);
 		});

--- a/packages/web3-eth/test/integration/subscription_on_2_events.test.ts
+++ b/packages/web3-eth/test/integration/subscription_on_2_events.test.ts
@@ -1,0 +1,114 @@
+/*
+This file is part of web3.js.
+
+web3.js is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+web3.js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { BlockHeaderOutput, Web3 } from 'web3';
+import {
+	closeOpenConnection,
+	describeIf,
+	getSystemTestProvider,
+	isSocket,
+	sendFewSampleTxs,
+	waitForOpenConnection,
+} from '../fixtures/system_test_utils';
+import { Resolve } from './helper';
+
+const checkTxCount = 2;
+describeIf(isSocket)('subscription on multiple events', () => {
+	test(`catch the data of pendingTransactions and newHeads`, async () => {
+		const web3 = new Web3(getSystemTestProvider());
+		const web3Eth = web3.eth;
+		await waitForOpenConnection(web3Eth);
+		const pendingTransactionsSub = await web3Eth.subscribe('pendingTransactions');
+
+		let pendingTransactionsCount = 0;
+		const pendingTransactionsData = new Promise((resolve: Resolve, reject) => {
+			(() => {
+				pendingTransactionsSub.on('data', (data: string) => {
+					expect(typeof data).toBe('string');
+
+					pendingTransactionsCount += 1;
+					if (pendingTransactionsCount >= checkTxCount) {
+						resolve();
+					}
+				});
+				pendingTransactionsSub.on('error', error => {
+					reject(error);
+				});
+			})();
+		});
+
+		const newHeadsSub = await web3.eth.subscribe('newHeads');
+		let newHeadsCount = 0;
+		const newHeadsData = new Promise((resolve: Resolve, reject) => {
+			newHeadsSub.on('data', (data: BlockHeaderOutput) => {
+				expect(typeof data.parentHash).toBe('string');
+
+				newHeadsCount += 1;
+				if (newHeadsCount >= checkTxCount) {
+					resolve();
+				}
+			});
+			newHeadsSub.on('error', error => {
+				reject(error);
+			});
+		});
+
+		await sendFewSampleTxs(2);
+
+		await pendingTransactionsData;
+		await newHeadsData;
+
+		await closeOpenConnection(web3Eth);
+	});
+
+	test(`catch the data of an event even after subscribing off another one`, async () => {
+		const web3 = new Web3(getSystemTestProvider());
+		const web3Eth = web3.eth;
+		await waitForOpenConnection(web3Eth);
+		const pendingTransactionsSub = await web3Eth.subscribe('pendingTransactions');
+
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		pendingTransactionsSub.on('data', () => {});
+		pendingTransactionsSub.on('error', error => {
+			throw error;
+		});
+
+		const newHeadsSub = await web3.eth.subscribe('newHeads');
+		let times = 0;
+		const newHeadsData = new Promise((resolve: Resolve, reject) => {
+			newHeadsSub.on('data', (data: BlockHeaderOutput) => {
+				expect(typeof data.parentHash).toBe('string');
+
+				times += 1;
+				if (times >= checkTxCount) {
+					resolve();
+				}
+			});
+			newHeadsSub.on('error', error => {
+				reject(error);
+			});
+		});
+
+		await pendingTransactionsSub.unsubscribe();
+
+		await sendFewSampleTxs(2);
+
+		await newHeadsData;
+
+		await closeOpenConnection(web3Eth);
+	});
+});

--- a/packages/web3-eth/test/unit/web3_eth_subscription.test.ts
+++ b/packages/web3-eth/test/unit/web3_eth_subscription.test.ts
@@ -45,7 +45,7 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 		expect(logs).toStrictEqual(dummyLogs);
 	});
 
-	it('should call `processSubscriptionResult` when the logs are of type LogsSubscription and the `fromBlock` is provided', async () => {
+	it('should call `_processSubscriptionResult` when the logs are of type LogsSubscription and the `fromBlock` is provided', async () => {
 		const requestManager = { send: jest.fn(), on: jest.fn(), provider: { on: jest.fn() } };
 		const subManager = new Web3SubscriptionManager(requestManager as any, undefined as any);
 
@@ -59,7 +59,7 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 			} as unknown as Web3BaseProvider,
 			subscriptionManager: subManager,
 		});
-		jest.spyOn(dummyLogs, 'processSubscriptionResult');
+		jest.spyOn(dummyLogs, '_processSubscriptionResult');
 
 		const logs = await web3Eth.subscribe('logs', {
 			fromBlock: 0,
@@ -67,7 +67,7 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 		await sleep(100);
 
 		expect(logs).toStrictEqual(dummyLogs);
-		expect(dummyLogs.processSubscriptionResult).toHaveBeenCalled();
+		expect(dummyLogs._processSubscriptionResult).toHaveBeenCalled();
 	});
 
 	it('should be able to clear subscriptions', async () => {

--- a/packages/web3-eth/test/unit/web3_eth_subscription.test.ts
+++ b/packages/web3-eth/test/unit/web3_eth_subscription.test.ts
@@ -14,7 +14,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
-import { Web3RequestManager, Web3SubscriptionManager } from 'web3-core';
+import { Web3SubscriptionManager } from 'web3-core';
 import { Web3BaseProvider } from 'web3-types';
 import * as rpcMethodWrappers from '../../src/rpc_method_wrappers';
 import { LogsSubscription } from '../../src';
@@ -28,7 +28,7 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 	let web3Eth: Web3Eth;
 
 	it('should return the subscription data provided by the Subscription Manager', async () => {
-		const requestManager = { send: jest.fn(), on: jest.fn(), provider: jest.fn() };
+		const requestManager = { send: jest.fn(), on: jest.fn(), provider: { on: jest.fn() } };
 
 		const subManager = new Web3SubscriptionManager(requestManager as any, undefined as any);
 		const dummyLogs = { logs: { test1: 'test1' } };
@@ -45,16 +45,11 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 		expect(logs).toStrictEqual(dummyLogs);
 	});
 
-	it('should call `_processSubscriptionResult` when the logs are of type LogsSubscription and the `fromBlock` is provided', async () => {
-		const requestManager = { send: jest.fn(), on: jest.fn(), provider: jest.fn() };
+	it('should call `processSubscriptionResult` when the logs are of type LogsSubscription and the `fromBlock` is provided', async () => {
+		const requestManager = { send: jest.fn(), on: jest.fn(), provider: { on: jest.fn() } };
 		const subManager = new Web3SubscriptionManager(requestManager as any, undefined as any);
 
-		const dummyLogs = new LogsSubscription(
-			{},
-			{
-				requestManager: requestManager as unknown as Web3RequestManager,
-			},
-		);
+		const dummyLogs = new LogsSubscription({}, subManager);
 		jest.spyOn(subManager, 'subscribe').mockResolvedValueOnce(dummyLogs);
 		jest.spyOn(rpcMethodWrappers, 'getLogs').mockResolvedValueOnce(mockGetLogsRpcResponse);
 
@@ -64,7 +59,7 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 			} as unknown as Web3BaseProvider,
 			subscriptionManager: subManager,
 		});
-		jest.spyOn(dummyLogs, '_processSubscriptionResult');
+		jest.spyOn(dummyLogs, 'processSubscriptionResult');
 
 		const logs = await web3Eth.subscribe('logs', {
 			fromBlock: 0,
@@ -72,11 +67,11 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 		await sleep(100);
 
 		expect(logs).toStrictEqual(dummyLogs);
-		expect(dummyLogs._processSubscriptionResult).toHaveBeenCalled();
+		expect(dummyLogs.processSubscriptionResult).toHaveBeenCalled();
 	});
 
 	it('should be able to clear subscriptions', async () => {
-		const requestManager = { send: jest.fn(), on: jest.fn(), provider: jest.fn() };
+		const requestManager = { send: jest.fn(), on: jest.fn(), provider: { on: jest.fn() } };
 		const subManager = new Web3SubscriptionManager(requestManager as any, undefined as any);
 
 		jest.spyOn(subManager, 'unsubscribe');
@@ -94,7 +89,7 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 	});
 
 	it('should be able to clear subscriptions and pass `shouldClearSubscription` when passing `notClearSyncing`', async () => {
-		const requestManager = { send: jest.fn(), on: jest.fn(), provider: jest.fn() };
+		const requestManager = { send: jest.fn(), on: jest.fn(), provider: { on: jest.fn() } };
 		const subManager = new Web3SubscriptionManager(requestManager as any, undefined as any);
 
 		jest.spyOn(subManager, 'unsubscribe');

--- a/packages/web3-eth/test/unit/web3_eth_subscription.test.ts
+++ b/packages/web3-eth/test/unit/web3_eth_subscription.test.ts
@@ -49,7 +49,7 @@ describe('Web3Eth subscribe and clear subscriptions', () => {
 		const requestManager = { send: jest.fn(), on: jest.fn(), provider: { on: jest.fn() } };
 		const subManager = new Web3SubscriptionManager(requestManager as any, undefined as any);
 
-		const dummyLogs = new LogsSubscription({}, subManager);
+		const dummyLogs = new LogsSubscription({}, { subscriptionManager: subManager });
 		jest.spyOn(subManager, 'subscribe').mockResolvedValueOnce(dummyLogs);
 		jest.spyOn(rpcMethodWrappers, 'getLogs').mockResolvedValueOnce(mockGetLogsRpcResponse);
 

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -121,6 +121,15 @@ Documentation:
 
 ## [Unreleased]
 
+### Added
+
+-   Added the `SimpleProvider` interface which has only `request(args)` method that is compatible with EIP-1193 (#6210)
+-   Added the `Eip1193EventName` type that contains the possible events names according to EIP-1193 (#6210)
+
+### Changed
+
+-   The `EIP1193Provider` class has now all the events (for `on` and `removeListener`) according to EIP-1193 (#6210)
+
 ### Fixed
 
 -   Fixed bug #6185, now web3.js compiles on typescript v5 (#6195)

--- a/packages/web3-types/src/web3_base_provider.ts
+++ b/packages/web3-types/src/web3_base_provider.ts
@@ -108,12 +108,25 @@ export type ProviderChainId = string;
 
 export type ProviderAccounts = string[];
 
+export type Eip1193EventName =
+	| 'connect'
+	| 'disconnect'
+	| 'message'
+	| 'chainChanged'
+	| 'accountsChanged';
+
 export interface EIP1193Provider<API extends Web3APISpec> extends SimpleProvider<API> {
 	on(event: 'connect', listener: (info: ProviderInfo) => void): void;
 	on(event: 'disconnect', listener: (error: ProviderRpcError) => void): void;
 	on(event: 'message', listener: (message: ProviderMessage) => void): void;
 	on(event: 'chainChanged', listener: (chainId: ProviderChainId) => void): void;
 	on(event: 'accountsChanged', listener: (accounts: ProviderAccounts) => void): void;
+
+	removeListener(event: 'connect', listener: (info: ProviderInfo) => void): void;
+	removeListener(event: 'disconnect', listener: (error: ProviderRpcError) => void): void;
+	removeListener(event: 'message', listener: (message: ProviderMessage) => void): void;
+	removeListener(event: 'chainChanged', listener: (chainId: ProviderChainId) => void): void;
+	removeListener(event: 'accountsChanged', listener: (accounts: ProviderAccounts) => void): void;
 }
 
 // Provider interface compatible with EIP-1193

--- a/packages/web3-types/src/web3_base_provider.ts
+++ b/packages/web3-types/src/web3_base_provider.ts
@@ -94,6 +94,12 @@ export interface LegacyRequestProvider {
 	): void;
 }
 
+export interface SimpleProvider<API extends Web3APISpec> {
+	request<Method extends Web3APIMethod<API>, ResponseType = Web3APIReturnType<API, Method>>(
+		args: Web3APIPayload<API, Method>,
+	): Promise<JsonRpcResponseWithResult<ResponseType> | unknown>;
+}
+
 export interface ProviderInfo {
 	chainId: string;
 }
@@ -102,16 +108,12 @@ export type ProviderChainId = string;
 
 export type ProviderAccounts = string[];
 
-export interface EIP1193Provider<API extends Web3APISpec> {
+export interface EIP1193Provider<API extends Web3APISpec> extends SimpleProvider<API> {
 	on(event: 'connect', listener: (info: ProviderInfo) => void): void;
 	on(event: 'disconnect', listener: (error: ProviderRpcError) => void): void;
 	on(event: 'message', listener: (message: ProviderMessage) => void): void;
 	on(event: 'chainChanged', listener: (chainId: ProviderChainId) => void): void;
 	on(event: 'accountsChanged', listener: (accounts: ProviderAccounts) => void): void;
-
-	request<Method extends Web3APIMethod<API>, ResponseType = Web3APIReturnType<API, Method>>(
-		args: Web3APIPayload<API, Method>,
-	): Promise<JsonRpcResponseWithResult<ResponseType> | unknown>;
 }
 
 // Provider interface compatible with EIP-1193
@@ -258,7 +260,8 @@ export type SupportedProviders<API extends Web3APISpec = Web3EthExecutionAPI> =
 	| Web3BaseProvider<API>
 	| LegacyRequestProvider
 	| LegacySendProvider
-	| LegacySendAsyncProvider;
+	| LegacySendAsyncProvider
+	| SimpleProvider<API>;
 
 export type Web3BaseProviderConstructor = new <API extends Web3APISpec>(
 	url: string,

--- a/packages/web3-types/src/web3_base_provider.ts
+++ b/packages/web3-types/src/web3_base_provider.ts
@@ -94,7 +94,21 @@ export interface LegacyRequestProvider {
 	): void;
 }
 
+export interface ProviderInfo {
+	chainId: string;
+}
+
+export type ProviderChainId = string;
+
+export type ProviderAccounts = string[];
+
 export interface EIP1193Provider<API extends Web3APISpec> {
+	on(event: 'connect', listener: (info: ProviderInfo) => void): void;
+	on(event: 'disconnect', listener: (error: ProviderRpcError) => void): void;
+	on(event: 'message', listener: (message: ProviderMessage) => void): void;
+	on(event: 'chainChanged', listener: (chainId: ProviderChainId) => void): void;
+	on(event: 'accountsChanged', listener: (accounts: ProviderAccounts) => void): void;
+
 	request<Method extends Web3APIMethod<API>, ResponseType = Web3APIReturnType<API, Method>>(
 		args: Web3APIPayload<API, Method>,
 	): Promise<JsonRpcResponseWithResult<ResponseType> | unknown>;

--- a/packages/web3-utils/src/socket_provider.ts
+++ b/packages/web3-utils/src/socket_provider.ts
@@ -16,6 +16,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 import {
 	ConnectionEvent,
+	Eip1193EventName,
 	EthExecutionAPI,
 	JsonRpcBatchRequest,
 	JsonRpcBatchResponse,
@@ -223,8 +224,11 @@ export abstract class SocketProvider<
 		listener: Web3Eip1193ProviderEventCallback<unknown> | Web3ProviderEventCallback<T>,
 	): void;
 	public on<T = JsonRpcResult, P = unknown>(
-		type: string | 'disconnect' | 'connect' | 'chainChanged' | 'accountsChanged',
-		listener: Web3Eip1193ProviderEventCallback<P> | Web3ProviderEventCallback<T>,
+		type: string | Eip1193EventName,
+		listener:
+			| Web3Eip1193ProviderEventCallback<P>
+			| Web3ProviderMessageEventCallback<T>
+			| Web3ProviderEventCallback<T>,
 	): void {
 		this._eventEmitter.on(type, listener);
 	}
@@ -249,15 +253,20 @@ export abstract class SocketProvider<
 	): void;
 	public once<T = JsonRpcResult>(
 		type: 'message',
-		listener: Web3Eip1193ProviderEventCallback<ProviderMessage> | Web3ProviderEventCallback<T>,
+		listener:
+			| Web3Eip1193ProviderEventCallback<ProviderMessage>
+			| Web3ProviderMessageEventCallback<T>,
 	): void;
 	public once<T = JsonRpcResult>(
 		type: string,
 		listener: Web3Eip1193ProviderEventCallback<unknown> | Web3ProviderEventCallback<T>,
 	): void;
 	public once<T = JsonRpcResult, P = unknown>(
-		type: string | 'disconnect' | 'connect' | 'chainChanged' | 'accountsChanged',
-		listener: Web3Eip1193ProviderEventCallback<P> | Web3ProviderEventCallback<T>,
+		type: string | Eip1193EventName,
+		listener:
+			| Web3Eip1193ProviderEventCallback<P>
+			| Web3ProviderMessageEventCallback<T>
+			| Web3ProviderEventCallback<T>,
 	): void {
 		this._eventEmitter.once(type, listener);
 	}
@@ -285,15 +294,20 @@ export abstract class SocketProvider<
 	): void;
 	public removeListener<T = JsonRpcResult>(
 		type: 'message',
-		listener: Web3Eip1193ProviderEventCallback<ProviderMessage> | Web3ProviderEventCallback<T>,
+		listener:
+			| Web3Eip1193ProviderEventCallback<ProviderMessage>
+			| Web3ProviderMessageEventCallback<T>,
 	): void;
 	public removeListener<T = JsonRpcResult>(
 		type: string,
 		listener: Web3Eip1193ProviderEventCallback<unknown> | Web3ProviderEventCallback<T>,
 	): void;
 	public removeListener<T = JsonRpcResult, P = unknown>(
-		type: string | 'disconnect' | 'connect' | 'chainChanged' | 'accountsChanged',
-		listener: Web3Eip1193ProviderEventCallback<P> | Web3ProviderEventCallback<T>,
+		type: string | Eip1193EventName,
+		listener:
+			| Web3Eip1193ProviderEventCallback<P>
+			| Web3ProviderMessageEventCallback<T>
+			| Web3ProviderEventCallback<T>,
 	): void {
 		this._eventEmitter.removeListener(type, listener);
 	}

--- a/packages/web3/test/e2e/e2e_utils.ts
+++ b/packages/web3/test/e2e/e2e_utils.ts
@@ -52,7 +52,7 @@ export const getE2ETestAccountAddress = (): string => {
 
 export const getE2ETestContractAddress = () =>
 	secrets[getSystemTestBackend().toUpperCase() as 'SEPOLIA' | 'MAINNET']
-		.DEPLOYED_TEST_CONTRACT_ADDRESS;
+		.DEPLOYED_TEST_CONTRACT_ADDRESS as string;
 
 export const getAllowedSendTransaction = (): boolean => {
 	if (process.env.ALLOWED_SEND_TRANSACTION !== undefined) {

--- a/packages/web3/test/e2e/e2e_utils.ts
+++ b/packages/web3/test/e2e/e2e_utils.ts
@@ -51,6 +51,7 @@ export const getE2ETestAccountAddress = (): string => {
 };
 
 export const getE2ETestContractAddress = () =>
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 	secrets[getSystemTestBackend().toUpperCase() as 'SEPOLIA' | 'MAINNET']
 		.DEPLOYED_TEST_CONTRACT_ADDRESS as string;
 


### PR DESCRIPTION
## Description
Identified issues:
-   Subscribing to multiple blockchain events causes every listener to be fired for every registered event
-   Unsubscribe at a Web3Subscription class will still have the id of the subscription at the Web3SubscriptionManager
-   A call to the provider is made for every subscription object. (This means, in case of multiple creating of subscription objects, multiple subscriptions are made at the provider for each subscription type).


Refactor subscription's logic

-   `Web3Subscription` constructor now accepts `Web3SubscriptionManager` (as an alternative to accepting `Web3RequestManager` that is now marked as deprecated)
-   `Web3Subscription` constructor overloading that accepts `Web3SubscriptionManager` is marked as deprecated
  - Moved subscribing to provider events from  `Web3Subscription` to `Web3SubscriptionManager`
  - `subscribe` and `unsubscribe` called at `Web3Subscription` now is the same as calling them on `Web3SubscriptionManager`
   - `Web3Subscription` is lined now to `Web3SubscriptionManager` instead of directly to `Web3RequestManager`
   - Added the `SimpleProvider` interface which has only `request(args)` method that is compatible with EIP-1193
-   Added the `Eip1193EventName` type that contains the possible events names according to EIP-1193
-   The `EIP1193Provider` class has now all the events (for `on` and `removeListener`) according to EIP-1193

 - update test cases ...


Fixes: #6202


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
