### PR TITLE
fix: timer types to be context dependent

### DIFF
--- a/packages/web3-core/test/unit/web3_batch_request.test.ts
+++ b/packages/web3-core/test/unit/web3_batch_request.test.ts
@@ -16,7 +16,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { JsonRpcBatchRequest, JsonRpcBatchResponse, JsonRpcOptionalRequest } from 'web3-types';
-import { jsonRpc, Web3DeferredPromise } from 'web3-utils';
+import { jsonRpc, Web3DeferredPromise, Timeout } from 'web3-utils';
 import { OperationAbortError, OperationTimeoutError } from 'web3-errors';
 import { Web3BatchRequest } from '../../src/web3_batch_request';
 
@@ -174,7 +174,7 @@ describe('Web3BatchRequest', () => {
 		});
 
 		it('should timeout if request not executed in a particular time', async () => {
-			let timerId!: NodeJS.Timeout;
+			let timerId!: Timeout;
 
 			jest.spyOn(requestManager, 'sendBatch').mockImplementation(async () => {
 				return new Promise(resolve => {

--- a/packages/web3-eth/src/utils/reject_if_block_timeout.ts
+++ b/packages/web3-eth/src/utils/reject_if_block_timeout.ts
@@ -34,7 +34,7 @@ function resolveByPolling(
 	transactionHash?: Bytes,
 ): [Promise<never>, ResourceCleaner] {
 	const pollingInterval = web3Context.transactionPollingInterval;
-	const [intervalId, promiseToError]: [NodeJS.Timer, Promise<never>] =
+	const [intervalId, promiseToError] =
 		rejectIfConditionAtInterval(async () => {
 			let lastBlockNumber;
 			try {

--- a/packages/web3-eth/src/utils/wait_for_transaction_receipt.ts
+++ b/packages/web3-eth/src/utils/wait_for_transaction_receipt.ts
@@ -43,7 +43,7 @@ export async function waitForTransactionReceipt<ReturnFormat extends DataFormat>
 		}
 	}, pollingInterval);
 
-	const [timeoutId, rejectOnTimeout]: [NodeJS.Timer, Promise<never>] = rejectIfTimeout(
+	const [timeoutId, rejectOnTimeout] = rejectIfTimeout(
 		web3Context.transactionPollingTimeout,
 		new TransactionPollingTimeoutError({
 			numberOfSeconds: web3Context.transactionPollingTimeout / 1000,

--- a/packages/web3-utils/src/chunk_response_parser.ts
+++ b/packages/web3-utils/src/chunk_response_parser.ts
@@ -17,7 +17,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 import { JsonRpcResponse } from 'web3-types';
 import { InvalidResponseError } from 'web3-errors';
 import { EventEmitter } from 'events';
-import { Timeout } from './promise_helpers';
+import { Timeout } from './promise_helpers.js';
 
 export class ChunkResponseParser {
 	private lastChunk: string | undefined;

--- a/packages/web3-utils/src/chunk_response_parser.ts
+++ b/packages/web3-utils/src/chunk_response_parser.ts
@@ -17,10 +17,11 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 import { JsonRpcResponse } from 'web3-types';
 import { InvalidResponseError } from 'web3-errors';
 import { EventEmitter } from 'events';
+import { Timeout } from './promise_helpers';
 
 export class ChunkResponseParser {
 	private lastChunk: string | undefined;
-	private lastChunkTimeout: NodeJS.Timeout | undefined;
+	private lastChunkTimeout: Timeout | undefined;
 	private _clearQueues: (() => void) | undefined;
 	private readonly eventEmitter: EventEmitter;
 	private readonly autoReconnect: boolean;

--- a/packages/web3-utils/src/promise_helpers.ts
+++ b/packages/web3-utils/src/promise_helpers.ts
@@ -17,6 +17,10 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 import { isNullish } from 'web3-validator';
 
+export type Timer = ReturnType<typeof setInterval>;
+export type Timeout = ReturnType<typeof setTimeout>;
+
+
 /**
  * An alternative to the node function `isPromise` that exists in `util/types` because it is not available on the browser.
  * @param object - to check if it is a `Promise`
@@ -54,7 +58,7 @@ export async function waitWithTimeout<T>(
 	timeout: number,
 	error?: Error,
 ): Promise<T | undefined> {
-	let timeoutId: NodeJS.Timeout | undefined;
+	let timeoutId: Timeout | undefined;
 	const result = await Promise.race([
 		awaitable instanceof Promise ? awaitable : awaitable(),
 		new Promise<undefined | Error>((resolve, reject) => {
@@ -81,7 +85,7 @@ export async function pollTillDefined<T>(
 ): Promise<Exclude<T, undefined>> {
 	const awaitableRes = waitWithTimeout(func, interval);
 
-	let intervalId: NodeJS.Timer | undefined;
+	let intervalId: Timer | undefined;
 	const polledRes = new Promise<Exclude<T, undefined>>((resolve, reject) => {
 		intervalId = setInterval(() => {
 			(async () => {
@@ -122,14 +126,14 @@ export async function pollTillDefined<T>(
  * const [timerId, promise] = web3.utils.rejectIfTimeout(100, new Error('time out'));
  * ```
  */
-export function rejectIfTimeout(timeout: number, error: Error): [NodeJS.Timer, Promise<never>] {
-	let timeoutId: NodeJS.Timer | undefined;
+export function rejectIfTimeout(timeout: number, error: Error): [Timer, Promise<never>] {
+	let timeoutId: Timer | undefined;
 	const rejectOnTimeout = new Promise<never>((_, reject) => {
 		timeoutId = setTimeout(() => {
 			reject(error);
 		}, timeout);
 	});
-	return [timeoutId as unknown as NodeJS.Timer, rejectOnTimeout];
+	return [timeoutId!, rejectOnTimeout];
 }
 /**
  * Sets an interval that repeatedly executes the given cond function with the specified interval between each call.
@@ -141,8 +145,8 @@ export function rejectIfTimeout(timeout: number, error: Error): [NodeJS.Timer, P
 export function rejectIfConditionAtInterval<T>(
 	cond: AsyncFunction<T | undefined>,
 	interval: number,
-): [NodeJS.Timer, Promise<never>] {
-	let intervalId: NodeJS.Timer | undefined;
+): [Timer, Promise<never>] {
+	let intervalId: Timer | undefined;
 	const rejectIfCondition = new Promise<never>((_, reject) => {
 		intervalId = setInterval(() => {
 			(async () => {
@@ -154,5 +158,5 @@ export function rejectIfConditionAtInterval<T>(
 			})() as unknown;
 		}, interval);
 	});
-	return [intervalId as unknown as NodeJS.Timer, rejectIfCondition];
+	return [intervalId!, rejectIfCondition];
 }

--- a/packages/web3-utils/src/web3_deferred_promise.ts
+++ b/packages/web3-utils/src/web3_deferred_promise.ts
@@ -17,7 +17,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 import { OperationTimeoutError } from 'web3-errors';
 import { Web3DeferredPromiseInterface } from 'web3-types';
-import { Timeout } from './promise_helpers';
+import { Timeout } from './promise_helpers.js';
 
 /**
  * The class is a simple implementation of a deferred promise with optional timeout functionality,

--- a/packages/web3-utils/src/web3_deferred_promise.ts
+++ b/packages/web3-utils/src/web3_deferred_promise.ts
@@ -17,6 +17,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 import { OperationTimeoutError } from 'web3-errors';
 import { Web3DeferredPromiseInterface } from 'web3-types';
+import { Timeout } from './promise_helpers';
 
 /**
  * The class is a simple implementation of a deferred promise with optional timeout functionality,
@@ -32,7 +33,7 @@ export class Web3DeferredPromise<T> implements Promise<T>, Web3DeferredPromiseIn
 	private _resolve!: (value: T | PromiseLike<T>) => void;
 	private _reject!: (reason?: unknown) => void;
 	private _state: 'pending' | 'fulfilled' | 'rejected' = 'pending';
-	private _timeoutId?: NodeJS.Timeout;
+	private _timeoutId?: Timeout;
 	private readonly _timeoutInterval?: number;
 	private readonly _timeoutMessage: string;
 


### PR DESCRIPTION
## Description
Currently timer and tiemout types are hardcoded to nodejs types which have conflicts when used in browser. Changed to infer type based on method return in different context

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
