### PR TITLE
add inner error to errors on send 6300

### DIFF
--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -158,10 +158,13 @@ Documentation:
 ### Fixed
 
 -   Fixed the issue: "Version 4.x does not fire connected event for subscriptions. #6252". (#6262)
--   Fixed rpc errors not being sent as an inner error when using the `send` method on request manager (#6300).
 
 ### Added
 
 -   Added minimum support of web3.extend function
 
 ## [Unreleased]
+
+### Fixed
+
+-   Fixed rpc errors not being sent as an inner error when using the `send` method on request manager (#6300).

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -158,6 +158,7 @@ Documentation:
 ### Fixed
 
 -   Fixed the issue: "Version 4.x does not fire connected event for subscriptions. #6252". (#6262)
+-   Fixed rpc errors not being sent as an inner error when using the `send` method on request manager (#6300).
 
 ## Added
 

--- a/packages/web3-core/src/web3_request_manager.ts
+++ b/packages/web3-core/src/web3_request_manager.ts
@@ -156,7 +156,6 @@ export class Web3RequestManager<
 		ResponseType = Web3APIReturnType<API, Method>,
 	>(request: Web3APIRequest<API, Method>): Promise<ResponseType> {
 		const response = await this._sendRequest<Method, ResponseType>(request);
-
 		if (jsonRpc.isResponseWithResult(response)) {
 			return response.result;
 		}

--- a/packages/web3-errors/src/errors/response_errors.ts
+++ b/packages/web3-errors/src/errors/response_errors.ts
@@ -67,6 +67,14 @@ export class ResponseError<ErrorType = unknown, RequestType = unknown> extends B
 		}
 
 		this.request = request;
+		let errorOrErrors: JsonRpcError | JsonRpcError[] | undefined;
+		if (`error` in response) {
+			errorOrErrors = response.error as JsonRpcError;
+		} else if (response instanceof Array) {
+			errorOrErrors = response.map(r => r.error) as JsonRpcError[];
+		}
+
+		this.innerError = errorOrErrors as Error | Error[] | undefined;
 	}
 
 	public toJSON() {
@@ -84,7 +92,6 @@ export class InvalidResponseError<ErrorType = unknown, RequestType = unknown> ex
 	) {
 		super(result, undefined, request);
 		this.code = ERR_INVALID_RESPONSE;
-
 		let errorOrErrors: JsonRpcError | JsonRpcError[] | undefined;
 		if (`error` in result) {
 			errorOrErrors = result.error as JsonRpcError;

--- a/packages/web3-errors/test/unit/__snapshots__/errors.test.ts.snap
+++ b/packages/web3-errors/test/unit/__snapshots__/errors.test.ts.snap
@@ -256,7 +256,14 @@ Object {
     "a": "10",
     "b": "20",
   },
-  "innerError": undefined,
+  "innerError": Object {
+    "code": 123,
+    "data": Object {
+      "a": "10",
+      "b": "20",
+    },
+    "message": "error message",
+  },
   "message": "Returned error: error message",
   "name": "ResponseError",
   "request": undefined,
@@ -267,7 +274,11 @@ exports[`errors ResponseError should have valid json structure without data 1`] 
 Object {
   "code": 100,
   "data": undefined,
-  "innerError": undefined,
+  "innerError": Object {
+    "code": 123,
+    "data": undefined,
+    "message": "error message",
+  },
   "message": "Returned error: error message",
   "name": "ResponseError",
   "request": undefined,

--- a/packages/web3-errors/test/unit/__snapshots__/errors.test.ts.snap
+++ b/packages/web3-errors/test/unit/__snapshots__/errors.test.ts.snap
@@ -285,6 +285,43 @@ Object {
 }
 `;
 
+exports[`errors ResponseError should include the array of inner errors 1`] = `
+Object {
+  "code": 100,
+  "data": Array [
+    Object {
+      "a": "10",
+      "b": "20",
+    },
+    Object {
+      "c": "30",
+      "d": "40",
+    },
+  ],
+  "innerError": Array [
+    Object {
+      "code": 123,
+      "data": Object {
+        "a": "10",
+        "b": "20",
+      },
+      "message": "error message",
+    },
+    Object {
+      "code": 124,
+      "data": Object {
+        "c": "30",
+        "d": "40",
+      },
+      "message": "error message",
+    },
+  ],
+  "message": "Returned error: error message,error message",
+  "name": "ResponseError",
+  "request": undefined,
+}
+`;
+
 exports[`errors RevertInstructionError should have valid json structure 1`] = `
 Object {
   "code": 401,

--- a/packages/web3-errors/test/unit/errors.test.ts
+++ b/packages/web3-errors/test/unit/errors.test.ts
@@ -349,6 +349,23 @@ describe('errors', () => {
 				}).toJSON(),
 			).toMatchSnapshot();
 		});
+
+		it('should include the array of inner errors', () => {
+			expect(
+				new responseErrors.ResponseError([
+					{
+						id: 1,
+						jsonrpc: '2.0',
+						error: { code: 123, message: 'error message', data: { a: '10', b: '20' } },
+					},
+					{
+						id: 2,
+						jsonrpc: '2.0',
+						error: { code: 124, message: 'error message', data: { c: '30', d: '40' } },
+					},
+				]).toJSON(),
+			).toMatchSnapshot();
+		});
 	});
 
 	describe('InvalidResponseError', () => {


### PR DESCRIPTION
## Description
#6300 
Error objects that are returned from an RPC is not included in the error, making it an issue if a user wanted to keep track of this. For example when cancelling a send transaction on metamask, metamask will send back an error and code but we currently do not include that in the error.  This PR adds the error Object to be apart of the innerError property. 
Please include a summary of the changes and be sure to follow our [Contribution Guidelines](../CONTRIBUTIONS.md).

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
