### PR TITLE
web3-eth-contract validation test fail

### DIFF
--- a/packages/web3-eth-contract/test/integration/local_account/contract_erc721.test.ts
+++ b/packages/web3-eth-contract/test/integration/local_account/contract_erc721.test.ts
@@ -19,7 +19,6 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 import Web3 from 'web3';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Web3Account } from 'web3-eth-accounts';
-import { EventLog } from 'web3-types';
 import { Contract } from '../../../src';
 import { ERC721TokenAbi, ERC721TokenBytecode } from '../../shared_fixtures/build/ERC721Token';
 import { getSystemTestProvider, createLocalAccount } from '../../fixtures/system_test_utils';
@@ -80,8 +79,7 @@ describe('contract', () => {
 				tempAccount.address.toLowerCase(),
 			);
 
-			const logs = await contractDeployed.getPastEvents('Transfer');
-			const tokenId = (logs[0] as EventLog)?.returnValues?.tokenId as string;
+			const tokenId = awardReceipt.events?.Transfer.returnValues?.tokenId as string;
 
 			expect(
 				toUpperCaseHex(
@@ -113,8 +111,7 @@ describe('contract', () => {
 				tempAccount.address.toLowerCase(),
 			);
 
-			const logs = await contractDeployed.getPastEvents('Transfer');
-			const tokenId = (logs[0] as EventLog)?.returnValues?.tokenId as string;
+			const tokenId = awardReceipt.events?.Transfer.returnValues?.tokenId as string;
 			const transferFromReceipt = await contractDeployed.methods
 				.transferFrom(tempAccount.address, toAccount.address, tokenId)
 				.send({
@@ -186,8 +183,7 @@ describe('contract', () => {
 				tempAccount.address.toLowerCase(),
 			);
 
-			const logs = await contractDeployed.getPastEvents('Transfer');
-			const tokenId = (logs[0] as EventLog)?.returnValues?.tokenId as string;
+			const tokenId = awardReceipt.events?.Transfer.returnValues?.tokenId as string;
 
 			const approveReceipt = await contractDeployed.methods
 				.approve(toAccount.address, tokenId)


### PR DESCRIPTION
## Description
investigated #6461 
```
const logs = await contractDeployed.getPastEvents('Transfer');
			const tokenId = (logs[0] as EventLog)?.returnValues?.tokenId as string;
```
in this line, logs can sometimes be undefined, creating this error.

Fix is to just use receipt and instead of `getPastEvents` 
Please include a summary of the changes and be sure to follow our [Contribution Guidelines](../CONTRIBUTIONS.md).

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
