### PR TITLE
Release/4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1775,7 +1775,7 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.0]
 
 ### Added
 
@@ -1827,6 +1827,8 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 #### web3-eth
 
+-   sendTransaction will have gas filled by default using method `estimateGas` unless transaction builder `options.fillGas` is false. (#6249)
+-   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
 -   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
 
 #### web3-providers-ws
@@ -1844,11 +1846,48 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 #### web3-eth
 
+-   `MissingGasError` error message changed for clarity (#6215)
 -   `input` and `data` are no longer auto populated for transaction objects if they are not present. Instead, whichever property is provided by the user is formatted and sent to the RPC provider. Transaction objects returned from RPC responses are still formatted to contain both `input` and `data` properties (#6294)
+
+#### web3-eth-accounts
+
+-   Dependencies updated
+
+#### web3-eth-contract
+
+-   Dependencies updated
+
+#### web3-eth-ens
+
+-   Dependencies updated
+
+#### web3-eth-iban
+
+-   Dependencies updated
+
+#### web3-eth-personal
+
+-   Dependencies updated
+
+#### web3-net
+
+-   Dependencies updated
+
+#### web3-providers-http
+
+-   Dependencies updated
+
+#### web3-providers-ipc
+
+-   Dependencies updated
 
 #### web3-types
 
 -   `input` and `data` are now optional properties on `PopulatedUnsignedBaseTransaction` (previously `input` was a required property, and `data` was not available) (#6294)
+
+#### web3-utils
+
+-   Dependencies updated
 
 #### web3-validator
 
@@ -1865,3 +1904,5 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 #### web3-validator
 
 -   Type `RawValidationError` was removed (#6264)
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1779,9 +1779,19 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 ### Added
 
+#### web3
+
+-   Added minimum support of web3.extend function
+
+#### web3-core
+
+-   Added minimum support of web3.extend function
+
 #### web3-errors
 
 -   `RpcErrorMessages` that contains mapping for standard RPC Errors and their messages. (#6230)
+-   created `TransactionGasMismatchInnerError` for clarity on the error in `TransactionGasMismatchError` (#6215)
+-   created `MissingGasInnerError` for clarity on the error in `MissingGasError` (#6215)
 
 #### web3-eth
 
@@ -1818,6 +1828,10 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 #### web3-eth
 
 -   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
+
+#### web3-providers-ws
+
+-   Ensure a fixed version for "@types/ws": "8.5.3" (#6309)
 
 ### Changed
 

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -146,7 +146,7 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.0]
 
 ### Changed
 
@@ -162,3 +162,5 @@ Documentation:
 ### Added
 
 -   Added minimum support of web3.extend function
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -159,6 +159,6 @@ Documentation:
 
 -   Fixed the issue: "Version 4.x does not fire connected event for subscriptions. #6252". (#6262)
 
-## Added
+### Added
 
 -   Added minimum support of web3.extend function

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.0.3",
+	"version": "4.1.0-rc.0",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,16 +42,16 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.2",
-		"web3-eth-iban": "^4.0.3",
-		"web3-providers-http": "^4.0.3",
-		"web3-providers-ws": "^4.0.3",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-eth-iban": "^4.0.4-rc.0",
+		"web3-providers-http": "^4.0.4-rc.0",
+		"web3-providers-ws": "^4.0.4-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	},
 	"optionalDependencies": {
-		"web3-providers-ipc": "^4.0.3"
+		"web3-providers-ipc": "^4.0.4-rc.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.1.0-rc.0",
+	"version": "4.1.0",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,16 +42,16 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-eth-iban": "^4.0.4-rc.0",
-		"web3-providers-http": "^4.0.4-rc.0",
-		"web3-providers-ws": "^4.0.4-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-errors": "^1.1.0",
+		"web3-eth-iban": "^4.0.4",
+		"web3-providers-http": "^4.0.4",
+		"web3-providers-ws": "^4.0.4",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	},
 	"optionalDependencies": {
-		"web3-providers-ipc": "^4.0.4-rc.0"
+		"web3-providers-ipc": "^4.0.4"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -130,7 +130,7 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [1.1.0]
 
 ### Added
 
@@ -141,3 +141,5 @@ Documentation:
 ### Fixed
 
 -   Fixed: "'disconnect' in Eip1193 provider must emit ProviderRpcError #6003".(#6230)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.1.0-rc.0",
+	"version": "1.1.0",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.1.0-rc.0"
+		"web3-types": "^1.1.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.0.2",
+	"version": "1.1.0-rc.0",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.0.2"
+		"web3-types": "^1.1.0-rc.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -124,8 +124,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.0]
 
 ### Added
 
 -   A `getEncodedEip712Data` method that takes an EIP-712 typed data object and returns the encoded data with the option to also keccak256 hash it (#6286)
+
+## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.0.3",
+	"version": "4.1.0-rc.0",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -44,9 +44,9 @@
 	"dependencies": {
 		"@ethersproject/abi": "^5.7.0",
 		"@ethersproject/bignumber": "^5.7.0",
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3"
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.1.0-rc.0",
+	"version": "4.1.0",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -44,9 +44,9 @@
 	"dependencies": {
 		"@ethersproject/abi": "^5.7.0",
 		"@ethersproject/bignumber": "^5.7.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0"
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -118,4 +118,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -55,15 +55,15 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.3"
+		"web3-providers-ipc": "^4.0.4-rc.0"
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	}
 }

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -55,15 +55,15 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.4-rc.0"
+		"web3-providers-ipc": "^4.0.4"
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -284,4 +284,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0-rc.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-eth": "^4.1.0-rc.0",
-		"web3-eth-abi": "^4.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-core": "^4.1.0",
+		"web3-errors": "^1.1.0",
+		"web3-eth": "^4.1.0",
+		"web3-eth-abi": "^4.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -67,6 +67,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.4-rc.0"
+		"web3-eth-accounts": "^4.0.4"
 	}
 }

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.3",
-		"web3-errors": "^1.0.2",
-		"web3-eth": "^4.0.3",
-		"web3-eth-abi": "^4.0.3",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-core": "^4.1.0-rc.0",
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-eth": "^4.1.0-rc.0",
+		"web3-eth-abi": "^4.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -67,6 +67,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.3"
+		"web3-eth-accounts": "^4.0.4-rc.0"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -111,4 +111,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.0.3",
-		"web3-errors": "^1.0.2",
-		"web3-eth": "^4.0.3",
-		"web3-eth-contract": "^4.0.3",
-		"web3-net": "^4.0.3",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-core": "^4.1.0-rc.0",
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-eth": "^4.1.0-rc.0",
+		"web3-eth-contract": "^4.0.4-rc.0",
+		"web3-net": "^4.0.4-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	}
 }

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.1.0-rc.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-eth": "^4.1.0-rc.0",
-		"web3-eth-contract": "^4.0.4-rc.0",
-		"web3-net": "^4.0.4-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-core": "^4.1.0",
+		"web3-errors": "^1.1.0",
+		"web3-eth": "^4.1.0",
+		"web3-eth-contract": "^4.0.4",
+		"web3-net": "^4.0.4",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -101,4 +101,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	}
 }

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -117,4 +117,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,12 +42,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.3",
-		"web3-eth": "^4.0.3",
-		"web3-rpc-methods": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-core": "^4.1.0-rc.0",
+		"web3-eth": "^4.1.0-rc.0",
+		"web3-rpc-methods": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -62,6 +62,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.3"
+		"web3-providers-ws": "^4.0.4-rc.0"
 	}
 }

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,12 +42,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0-rc.0",
-		"web3-eth": "^4.1.0-rc.0",
-		"web3-rpc-methods": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-core": "^4.1.0",
+		"web3-eth": "^4.1.0",
+		"web3-rpc-methods": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -62,6 +62,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.4-rc.0"
+		"web3-providers-ws": "^4.0.4"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -161,27 +161,22 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.0]
 
 ### Fixed
 
 -   sendTransaction will have gas filled by default using method `estimateGas` unless transaction builder `options.fillGas` is false. (#6249)
 -   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
+-   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
 
 ### Changed
 
 -   `MissingGasError` error message changed for clarity (#6215)
--
+-   `input` and `data` are no longer auto populated for transaction objects if they are not present. Instead, whichever property is provided by the user is formatted and sent to the RPC provider. Transaction objects returned from RPC responses are still formatted to contain both `input` and `data` properties (#6294)
 
 ### Added
 
 -   A `rpc_method_wrapper` (`signTypedData`) for the rpc calls `eth_signTypedData` and `eth_signTypedData_v4` (#6286)
 -   A `signTypedData` method to the `Web3Eth` class (#6286)
 
-### Fixed
-
--   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
-
-### Changed
-
--   `input` and `data` are no longer auto populated for transaction objects if they are not present. Instead, whichever property is provided by the user is formatted and sent to the RPC provider. Transaction objects returned from RPC responses are still formatted to contain both `input` and `data` properties (#6294)
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.0.3",
+	"version": "4.1.0-rc.0",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,20 +59,20 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.0.3",
-		"web3-providers-http": "^4.0.3"
+		"web3-eth-abi": "^4.1.0-rc.0",
+		"web3-providers-http": "^4.0.4-rc.0"
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.0.3",
-		"web3-errors": "^1.0.2",
-		"web3-eth-abi": "^4.0.3",
-		"web3-eth-accounts": "^4.0.3",
-		"web3-net": "^4.0.3",
-		"web3-providers-ws": "^4.0.3",
-		"web3-rpc-methods": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-core": "^4.1.0-rc.0",
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-eth-abi": "^4.1.0-rc.0",
+		"web3-eth-accounts": "^4.0.4-rc.0",
+		"web3-net": "^4.0.4-rc.0",
+		"web3-providers-ws": "^4.0.4-rc.0",
+		"web3-rpc-methods": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	}
 }

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.1.0-rc.0",
+	"version": "4.1.0",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,20 +59,20 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.1.0-rc.0",
-		"web3-providers-http": "^4.0.4-rc.0"
+		"web3-eth-abi": "^4.1.0",
+		"web3-providers-http": "^4.0.4"
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.1.0-rc.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-eth-abi": "^4.1.0-rc.0",
-		"web3-eth-accounts": "^4.0.4-rc.0",
-		"web3-net": "^4.0.4-rc.0",
-		"web3-providers-ws": "^4.0.4-rc.0",
-		"web3-rpc-methods": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-core": "^4.1.0",
+		"web3-errors": "^1.1.0",
+		"web3-eth-abi": "^4.1.0",
+		"web3-eth-accounts": "^4.0.4",
+		"web3-net": "^4.0.4",
+		"web3-providers-ws": "^4.0.4",
+		"web3-rpc-methods": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -117,4 +117,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.3",
-		"web3-rpc-methods": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3"
+		"web3-core": "^4.1.0-rc.0",
+		"web3-rpc-methods": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0"
 	}
 }

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0-rc.0",
-		"web3-rpc-methods": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0"
+		"web3-core": "^4.1.0",
+		"web3-rpc-methods": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -101,4 +101,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,8 +61,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3"
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0"
 	}
 }

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,8 +61,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0"
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -111,4 +111,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3"
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0"
 	}
 }

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0"
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -104,8 +104,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.0.4]
 
 ### Fixed
 
 -   Ensure a fixed version for "@types/ws": "8.5.3" (#6309)
+
+## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
 	"dependencies": {
 		"@types/ws": "8.5.3",
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
 	"dependencies": {
 		"@types/ws": "8.5.3",
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -102,8 +102,10 @@ Documentation:
 
 -   Rpc method `getPastLogs` accept blockHash as a parameter https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs (#6181)
 
-## [Unreleased]
+## [1.1.0]
 
 ### Added
 
 -   A `signTypedData` method to `eth_rpc_methods` for the rpc calls `eth_signTypedData` and `eth_signTypedData_v4` (#6286)
+
+## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.0.2",
+	"version": "1.1.0-rc.0",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.3",
-		"web3-types": "^1.0.2",
-		"web3-validator": "^1.0.2"
+		"web3-core": "^4.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	}
 }

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.1.0-rc.0",
+	"version": "1.1.0",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-core": "^4.1.0",
+		"web3-types": "^1.1.0",
+		"web3-validator": "^2.0.0"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -140,7 +140,7 @@ Documentation:
 
 -   type `Filter` includes `blockHash` (#6206)
 
-## [Unreleased]
+## [1.1.0]
 
 ### Changed
 
@@ -150,3 +150,5 @@ Documentation:
 
 -   `eth_signTypedData` and `eth_signTypedData_v4` to `web3_eth_execution_api` (#6286)
 -   `Eip712TypeDetails` and `Eip712TypedData` to `eth_types` (#6286)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.1.0-rc.0",
+	"version": "1.1.0",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.0.2",
+	"version": "1.1.0-rc.0",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -140,4 +140,10 @@ Documentation:
 
 -   BigInts pass validation within the method `numberToHex` (#6206)
 
+## [4.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.4-rc.0",
+	"version": "4.0.4",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -60,8 +60,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-validator": "^2.0.0"
 	}
 }

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.3",
+	"version": "4.0.4-rc.0",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -60,8 +60,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-validator": "^1.0.2"
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -120,7 +120,7 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [2.0.0]
 
 ### Changed
 
@@ -134,3 +134,5 @@ Documentation:
 ### Added
 
 -   Added `json-schema` as a main json schema type (#6264)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "1.0.2",
+	"version": "2.0.0-rc.0",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -47,8 +47,8 @@
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
 		"util": "^0.12.5",
-		"web3-errors": "^1.0.2",
-		"web3-types": "^1.0.2",
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "2.0.0-rc.0",
+	"version": "2.0.0",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -47,8 +47,8 @@
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
 		"util": "^0.12.5",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
+		"web3-errors": "^1.1.0",
+		"web3-types": "^1.1.0",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -133,8 +133,10 @@ Documentation:
 
 -   Fixed bug #6236 by adding personal type in web3.eth (#6245)
 
-## [Unreleased]
+## [4.1.0]
 
 ### Added
 
 -   Added minimum support of web3.extend function
+
+## [Unreleased]

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -135,6 +135,6 @@ Documentation:
 
 ## [Unreleased]
 
-## Added
+### Added
 
 -   Added minimum support of web3.extend function

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.0.3",
+	"version": "4.1.0-rc.0",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -77,24 +77,24 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.3"
+		"web3-providers-ipc": "^4.0.4-rc.0"
 	},
 	"dependencies": {
-		"web3-core": "^4.0.3",
-		"web3-errors": "^1.0.2",
-		"web3-eth": "^4.0.3",
-		"web3-eth-abi": "^4.0.3",
-		"web3-eth-accounts": "^4.0.3",
-		"web3-eth-contract": "^4.0.3",
-		"web3-eth-ens": "^4.0.3",
-		"web3-eth-iban": "^4.0.3",
-		"web3-eth-personal": "^4.0.3",
-		"web3-net": "^4.0.3",
-		"web3-providers-http": "^4.0.3",
-		"web3-providers-ws": "^4.0.3",
-		"web3-rpc-methods": "^1.0.2",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3",
-		"web3-validator": "^1.0.2"
+		"web3-core": "^4.1.0-rc.0",
+		"web3-errors": "^1.1.0-rc.0",
+		"web3-eth": "^4.1.0-rc.0",
+		"web3-eth-abi": "^4.1.0-rc.0",
+		"web3-eth-accounts": "^4.0.4-rc.0",
+		"web3-eth-contract": "^4.0.4-rc.0",
+		"web3-eth-ens": "^4.0.4-rc.0",
+		"web3-eth-iban": "^4.0.4-rc.0",
+		"web3-eth-personal": "^4.0.4-rc.0",
+		"web3-net": "^4.0.4-rc.0",
+		"web3-providers-http": "^4.0.4-rc.0",
+		"web3-providers-ws": "^4.0.4-rc.0",
+		"web3-rpc-methods": "^1.1.0-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0",
+		"web3-validator": "^2.0.0-rc.0"
 	}
 }

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.1.0-rc.0",
+	"version": "4.1.0",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -77,24 +77,24 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.4-rc.0"
+		"web3-providers-ipc": "^4.0.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0-rc.0",
-		"web3-errors": "^1.1.0-rc.0",
-		"web3-eth": "^4.1.0-rc.0",
-		"web3-eth-abi": "^4.1.0-rc.0",
-		"web3-eth-accounts": "^4.0.4-rc.0",
-		"web3-eth-contract": "^4.0.4-rc.0",
-		"web3-eth-ens": "^4.0.4-rc.0",
-		"web3-eth-iban": "^4.0.4-rc.0",
-		"web3-eth-personal": "^4.0.4-rc.0",
-		"web3-net": "^4.0.4-rc.0",
-		"web3-providers-http": "^4.0.4-rc.0",
-		"web3-providers-ws": "^4.0.4-rc.0",
-		"web3-rpc-methods": "^1.1.0-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0",
-		"web3-validator": "^2.0.0-rc.0"
+		"web3-core": "^4.1.0",
+		"web3-errors": "^1.1.0",
+		"web3-eth": "^4.1.0",
+		"web3-eth-abi": "^4.1.0",
+		"web3-eth-accounts": "^4.0.4",
+		"web3-eth-contract": "^4.0.4",
+		"web3-eth-ens": "^4.0.4",
+		"web3-eth-iban": "^4.0.4",
+		"web3-eth-personal": "^4.0.4",
+		"web3-net": "^4.0.4",
+		"web3-providers-http": "^4.0.4",
+		"web3-providers-ws": "^4.0.4",
+		"web3-rpc-methods": "^1.1.0",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4",
+		"web3-validator": "^2.0.0"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.1.0-rc.0' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.1.0' };

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.0.3' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.1.0-rc.0' };

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -70,4 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Dependencies updated
 
+## [1.0.2]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,18 +45,18 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.0.3",
-		"web3-core": "^4.0.3",
-		"web3-eth-abi": "^4.0.3",
-		"web3-eth-contract": "^4.0.3",
-		"web3-types": "^1.0.2",
-		"web3-utils": "^4.0.3"
+		"web3": "^4.1.0-rc.0",
+		"web3-core": "^4.1.0-rc.0",
+		"web3-eth-abi": "^4.1.0-rc.0",
+		"web3-eth-contract": "^4.0.4-rc.0",
+		"web3-types": "^1.1.0-rc.0",
+		"web3-utils": "^4.0.4-rc.0"
 	},
 	"peerDependencies": {
-		"web3-core": ">= 4.0.3 < 5",
-		"web3-eth-abi": ">= 4.0.3 < 5",
-		"web3-eth-contract": ">= 4.0.3 < 5",
-		"web3-types": ">= 1.0.2 < 5",
-		"web3-utils": ">= ^4.0.3 < 5"
+		"web3-core": ">= 4.1.0-rc.0 < 5",
+		"web3-eth-abi": ">= 4.1.0-rc.0 < 5",
+		"web3-eth-contract": ">= 4.0.4-rc.0 < 5",
+		"web3-types": ">= 1.1.0-rc.0 < 5",
+		"web3-utils": ">= 4.0.4-rc.0 < 5"
 	}
 }

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,18 +45,18 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.1.0-rc.0",
-		"web3-core": "^4.1.0-rc.0",
-		"web3-eth-abi": "^4.1.0-rc.0",
-		"web3-eth-contract": "^4.0.4-rc.0",
-		"web3-types": "^1.1.0-rc.0",
-		"web3-utils": "^4.0.4-rc.0"
+		"web3": "^4.1.0",
+		"web3-core": "^4.1.0",
+		"web3-eth-abi": "^4.1.0",
+		"web3-eth-contract": "^4.0.4",
+		"web3-types": "^1.1.0",
+		"web3-utils": "^4.0.4"
 	},
 	"peerDependencies": {
-		"web3-core": ">= 4.1.0-rc.0 < 5",
-		"web3-eth-abi": ">= 4.1.0-rc.0 < 5",
-		"web3-eth-contract": ">= 4.0.4-rc.0 < 5",
-		"web3-types": ">= 1.1.0-rc.0 < 5",
-		"web3-utils": ">= 4.0.4-rc.0 < 5"
+		"web3-core": ">= 4.1.0 < 5",
+		"web3-eth-abi": ">= 4.1.0 < 5",
+		"web3-eth-contract": ">= 4.0.4 < 5",
+		"web3-types": ">= 1.1.0 < 5",
+		"web3-utils": ">= 4.0.4 < 5"
 	}
 }


### PR DESCRIPTION

### Added

#### web3

-   Added minimum support of web3.extend function

#### web3-core

-   Added minimum support of web3.extend function

#### web3-errors

-   `RpcErrorMessages` that contains mapping for standard RPC Errors and their messages. (#6230)
-   created `TransactionGasMismatchInnerError` for clarity on the error in `TransactionGasMismatchError` (#6215)
-   created `MissingGasInnerError` for clarity on the error in `MissingGasError` (#6215)

#### web3-eth

-   A `rpc_method_wrapper` (`signTypedData`) for the rpc calls `eth_signTypedData` and `eth_signTypedData_v4` (#6286)
-   A `signTypedData` method to the `Web3Eth` class (#6286)

#### web3-eth-abi

-   A `getEncodedEip712Data` method that takes an EIP-712 typed data object and returns the encoded data with the option to also keccak256 hash it (#6286)

#### web3-rpc-methods

-   A `signTypedData` method to `eth_rpc_methods` for the rpc calls `eth_signTypedData` and `eth_signTypedData_v4` (#6286)

#### web3-types

-   `eth_signTypedData` and `eth_signTypedData_v4` to `web3_eth_execution_api` (#6286)
-   `Eip712TypeDetails` and `Eip712TypedData` to `eth_types` (#6286)

#### web3-validator

-   Added `json-schema` as a main json schema type (#6264)

### Fixed

#### web3-core

-   Fixed the issue: "Version 4.x does not fire connected event for subscriptions. #6252". (#6262)

#### web3-errors

-   Fixed: "'disconnect' in Eip1193 provider must emit ProviderRpcError #6003".(#6230)

#### web3-eth

-   sendTransaction will have gas filled by default using method `estimateGas` unless transaction builder `options.fillGas` is false. (#6249)
-   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
-   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)

#### web3-providers-ws

-   Ensure a fixed version for "@types/ws": "8.5.3" (#6309)

### Changed

#### web3-core

-   No need to pass `CommonSubscriptionEvents &` at every child class of `Web3Subscription` (#6262)
-   Implementation of `_processSubscriptionResult` and `_processSubscriptionError` has been written in the base class `Web3Subscription` and maid `public`. (#6262)
-   A new optional protected method `formatSubscriptionResult` could be used to customize data formatting instead of re-implementing `_processSubscriptionResult`. (#6262)
-   No more needed to pass `CommonSubscriptionEvents & ` for the first generic parameter of `Web3Subscription` when inheriting from it. (#6262)

#### web3-eth

-   `MissingGasError` error message changed for clarity (#6215)
-   `input` and `data` are no longer auto populated for transaction objects if they are not present. Instead, whichever property is provided by the user is formatted and sent to the RPC provider. Transaction objects returned from RPC responses are still formatted to contain both `input` and `data` properties (#6294)

#### web3-eth-accounts

-   Dependencies updated

#### web3-eth-contract

-   Dependencies updated

#### web3-eth-ens

-   Dependencies updated

#### web3-eth-iban

-   Dependencies updated

#### web3-eth-personal

-   Dependencies updated

#### web3-net

-   Dependencies updated

#### web3-providers-http

-   Dependencies updated

#### web3-providers-ipc

-   Dependencies updated

#### web3-types

-   `input` and `data` are now optional properties on `PopulatedUnsignedBaseTransaction` (previously `input` was a required property, and `data` was not available) (#6294)

#### web3-utils

-   Dependencies updated

#### web3-validator

-   Replace `is-my-json-valid` with `zod` dependency. Related code was changed (#6264)
-   Types `ValidationError` and `JsonSchema` were changed (#6264)

### Removed

#### web3-eth

-   Missing `blockHeaderSchema` properties causing some properties to not appear in response of `newHeads` subscription (#6243)
-   Type `RawValidationError` was removed (#6264)

#### web3-validator

-   Type `RawValidationError` was removed (#6264)

