### PR TITLE
Ensure `r` and `s` returned by `signTransaction` to have 64 character

### DIFF
--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -107,3 +107,7 @@ Documentation:
 [Migration Guide from 1.x](https://docs.web3js.org/guides/web3_upgrade_guide/x/)
 
 ## [Unreleased]
+
+### Fixed
+
+-   Fixed "The `r` and `s` returned by `signTransaction` to does not always consist of 64 characters #6207" (#6216)

--- a/packages/web3-eth-accounts/src/account.ts
+++ b/packages/web3-eth-accounts/src/account.ts
@@ -271,8 +271,8 @@ export const signTransaction = async (
 	return {
 		messageHash: bytesToHex(signedTx.getMessageToSign(true)),
 		v: `0x${signedTx.v.toString(16)}`,
-		r: `0x${signedTx.r.toString(16)}`,
-		s: `0x${signedTx.s.toString(16)}`,
+		r: `0x${signedTx.r.toString(16).padStart(64, '0')}`,
+		s: `0x${signedTx.s.toString(16).padStart(64, '0')}`,
 		rawTransaction: rawTx,
 		transactionHash: bytesToHex(txHash),
 	};

--- a/packages/web3-eth-accounts/test/unit/account.test.ts
+++ b/packages/web3-eth-accounts/test/unit/account.test.ts
@@ -104,9 +104,9 @@ describe('accounts', () => {
 			expect(signedResult.messageHash).toBeDefined();
 			expect(signedResult.rawTransaction).toBeDefined();
 			expect(signedResult.transactionHash).toBeDefined();
-			expect(signedResult.r).toBeDefined();
-			expect(signedResult.s).toBeDefined();
-			expect(signedResult.v).toBeDefined();
+			expect(signedResult.r).toMatch(/0[xX][0-9a-fA-F]{64}/);
+			expect(signedResult.s).toMatch(/0[xX][0-9a-fA-F]{64}/);
+			expect(signedResult.v).toMatch(/0[xX][0-9a-fA-F]+/);
 		});
 
 		it.each(transactionsTestData)('Recover transaction', async txData => {

--- a/packages/web3-eth/test/integration/web3_eth/sign_transaction.test.ts
+++ b/packages/web3-eth/test/integration/web3_eth/sign_transaction.test.ts
@@ -61,8 +61,8 @@ describe('Web3Eth.signTransaction', () => {
 		// Pulling out of toMatchObject to be compatiable with Cypress
 		expect(response.raw).toMatch(/0[xX][0-9a-fA-F]+/);
 		expect(typeof (response.tx as TransactionLegacySignedAPI).v).toBe('bigint');
-		expect(response.tx.r).toMatch(/0[xX][0-9a-fA-F]+/);
-		expect(response.tx.s).toMatch(/0[xX][0-9a-fA-F]+/);
+		expect(response.tx.r).toMatch(/0[xX][0-9a-fA-F]{64}/);
+		expect(response.tx.s).toMatch(/0[xX][0-9a-fA-F]{64}/);
 	});
 
 	it('should sign a contract deployment', async () => {
@@ -90,7 +90,7 @@ describe('Web3Eth.signTransaction', () => {
 		// Pulling out of toMatchObject to be compatiable with Cypress
 		expect(response.raw).toMatch(/0[xX][0-9a-fA-F]+/);
 		expect(typeof (response.tx as TransactionLegacySignedAPI).v).toBe('bigint');
-		expect(response.tx.r).toMatch(/0[xX][0-9a-fA-F]+/);
-		expect(response.tx.s).toMatch(/0[xX][0-9a-fA-F]+/);
+		expect(response.tx.r).toMatch(/0[xX][0-9a-fA-F]{64}/);
+		expect(response.tx.s).toMatch(/0[xX][0-9a-fA-F]{64}/);
 	});
 });


### PR DESCRIPTION

## Description

Fixes #6207

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
