### PR TITLE
Release/4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1905,4 +1905,92 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Type `RawValidationError` was removed (#6264)
 
+## [4.1.1]
+
+### Added
+
+#### web3
+
+-   To fix issue #6190, added the functionality to introduce different timeout value for Web3. (#6336)
+
+#### web3-core
+
+-   To fix issue #6190, added the functionality to introduce different timeout value for Web3. (#6336)
+
+#### web3-eth-contract
+
+-   In case of error events there will be inner error also available for details
+
+### Fixed
+
+#### web3-core
+
+-   Fixed rpc errors not being sent as an inner error when using the `send` method on request manager (#6300).
+
+#### web3-errors
+
+-   ESM import bug (#6359)
+
+#### web3-eth-contract
+
+-   Fixed bug in `contract.events.allEvents`
+
+#### web3-validator
+
+-   ESM import bug (#6359)
+
+### Changed
+
+#### web3-eth
+
+-   Dependencies updated
+
+#### web3-eth-abi
+
+-   Dependencies updated
+
+#### web3-eth-accounts
+
+-   Dependencies updated
+
+#### web3-eth-ens
+
+-   Dependencies updated
+
+#### web3-eth-iban
+
+-   Dependencies updated
+
+#### web3-eth-personal
+
+-   Dependencies updated
+
+#### web3-net
+
+-   Dependencies updated
+
+#### web3-providers-http
+
+-   Dependencies updated
+
+#### web3-providers-ipc
+
+-   Dependencies updated
+
+#### web3-providers-ws
+
+-   Dependencies updated
+
+#### web3-rpc-methods
+
+-   Dependencies updated
+
+#### web3-types
+
+-   Dependencies updated
+
+#### web3-utils
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1923,6 +1923,10 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 ### Fixed
 
+#### web3-eth
+
+-   Added return type for `formatSubscriptionResult` in class `NewHeadsSubscription` (#6368)
+
 #### web3-core
 
 -   Fixed rpc errors not being sent as an inner error when using the `send` method on request manager (#6300).
@@ -1940,10 +1944,6 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 -   ESM import bug (#6359)
 
 ### Changed
-
-#### web3-eth
-
--   Dependencies updated
 
 #### web3-eth-abi
 

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -163,7 +163,7 @@ Documentation:
 
 -   Added minimum support of web3.extend function
 
-## [Unreleased]
+## [4.1.1]
 
 ### Fixed
 
@@ -173,3 +173,4 @@ Documentation:
 
 -   To fix issue #6190, added the functionality to introduce different timeout value for Web3. (#6336)
 
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,16 +42,16 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.0",
-		"web3-eth-iban": "^4.0.4",
-		"web3-providers-http": "^4.0.4",
-		"web3-providers-ws": "^4.0.4",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-errors": "^1.1.1",
+		"web3-eth-iban": "^4.0.5",
+		"web3-providers-http": "^4.0.5",
+		"web3-providers-ws": "^4.0.5",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	},
 	"optionalDependencies": {
-		"web3-providers-ipc": "^4.0.4"
+		"web3-providers-ipc": "^4.0.5"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -142,8 +142,10 @@ Documentation:
 
 -   Fixed: "'disconnect' in Eip1193 provider must emit ProviderRpcError #6003".(#6230)
 
-## [Unreleased]
+## [1.1.1]
 
 ### Fixed
 
 -   ESM import bug (#6359)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.1.0"
+		"web3-types": "^1.1.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -130,4 +130,10 @@ Documentation:
 
 -   A `getEncodedEip712Data` method that takes an EIP-712 typed data object and returns the encoded data with the option to also keccak256 hash it (#6286)
 
+## [4.1.1]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -44,9 +44,9 @@
 	"dependencies": {
 		"@ethersproject/abi": "^5.7.0",
 		"@ethersproject/bignumber": "^5.7.0",
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4"
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -124,4 +124,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -55,15 +55,15 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.4"
+		"web3-providers-ipc": "^4.0.5"
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -290,7 +290,7 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.0.5]
 
 ### Fixed
 
@@ -299,3 +299,5 @@ Documentation:
 ### Added
 
 -   In case of error events there will be inner error also available for details
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0",
-		"web3-errors": "^1.1.0",
-		"web3-eth": "^4.1.0",
-		"web3-eth-abi": "^4.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-core": "^4.1.1",
+		"web3-errors": "^1.1.1",
+		"web3-eth": "^4.1.1",
+		"web3-eth-abi": "^4.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -67,6 +67,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.4"
+		"web3-eth-accounts": "^4.0.5"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -117,4 +117,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.1.0",
-		"web3-errors": "^1.1.0",
-		"web3-eth": "^4.1.0",
-		"web3-eth-contract": "^4.0.4",
-		"web3-net": "^4.0.4",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-core": "^4.1.1",
+		"web3-errors": "^1.1.1",
+		"web3-eth": "^4.1.1",
+		"web3-eth-contract": "^4.0.5",
+		"web3-net": "^4.0.5",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -107,4 +107,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -123,4 +123,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,12 +42,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0",
-		"web3-eth": "^4.1.0",
-		"web3-rpc-methods": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-core": "^4.1.1",
+		"web3-eth": "^4.1.1",
+		"web3-rpc-methods": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -62,6 +62,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.4"
+		"web3-providers-ws": "^4.0.5"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -179,4 +179,10 @@ Documentation:
 -   A `rpc_method_wrapper` (`signTypedData`) for the rpc calls `eth_signTypedData` and `eth_signTypedData_v4` (#6286)
 -   A `signTypedData` method to the `Web3Eth` class (#6286)
 
+## [4.1.1]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -181,12 +181,8 @@ Documentation:
 
 ## [4.1.1]
 
-### Changed
-
--   Dependencies updated
-
-## [Unreleased]
-
 ### Fixed
 
 -   Added return type for `formatSubscriptionResult` in class `NewHeadsSubscription` (#6368)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,20 +59,20 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-abi": "^4.1.0",
-		"web3-providers-http": "^4.0.4"
+		"web3-eth-abi": "^4.1.1",
+		"web3-providers-http": "^4.0.5"
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.1.0",
-		"web3-errors": "^1.1.0",
-		"web3-eth-abi": "^4.1.0",
-		"web3-eth-accounts": "^4.0.4",
-		"web3-net": "^4.0.4",
-		"web3-providers-ws": "^4.0.4",
-		"web3-rpc-methods": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-core": "^4.1.1",
+		"web3-errors": "^1.1.1",
+		"web3-eth-abi": "^4.1.1",
+		"web3-eth-accounts": "^4.0.5",
+		"web3-net": "^4.0.5",
+		"web3-providers-ws": "^4.0.5",
+		"web3-rpc-methods": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -123,4 +123,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0",
-		"web3-rpc-methods": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4"
+		"web3-core": "^4.1.1",
+		"web3-rpc-methods": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -107,4 +107,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,8 +61,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^3.1.5",
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4"
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -117,4 +117,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4"
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -110,4 +110,10 @@ Documentation:
 
 -   Ensure a fixed version for "@types/ws": "8.5.3" (#6309)
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
 	"dependencies": {
 		"@types/ws": "8.5.3",
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -108,4 +108,10 @@ Documentation:
 
 -   A `signTypedData` method to `eth_rpc_methods` for the rpc calls `eth_signTypedData` and `eth_signTypedData_v4` (#6286)
 
+## [1.1.1]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0",
-		"web3-types": "^1.1.0",
-		"web3-validator": "^2.0.0"
+		"web3-core": "^4.1.1",
+		"web3-types": "^1.1.1",
+		"web3-validator": "^2.0.1"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -151,4 +151,10 @@ Documentation:
 -   `eth_signTypedData` and `eth_signTypedData_v4` to `web3_eth_execution_api` (#6286)
 -   `Eip712TypeDetails` and `Eip712TypedData` to `eth_types` (#6286)
 
+## [1.1.1]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -146,4 +146,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.5]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.4",
+	"version": "4.0.5",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -60,8 +60,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-validator": "^2.0.0"
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-validator": "^2.0.1"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -135,8 +135,10 @@ Documentation:
 
 -   Added `json-schema` as a main json schema type (#6264)
 
-## [Unreleased]
+## [2.0.1]
 
 ### Fixed
 
 -   ESM import bug (#6359)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -47,8 +47,8 @@
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
 		"util": "^0.12.5",
-		"web3-errors": "^1.1.0",
-		"web3-types": "^1.1.0",
+		"web3-errors": "^1.1.1",
+		"web3-types": "^1.1.1",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -139,8 +139,10 @@ Documentation:
 
 -   Added minimum support of web3.extend function
 
-## [Unreleased]
+## [4.1.1]
 
 ### Added
 
 -   To fix issue #6190, added the functionality to introduce different timeout value for Web3. (#6336)
+
+## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -77,24 +77,24 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.4"
+		"web3-providers-ipc": "^4.0.5"
 	},
 	"dependencies": {
-		"web3-core": "^4.1.0",
-		"web3-errors": "^1.1.0",
-		"web3-eth": "^4.1.0",
-		"web3-eth-abi": "^4.1.0",
-		"web3-eth-accounts": "^4.0.4",
-		"web3-eth-contract": "^4.0.4",
-		"web3-eth-ens": "^4.0.4",
-		"web3-eth-iban": "^4.0.4",
-		"web3-eth-personal": "^4.0.4",
-		"web3-net": "^4.0.4",
-		"web3-providers-http": "^4.0.4",
-		"web3-providers-ws": "^4.0.4",
-		"web3-rpc-methods": "^1.1.0",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4",
-		"web3-validator": "^2.0.0"
+		"web3-core": "^4.1.1",
+		"web3-errors": "^1.1.1",
+		"web3-eth": "^4.1.1",
+		"web3-eth-abi": "^4.1.1",
+		"web3-eth-accounts": "^4.0.5",
+		"web3-eth-contract": "^4.0.5",
+		"web3-eth-ens": "^4.0.5",
+		"web3-eth-iban": "^4.0.5",
+		"web3-eth-personal": "^4.0.5",
+		"web3-net": "^4.0.5",
+		"web3-providers-http": "^4.0.5",
+		"web3-providers-ws": "^4.0.5",
+		"web3-rpc-methods": "^1.1.1",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5",
+		"web3-validator": "^2.0.1"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.1.0' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.1.1' };

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -76,4 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Dependencies updated
 
+## [1.0.4]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,18 +45,18 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.1.0",
-		"web3-core": "^4.1.0",
-		"web3-eth-abi": "^4.1.0",
-		"web3-eth-contract": "^4.0.4",
-		"web3-types": "^1.1.0",
-		"web3-utils": "^4.0.4"
+		"web3": "^4.1.1",
+		"web3-core": "^4.1.1",
+		"web3-eth-abi": "^4.1.1",
+		"web3-eth-contract": "^4.0.5",
+		"web3-types": "^1.1.1",
+		"web3-utils": "^4.0.5"
 	},
 	"peerDependencies": {
-		"web3-core": ">= 4.1.0 < 5",
-		"web3-eth-abi": ">= 4.1.0 < 5",
-		"web3-eth-contract": ">= 4.0.4 < 5",
-		"web3-types": ">= 1.1.0 < 5",
-		"web3-utils": ">= 4.0.4 < 5"
+		"web3-core": ">= 4.1.1 < 5",
+		"web3-eth-abi": ">= 4.1.1 < 5",
+		"web3-eth-contract": ">= 4.0.5 < 5",
+		"web3-types": ">= 1.1.1 < 5",
+		"web3-utils": ">= 4.0.5 < 5"
 	}
 }


### PR DESCRIPTION

### Added

#### web3

-   To fix issue #6190, added the functionality to introduce different timeout value for Web3. (#6336)

#### web3-core

-   To fix issue #6190, added the functionality to introduce different timeout value for Web3. (#6336)

#### web3-eth-contract

-   In case of error events there will be inner error also available for details

### Fixed

#### web3-eth

-   Added return type for `formatSubscriptionResult` in class `NewHeadsSubscription` (#6368)

#### web3-core

-   Fixed rpc errors not being sent as an inner error when using the `send` method on request manager (#6300).

#### web3-errors

-   ESM import bug (#6359)

#### web3-eth-contract

-   Fixed bug in `contract.events.allEvents`

#### web3-validator

-   ESM import bug (#6359)

### Changed

-   Updated web3 dependencies of other packages