### PR TITLE
create a new type `Eip1193Compatible`

### DIFF
--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -161,4 +161,4 @@ Documentation:
 
 ### Added
 
--   add `asEip1193FullyCompatible` to `Web3BaseProvider` so every inherited class can have the returned value of `request` method, fully compatible with EIP-1193. (#6407)
+-   add `asEIP1193Provider` to `Web3BaseProvider` so every inherited class can have the returned value of `request` method, fully compatible with EIP-1193. (#6407)

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -158,3 +158,7 @@ Documentation:
 -   Dependencies updated
 
 ## [Unreleased]
+
+### Added
+
+-   add `asEip1193FullyCompatible` to `Web3BaseProvider` so every inherited class can have the returned value of `request` method, fully compatible with EIP-1193. (#6407)

--- a/packages/web3-types/src/web3_base_provider.ts
+++ b/packages/web3-types/src/web3_base_provider.ts
@@ -133,6 +133,19 @@ export interface EIP1193Provider<API extends Web3APISpec> extends SimpleProvider
 	removeListener(event: 'accountsChanged', listener: (accounts: ProviderAccounts) => void): void;
 }
 
+export type Eip1193FullyCompatible<API extends Web3APISpec = EthExecutionAPI> = Omit<
+	// eslint-disable-next-line no-use-before-define
+	Omit<Web3BaseProvider, 'request'>,
+	'asEip1193FullyCompatible'
+> & {
+	request<
+		Method extends Web3APIMethod<API>,
+		ResultType = Web3APIReturnType<API, Method> | unknown,
+	>(
+		request: Web3APIPayload<API, Method>,
+	): Promise<ResultType>;
+};
+
 // Provider interface compatible with EIP-1193
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md
 export abstract class Web3BaseProvider<API extends Web3APISpec = EthExecutionAPI>
@@ -187,6 +200,40 @@ export abstract class Web3BaseProvider<API extends Web3APISpec = EthExecutionAPI
 		return this.request(payload as Web3APIPayload<API, Web3APIMethod<API>>) as Promise<
 			JsonRpcResponse<R>
 		>;
+	}
+
+	/**
+	 * Modify the return type of the request method to be fully compatible with EIP-1193
+	 *
+	 * [deprecated] In the future major releases (\>= v5) all providers are supposed to be fully compatible with EIP-1193.
+	 * So this method will not be needed and would not be available in the future.
+	 *
+	 * @returns A new instance of the provider with the request method fully compatible with EIP-1193
+	 *
+	 * @example
+	 * ```ts
+	 * const provider = new Web3HttpProvider('http://localhost:8545');
+	 * const fullyCompatibleProvider = provider.asEip1193FullyCompatible();
+	 * const result = await fullyCompatibleProvider.request({ method: 'eth_getBalance' });
+	 * console.log(result); // '0x0234c8a3397aab58' or something like that
+	 * ```
+	 */
+	public asEip1193FullyCompatible(): Eip1193FullyCompatible<API> {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+		const newObj = Object.create(this) as Eip1193FullyCompatible<API>;
+		// eslint-disable-next-line @typescript-eslint/unbound-method
+		const originalRequest = newObj.request;
+		newObj.request = async function request(
+			args: Web3APIPayload<API, Web3APIMethod<API>>,
+		): Promise<unknown> {
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+			const response = (await originalRequest(args)) as JsonRpcResponseWithResult<unknown>;
+			return response.result;
+		} as typeof newObj.request;
+		// @ts-expect-error the property should not be available in the new object because of using Object.create(this).
+		//	But it is available if we do not delete it.
+		newObj.asEip1193FullyCompatible = undefined; // to prevent the user for calling this method again
+		return newObj;
 	}
 
 	// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#request

--- a/packages/web3-types/src/web3_base_provider.ts
+++ b/packages/web3-types/src/web3_base_provider.ts
@@ -136,7 +136,7 @@ export interface EIP1193Provider<API extends Web3APISpec> extends SimpleProvider
 export type Eip1193FullyCompatible<API extends Web3APISpec = EthExecutionAPI> = Omit<
 	// eslint-disable-next-line no-use-before-define
 	Omit<Web3BaseProvider, 'request'>,
-	'asEip1193FullyCompatible'
+	'asEIP1193Provider'
 > & {
 	request<
 		Method extends Web3APIMethod<API>,
@@ -213,12 +213,12 @@ export abstract class Web3BaseProvider<API extends Web3APISpec = EthExecutionAPI
 	 * @example
 	 * ```ts
 	 * const provider = new Web3HttpProvider('http://localhost:8545');
-	 * const fullyCompatibleProvider = provider.asEip1193FullyCompatible();
+	 * const fullyCompatibleProvider = provider.asEIP1193Provider();
 	 * const result = await fullyCompatibleProvider.request({ method: 'eth_getBalance' });
 	 * console.log(result); // '0x0234c8a3397aab58' or something like that
 	 * ```
 	 */
-	public asEip1193FullyCompatible(): Eip1193FullyCompatible<API> {
+	public asEIP1193Provider(): Eip1193FullyCompatible<API> {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		const newObj = Object.create(this) as Eip1193FullyCompatible<API>;
 		// eslint-disable-next-line @typescript-eslint/unbound-method
@@ -232,7 +232,7 @@ export abstract class Web3BaseProvider<API extends Web3APISpec = EthExecutionAPI
 		} as typeof newObj.request;
 		// @ts-expect-error the property should not be available in the new object because of using Object.create(this).
 		//	But it is available if we do not delete it.
-		newObj.asEip1193FullyCompatible = undefined; // to prevent the user for calling this method again
+		newObj.asEIP1193Provider = undefined; // to prevent the user for calling this method again
 		return newObj;
 	}
 

--- a/packages/web3-types/src/web3_base_provider.ts
+++ b/packages/web3-types/src/web3_base_provider.ts
@@ -133,7 +133,7 @@ export interface EIP1193Provider<API extends Web3APISpec> extends SimpleProvider
 	removeListener(event: 'accountsChanged', listener: (accounts: ProviderAccounts) => void): void;
 }
 
-export type Eip1193FullyCompatible<API extends Web3APISpec = EthExecutionAPI> = Omit<
+export type Eip1193Compatible<API extends Web3APISpec = EthExecutionAPI> = Omit<
 	// eslint-disable-next-line no-use-before-define
 	Omit<Web3BaseProvider, 'request'>,
 	'asEIP1193Provider'
@@ -218,9 +218,9 @@ export abstract class Web3BaseProvider<API extends Web3APISpec = EthExecutionAPI
 	 * console.log(result); // '0x0234c8a3397aab58' or something like that
 	 * ```
 	 */
-	public asEIP1193Provider(): Eip1193FullyCompatible<API> {
+	public asEIP1193Provider(): Eip1193Compatible<API> {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-		const newObj = Object.create(this) as Eip1193FullyCompatible<API>;
+		const newObj = Object.create(this) as Eip1193Compatible<API>;
 		// eslint-disable-next-line @typescript-eslint/unbound-method
 		const originalRequest = newObj.request;
 		newObj.request = async function request(

--- a/packages/web3-types/test/unit/jest.config.js
+++ b/packages/web3-types/test/unit/jest.config.js
@@ -3,7 +3,9 @@ const base = require('../config/jest.config');
 module.exports = {
 	...base,
 	testMatch: ['<rootDir>/test/unit/**/*.(spec|test).(js|ts)'],
-
+	moduleNameMapper: {
+		'^(\\.{1,2}/.*)\\.js$': '$1',
+	},
 	coverageDirectory: '.coverage/unit',
 	collectCoverageFrom: ['src/**'],
 };

--- a/packages/web3-types/test/unit/web3_base_provider.test.ts
+++ b/packages/web3-types/test/unit/web3_base_provider.test.ts
@@ -1,0 +1,65 @@
+﻿/*
+This file is part of web3.js.
+
+web3.js is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+web3.js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import {
+	EthExecutionAPI,
+	JsonRpcResponseWithResult,
+	Web3APIMethod,
+	Web3APIPayload,
+	Web3APIReturnType,
+	Web3BaseProvider,
+} from '../../src/index.js';
+
+// @ts-expect-error mock class for testing. The abstract methods are not implemented.
+class Web3ChildProvider extends Web3BaseProvider {
+	// eslint-disable-next-line class-methods-use-this
+	public async request<
+		Method extends Web3APIMethod<EthExecutionAPI>,
+		ResultType = Web3APIReturnType<EthExecutionAPI, Method> | unknown,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	>(_: Web3APIPayload<EthExecutionAPI, Method>): Promise<JsonRpcResponseWithResult<ResultType>> {
+		return new Promise(resolve =>
+			// eslint-disable-next-line no-promise-executor-return
+			resolve({
+				jsonrpc: '2.0',
+				id: 1,
+				result: 'result' as unknown as ResultType,
+			}),
+		);
+	}
+}
+
+describe('Web3BaseProvider', () => {
+	it('asEip1193FullyCompatible will fix the returned result of the request method', async () => {
+		const childProvider = new Web3ChildProvider();
+		const returnValue = await childProvider.request({ method: 'eth_getBalance' });
+		expect(returnValue.result).toBe('result');
+
+		const eip1193FullyCompatibleClass = childProvider.asEip1193FullyCompatible();
+		const returnValue2 = await eip1193FullyCompatibleClass.request({
+			method: 'eth_getBalance',
+		});
+		expect(returnValue2).toBe('result');
+	});
+
+	it('asEip1193FullyCompatible would not be available inside the newly generated class', () => {
+		const childProvider = new Web3ChildProvider();
+
+		const eip1193FullyCompatibleClass = childProvider.asEip1193FullyCompatible();
+		expect((eip1193FullyCompatibleClass as any).asEip1193FullyCompatible).toBeUndefined();
+	});
+});

--- a/packages/web3-types/test/unit/web3_base_provider.test.ts
+++ b/packages/web3-types/test/unit/web3_base_provider.test.ts
@@ -49,8 +49,8 @@ describe('Web3BaseProvider', () => {
 		const returnValue = await childProvider.request({ method: 'eth_getBalance' });
 		expect(returnValue.result).toBe('result');
 
-		const eip1193FullyCompatibleClass = childProvider.asEIP1193Provider();
-		const returnValue2 = await eip1193FullyCompatibleClass.request({
+		const eip1193CompatibleClass = childProvider.asEIP1193Provider();
+		const returnValue2 = await eip1193CompatibleClass.request({
 			method: 'eth_getBalance',
 		});
 		expect(returnValue2).toBe('result');
@@ -59,7 +59,7 @@ describe('Web3BaseProvider', () => {
 	it('asEIP1193Provider would not be available inside the newly generated class', () => {
 		const childProvider = new Web3ChildProvider();
 
-		const eip1193FullyCompatibleClass = childProvider.asEIP1193Provider();
-		expect((eip1193FullyCompatibleClass as any).asEIP1193Provider).toBeUndefined();
+		const eip1193CompatibleClass = childProvider.asEIP1193Provider();
+		expect((eip1193CompatibleClass as any).asEIP1193Provider).toBeUndefined();
 	});
 });

--- a/packages/web3-types/test/unit/web3_base_provider.test.ts
+++ b/packages/web3-types/test/unit/web3_base_provider.test.ts
@@ -44,22 +44,22 @@ class Web3ChildProvider extends Web3BaseProvider {
 }
 
 describe('Web3BaseProvider', () => {
-	it('asEip1193FullyCompatible will fix the returned result of the request method', async () => {
+	it('asEIP1193Provider will fix the returned result of the request method', async () => {
 		const childProvider = new Web3ChildProvider();
 		const returnValue = await childProvider.request({ method: 'eth_getBalance' });
 		expect(returnValue.result).toBe('result');
 
-		const eip1193FullyCompatibleClass = childProvider.asEip1193FullyCompatible();
+		const eip1193FullyCompatibleClass = childProvider.asEIP1193Provider();
 		const returnValue2 = await eip1193FullyCompatibleClass.request({
 			method: 'eth_getBalance',
 		});
 		expect(returnValue2).toBe('result');
 	});
 
-	it('asEip1193FullyCompatible would not be available inside the newly generated class', () => {
+	it('asEIP1193Provider would not be available inside the newly generated class', () => {
 		const childProvider = new Web3ChildProvider();
 
-		const eip1193FullyCompatibleClass = childProvider.asEip1193FullyCompatible();
-		expect((eip1193FullyCompatibleClass as any).asEip1193FullyCompatible).toBeUndefined();
+		const eip1193FullyCompatibleClass = childProvider.asEIP1193Provider();
+		expect((eip1193FullyCompatibleClass as any).asEIP1193Provider).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Description

Fixes #6345 by allowing the user to get an instance of any Web3 Provider that has the returned value of `request` fully compatible with EIP-1193.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
