### PR TITLE
Release/4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1697,13 +1697,82 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.0.3]
 
+### Fixed
+
+#### web3
+
+-   Fixed bug #6236 by adding personal type in web3.eth (#6245)
+
+#### web3-rpc-methods
+
+-   Rpc method `getPastLogs` accept blockHash as a parameter https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs (#6181)
+
+#### web3-types
+
+-   type `Filter` includes `blockHash` (#6206)
 
 #### web3-utils
 
 -   BigInts pass validation within the method `numberToHex` (#6206)
 
-#### web3-rpc-methods
+### Changed
 
--   Rpc method `getPastLogs` accept blockHash as a parameter https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs (#6181)
+#### web3-core
+
+-   Dependencies updated
+
+#### web3-errors
+
+-   Dependencies updated
+
+#### web3-eth
+
+-   Dependencies updated
+
+#### web3-eth-abi
+
+-   Dependencies updated
+
+#### web3-eth-accounts
+
+-   Dependencies updated
+
+#### web3-eth-contract
+
+-   Dependencies updated
+
+#### web3-eth-ens
+
+-   Dependencies updated
+
+#### web3-eth-iban
+
+-   Dependencies updated
+
+#### web3-eth-personal
+
+-   Dependencies updated
+
+#### web3-net
+
+-   Dependencies updated
+
+#### web3-providers-http
+
+-   Dependencies updated
+
+#### web3-providers-ipc
+
+-   Dependencies updated
+
+#### web3-providers-ws
+
+-   Dependencies updated
+
+#### web3-validator
+
+-   Dependencies updated
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -136,4 +136,10 @@ Documentation:
 -   Fixed the issue: Unsubscribe at a Web3Subscription class will still have the id of the subscription at the Web3SubscriptionManager (#6210)
 -   Fixed the issue: A call to the provider is made for every subscription object (#6210)
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,16 +42,16 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.1",
-		"web3-eth-iban": "^4.0.2",
-		"web3-providers-http": "^4.0.2",
-		"web3-providers-ws": "^4.0.2",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-errors": "^1.0.2",
+		"web3-eth-iban": "^4.0.3",
+		"web3-providers-http": "^4.0.3",
+		"web3-providers-ws": "^4.0.3",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	},
 	"optionalDependencies": {
-		"web3-providers-ipc": "^4.0.2"
+		"web3-providers-ipc": "^4.0.3"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -124,4 +124,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [1.0.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.0.1"
+		"web3-types": "^1.0.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -118,4 +118,10 @@ Documentation:
 
 -   Support for "decoding" indexed string event arguments (returns the keccak256 hash of the string value instead of the actual string value) (#6167)
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -44,9 +44,9 @@
 	"dependencies": {
 		"@ethersproject/abi": "^5.7.0",
 		"@ethersproject/bignumber": "^5.7.0",
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2"
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -112,4 +112,10 @@ Documentation:
 
 -   Fixed "The `r` and `s` returned by `signTransaction` to does not always consist of 64 characters #6207" (#6216)
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -55,15 +55,15 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.2"
+		"web3-providers-ipc": "^4.0.3"
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -278,4 +278,10 @@ Documentation:
 
 -   Event filtering using non-indexed and indexed string event arguments (#6167)
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.2",
-		"web3-errors": "^1.0.1",
-		"web3-eth": "^4.0.2",
-		"web3-eth-abi": "^4.0.2",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-core": "^4.0.3",
+		"web3-errors": "^1.0.2",
+		"web3-eth": "^4.0.3",
+		"web3-eth-abi": "^4.0.3",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -67,6 +67,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.2"
+		"web3-eth-accounts": "^4.0.3"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -105,4 +105,10 @@ Documentation:
 
 -   Fixed bug #6185, now web3.js compiles on typescript v5 (#6195)
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.0.2",
-		"web3-errors": "^1.0.1",
-		"web3-eth": "^4.0.2",
-		"web3-eth-contract": "^4.0.2",
-		"web3-net": "^4.0.2",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-core": "^4.0.3",
+		"web3-errors": "^1.0.2",
+		"web3-eth": "^4.0.3",
+		"web3-eth-contract": "^4.0.3",
+		"web3-net": "^4.0.3",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -95,4 +95,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -111,4 +111,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,12 +42,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.2",
-		"web3-eth": "^4.0.2",
-		"web3-rpc-methods": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-core": "^4.0.3",
+		"web3-eth": "^4.0.3",
+		"web3-rpc-methods": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -62,6 +62,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.2"
+		"web3-providers-ws": "^4.0.3"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -155,4 +155,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -57,20 +57,20 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.0.2",
-		"web3-providers-http": "^4.0.2"
+		"web3-eth-abi": "^4.0.3",
+		"web3-providers-http": "^4.0.3"
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.0.2",
-		"web3-errors": "^1.0.1",
-		"web3-eth-abi": "^4.0.2",
-		"web3-eth-accounts": "^4.0.2",
-		"web3-net": "^4.0.2",
-		"web3-providers-ws": "^4.0.2",
-		"web3-rpc-methods": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-core": "^4.0.3",
+		"web3-errors": "^1.0.2",
+		"web3-eth-abi": "^4.0.3",
+		"web3-eth-accounts": "^4.0.3",
+		"web3-net": "^4.0.3",
+		"web3-providers-ws": "^4.0.3",
+		"web3-rpc-methods": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -111,4 +111,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.2",
-		"web3-rpc-methods": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2"
+		"web3-core": "^4.0.3",
+		"web3-rpc-methods": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -95,4 +95,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,8 +61,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2"
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -105,4 +105,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2"
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -98,4 +98,10 @@ Documentation:
 
 -   Fixed #6162 @types/ws issue (#6205)
 
+## [4.0.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
 	"dependencies": {
 		"@types/ws": "^8.5.3",
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -96,8 +96,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [1.0.2]
 
 ### Fixed
 
 -   Rpc method `getPastLogs` accept blockHash as a parameter https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs (#6181)
+
+## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.2",
-		"web3-types": "^1.0.1",
-		"web3-validator": "^1.0.1"
+		"web3-core": "^4.0.3",
+		"web3-types": "^1.0.2",
+		"web3-validator": "^1.0.2"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -134,8 +134,10 @@ Documentation:
 
 -   Fixed bug #6185, now web3.js compiles on typescript v5 (#6195)
 
-## [Unreleased]
+## [1.0.2]
 
 ### Fixed
 
 -   type `Filter` includes `blockHash` (#6206)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -134,8 +134,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.0.3]
 
 ### Fixed
 
 -   BigInts pass validation within the method `numberToHex` (#6206)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -60,8 +60,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-validator": "^1.0.1"
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-validator": "^1.0.2"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -114,4 +114,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [1.0.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -48,8 +48,8 @@
 		"ethereum-cryptography": "^2.0.0",
 		"is-my-json-valid": "^2.20.6",
 		"util": "^0.12.5",
-		"web3-errors": "^1.0.1",
-		"web3-types": "^1.0.1"
+		"web3-errors": "^1.0.2",
+		"web3-types": "^1.0.2"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -123,8 +123,10 @@ Documentation:
 -   Fixed bug #6185, now web3.js compiles on typescript v5 (#6195)
 -   Fixed #6162 @types/ws issue (#6205)
 
-## [Unreleased]
+## [4.0.3]
 
 ### Fixed
 
 -   Fixed bug #6236 by adding personal type in web3.eth (#6245)
+
+## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -77,24 +77,24 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.2"
+		"web3-providers-ipc": "^4.0.3"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.2",
-		"web3-errors": "^1.0.1",
-		"web3-eth": "^4.0.2",
-		"web3-eth-abi": "^4.0.2",
-		"web3-eth-accounts": "^4.0.2",
-		"web3-eth-contract": "^4.0.2",
-		"web3-eth-ens": "^4.0.2",
-		"web3-eth-iban": "^4.0.2",
-		"web3-eth-personal": "^4.0.2",
-		"web3-net": "^4.0.2",
-		"web3-providers-http": "^4.0.2",
-		"web3-providers-ws": "^4.0.2",
-		"web3-rpc-methods": "^1.0.1",
-		"web3-types": "^1.0.1",
-		"web3-utils": "^4.0.2",
-		"web3-validator": "^1.0.1"
+		"web3-core": "^4.0.3",
+		"web3-errors": "^1.0.2",
+		"web3-eth": "^4.0.3",
+		"web3-eth-abi": "^4.0.3",
+		"web3-eth-accounts": "^4.0.3",
+		"web3-eth-contract": "^4.0.3",
+		"web3-eth-ens": "^4.0.3",
+		"web3-eth-iban": "^4.0.3",
+		"web3-eth-personal": "^4.0.3",
+		"web3-net": "^4.0.3",
+		"web3-providers-http": "^4.0.3",
+		"web3-providers-ws": "^4.0.3",
+		"web3-rpc-methods": "^1.0.2",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3",
+		"web3-validator": "^1.0.2"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.2' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.3' };

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -64,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Stable release
 
-## [Unreleased]
+## [1.0.1]
+
+### Changed
+
+-   Dependencies updated
 
 ## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,18 +45,18 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.0.1",
-		"web3-core": "^4.0.1",
-		"web3-eth-abi": "^4.0.1",
-		"web3-eth-contract": "^4.0.1",
-		"web3-types": "^1.0.0",
-		"web3-utils": "^4.0.1"
+		"web3": "^4.0.3",
+		"web3-core": "^4.0.3",
+		"web3-eth-abi": "^4.0.3",
+		"web3-eth-contract": "^4.0.3",
+		"web3-types": "^1.0.2",
+		"web3-utils": "^4.0.3"
 	},
 	"peerDependencies": {
-		"web3-core": ">= 4.0.1 < 5",
-		"web3-eth-abi": ">= 4.0.1 < 5",
-		"web3-eth-contract": ">= 4.0.1 < 5",
-		"web3-types": ">= 1.0.0 < 5",
-		"web3-utils": ">= ^4.0.1 < 5"
+		"web3-core": ">= 4.0.3 < 5",
+		"web3-eth-abi": ">= 4.0.3 < 5",
+		"web3-eth-contract": ">= 4.0.3 < 5",
+		"web3-types": ">= 1.0.2 < 5",
+		"web3-utils": ">= ^4.0.3 < 5"
 	}
 }


### PR DESCRIPTION
## [4.0.3]

### Fixed

#### web3

-   Fixed bug #6236 by adding personal type in web3.eth (#6245)

#### web3-rpc-methods

-   Rpc method `getPastLogs` accept blockHash as a parameter https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs (#6181)

#### web3-types

-   type `Filter` includes `blockHash` (#6206)

#### web3-utils

-   BigInts pass validation within the method `numberToHex` (#6206)

### Changed

#### web3-core

-   Dependencies updated

#### web3-errors

-   Dependencies updated

#### web3-eth

-   Dependencies updated

#### web3-eth-abi

-   Dependencies updated

#### web3-eth-accounts

-   Dependencies updated

#### web3-eth-contract

-   Dependencies updated

#### web3-eth-ens

-   Dependencies updated

#### web3-eth-iban

-   Dependencies updated

#### web3-eth-personal

-   Dependencies updated

#### web3-net

-   Dependencies updated

#### web3-providers-http

-   Dependencies updated

#### web3-providers-ipc

-   Dependencies updated

#### web3-providers-ws

-   Dependencies updated

#### web3-validator

-   Dependencies updated