### PR TITLE
Release/4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2081,9 +2081,13 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.2.0]
 
 ### Added
+
+#### web3
+
+-   Various web3 sub packages has new functions details are in root changelog
 
 #### web3-eth
 
@@ -2109,10 +2113,19 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Fix the issue: "Uncaught TypeError: Class extends value undefined is not a constructor or null #6371". (#6398)
 
+#### web3-errors
+
+-   Added new SchemaFormatError (#6434)
+
 #### web3-eth
 
 -   Ensure provider.supportsSubscriptions exists before watching by subscription (#6440)
 -   Fixed param sent to `checkRevertBeforeSending` in `sendSignedTransaction` 
+-   Fixed `defaultTransactionBuilder` for value issue (#6509)
+
+#### web3-eth-abi
+
+-   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
 
 #### web3-eth-accounts
 
@@ -2122,11 +2135,31 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Fix issue lquixada/cross-fetch#78, enabling to run web3.js in service worker (#6463)
 
+#### web3-providers-ipc
+
+-   Fixed bug in chunks processing logic (#6496)
+
+#### web3-providers-ws
+
+-   Fixed bug in chunks processing logic (#6496)
+
+#### web3-utils
+
+-   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
+-   Fixed bug in chunks processing logic (#6496)
+
 #### web3-validator
 
--   Multi-dimensional arrays are now handled properly when parsing ABIs
+-   Multi-dimensional arrays are now handled properly when parsing ABIs (#6435)
+-   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
+-   Validator will now properly handle all valid numeric type sizes: intN / uintN where 8 <= N <= 256 and N % 8 == 0 (#6434)
+-   Will now throw SchemaFormatError when unsupported format is passed to `convertToZod` method (#6434)
 
 ### Changed
+
+#### web3
+
+-   Dependencies updated
 
 #### web3-core
 
@@ -2142,6 +2175,28 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   The `events` property was added to the `receipt` object (#6410)
 
+#### web3-eth-ens
+
+-   Dependencies updated
+
+#### web3-eth-iban
+
+-   Dependencies updated
+
+#### web3-eth-personal
+
+-   Dependencies updated
+
+#### web3-net
+
+-   Dependencies updated
+
 #### web3-providers-http
 
 -   Bump cross-fetch to version 4 (#6463).
+
+#### web3-rpc-methods
+
+-   Dependencies updated
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -179,7 +179,7 @@ Documentation:
 
 -   Added to `Web3Config` property `contractDataInputFill` allowing users to have the choice using property `data`, `input` or `both` for contract methods to be sent to the RPC provider when creating contracts. (#6377) (#6400)
 
-## [Unreleased]
+## [4.3.0]
 
 ### Changed
 
@@ -190,3 +190,5 @@ Documentation:
 ### Fixed
 
 -   Fix the issue: "Uncaught TypeError: Class extends value undefined is not a constructor or null #6371". (#6398)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,16 +42,16 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.2",
-		"web3-eth-iban": "^4.0.6",
-		"web3-providers-http": "^4.0.6",
-		"web3-providers-ws": "^4.0.6",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-errors": "^1.1.3",
+		"web3-eth-iban": "^4.0.7",
+		"web3-providers-http": "^4.1.0",
+		"web3-providers-ws": "^4.0.7",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	},
 	"optionalDependencies": {
-		"web3-providers-ipc": "^4.0.6"
+		"web3-providers-ipc": "^4.0.7"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -154,6 +154,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [1.1.3]
+
+### Fixed
 
 -   Added new SchemaFormatError (#6434)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.2.0"
+		"web3-types": "^1.3.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -142,8 +142,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.3]
 
 ### Fixed
 
 -   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
+
+## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -43,10 +43,10 @@
 	},
 	"dependencies": {
 		"abitype": "0.7.1",
-		"web3-validator": "^2.0.2",
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6"
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -137,7 +137,7 @@ Documentation:
 -   Fixed "The `r` and `s` returned by `sign` to does not always consist of 64 characters" (#6411)
 
 
-## [Unreleased]
+## [4.1.0]
 
 ### Added
 
@@ -148,3 +148,5 @@ Documentation:
 ### Fixed
 
 -   Fixed `recover` function, `v` will be normalized to value 0,1 (#6344) 
+
+## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.0.6",
+	"version": "4.1.0",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -55,15 +55,15 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.6"
+		"web3-providers-ipc": "^4.0.7"
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -308,8 +308,10 @@ Documentation:
 -   Added to `Web3Config` property `contractDataInputFill` allowing users to have the choice using property `data`, `input` or `both` for contract methods to be sent to the RPC provider when creating contracts. (#6377)
 
 
-## [Unreleased]
+## [4.1.1]
 
 ### Changed
 
 -   The `events` property was added to the `receipt` object (#6410)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.2.0",
-		"web3-errors": "^1.1.2",
-		"web3-eth": "^4.2.0",
-		"web3-eth-abi": "^4.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-core": "^4.3.0",
+		"web3-errors": "^1.1.3",
+		"web3-eth": "^4.3.0",
+		"web3-eth-abi": "^4.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",
@@ -67,6 +67,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.0.6"
+		"web3-eth-accounts": "^4.1.0"
 	}
 }

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -129,4 +129,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.7]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.0.6",
+	"version": "4.0.7",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.2.0",
-		"web3-errors": "^1.1.2",
-		"web3-eth": "^4.2.0",
-		"web3-eth-contract": "^4.1.0",
-		"web3-net": "^4.0.6",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-core": "^4.3.0",
+		"web3-errors": "^1.1.3",
+		"web3-eth": "^4.3.0",
+		"web3-eth-contract": "^4.1.1",
+		"web3-net": "^4.0.7",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	}
 }

--- a/packages/web3-eth-iban/CHANGELOG.md
+++ b/packages/web3-eth-iban/CHANGELOG.md
@@ -119,4 +119,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.7]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-iban/package.json
+++ b/packages/web3-eth-iban/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-iban",
-	"version": "4.0.6",
+	"version": "4.0.7",
 	"description": "This package converts Ethereum addresses to IBAN addresses and vice versa.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	}
 }

--- a/packages/web3-eth-personal/CHANGELOG.md
+++ b/packages/web3-eth-personal/CHANGELOG.md
@@ -135,4 +135,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.7]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-eth-personal/package.json
+++ b/packages/web3-eth-personal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-personal",
-	"version": "4.0.6",
+	"version": "4.0.7",
 	"description": "Web3 module to interact with the Ethereum blockchain accounts stored in the node.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,12 +42,12 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js"
 	},
 	"dependencies": {
-		"web3-core": "^4.2.0",
-		"web3-eth": "^4.2.0",
-		"web3-rpc-methods": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-core": "^4.3.0",
+		"web3-eth": "^4.3.0",
+		"web3-rpc-methods": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",
@@ -62,6 +62,6 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ws": "^4.0.6"
+		"web3-providers-ws": "^4.0.7"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -191,7 +191,7 @@ Documentation:
 
 -   Added to `Web3Config` property `contractDataInputFill` allowing users to have the choice using property `data`, `input` or `both` for contract methods to be sent to the RPC provider when creating contracts. (#6377) (#6400)
 
-## [Unreleased]
+## [4.3.0]
 
 ### Changed
 
@@ -206,3 +206,5 @@ Documentation:
 ### Added
 
 -   Added `ALL_EVENTS` and `ALL_EVENTS_ABI` constants, `SendTransactionEventsBase` type, `decodeEventABI` method (#6410)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,19 +59,19 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-http": "^4.0.6"
+		"web3-providers-http": "^4.1.0"
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.2.0",
-		"web3-errors": "^1.1.2",
-		"web3-eth-abi": "^4.1.2",
-		"web3-eth-accounts": "^4.0.6",
-		"web3-net": "^4.0.6",
-		"web3-providers-ws": "^4.0.6",
-		"web3-rpc-methods": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-core": "^4.3.0",
+		"web3-errors": "^1.1.3",
+		"web3-eth-abi": "^4.1.3",
+		"web3-eth-accounts": "^4.1.0",
+		"web3-net": "^4.0.7",
+		"web3-providers-ws": "^4.0.7",
+		"web3-rpc-methods": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	}
 }

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -135,4 +135,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.0.7]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.6",
+	"version": "4.0.7",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.2.0",
-		"web3-rpc-methods": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6"
+		"web3-core": "^4.3.0",
+		"web3-rpc-methods": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7"
 	}
 }

--- a/packages/web3-providers-http/CHANGELOG.md
+++ b/packages/web3-providers-http/CHANGELOG.md
@@ -119,7 +119,7 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.0]
 
 ### Changed
 
@@ -128,3 +128,5 @@ Documentation:
 ### Fixed
 
 -   Fix issue lquixada/cross-fetch#78, enabling to run web3.js in service worker (#6463)
+
+## [Unreleased]

--- a/packages/web3-providers-http/package.json
+++ b/packages/web3-providers-http/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-http",
-	"version": "4.0.6",
+	"version": "4.1.0",
 	"description": "HTTP provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,8 +61,8 @@
 	},
 	"dependencies": {
 		"cross-fetch": "^4.0.0",
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6"
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7"
 	}
 }

--- a/packages/web3-providers-ipc/CHANGELOG.md
+++ b/packages/web3-providers-ipc/CHANGELOG.md
@@ -129,8 +129,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.0.7]
 
 ### Fixed
 
 -   Fixed bug in chunks processing logic (#6496)
+
+## [Unreleased]

--- a/packages/web3-providers-ipc/package.json
+++ b/packages/web3-providers-ipc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ipc",
-	"version": "4.0.6",
+	"version": "4.0.7",
 	"description": "IPC provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6"
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -123,8 +123,10 @@ Documentation:
 -   Dependencies updated
 
 
-## [Unreleased]
+## [4.0.7]
 
 ### Fixed
 
 -   Fixed bug in chunks processing logic (#6496)
+
+## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.6",
+	"version": "4.0.7",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,9 +63,9 @@
 	"dependencies": {
 		"@types/ws": "8.5.3",
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
 		"ws": "^8.8.1"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -120,4 +120,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [1.1.3]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.2.0",
-		"web3-types": "^1.2.0",
-		"web3-validator": "^2.0.2"
+		"web3-core": "^4.3.0",
+		"web3-types": "^1.3.0",
+		"web3-validator": "^2.0.3"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -164,8 +164,10 @@ Documentation:
 -   add `asEIP1193Provider` to `Web3BaseProvider` so every inherited class can have the returned value of `request` method, fully compatible with EIP-1193. (#6407)
 
 
-## [Unreleased]
+## [1.3.0]
 
 ### Added
 
 -   Interface `EventLog` was added. (#6410)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -158,7 +158,7 @@ Documentation:
 
 -   `soliditySha3()` with BigInt support
 
-## [Unreleased]
+## [4.0.7]
 
 ### Added
 
@@ -168,3 +168,5 @@ Documentation:
 
 -   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
 -   Fixed bug in chunks processing logic (#6496)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.0.6",
+	"version": "4.0.7",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -64,8 +64,8 @@
 	},
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-validator": "^2.0.2"
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-validator": "^2.0.3"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -147,7 +147,7 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [2.0.3]
 
 ### Fixed
 
@@ -155,3 +155,5 @@ Documentation:
 -   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
 -   Validator will now properly handle all valid numeric type sizes: intN / uintN where 8 <= N <= 256 and N % 8 == 0 (#6434)
 -   Will now throw SchemaFormatError when unsupported format is passed to `convertToZod` method (#6434)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -47,8 +47,8 @@
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
 		"util": "^0.12.5",
-		"web3-errors": "^1.1.2",
-		"web3-types": "^1.2.0",
+		"web3-errors": "^1.1.3",
+		"web3-types": "^1.3.0",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -151,4 +151,14 @@ Documentation:
 
 -   Fix of incorrect provider warning behavior
 
+## [4.2.0]
+
+### Changed
+
+-   Dependencies updated
+
+### Added
+
+-   Various web3 sub packages has new functions details are in root changelog
+
 ## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.1.2",
+	"version": "4.2.0",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -78,24 +78,24 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3-providers-ipc": "^4.0.6"
+		"web3-providers-ipc": "^4.0.7"
 	},
 	"dependencies": {
-		"web3-core": "^4.2.0",
-		"web3-errors": "^1.1.2",
-		"web3-eth": "^4.2.0",
-		"web3-eth-abi": "^4.1.2",
-		"web3-eth-accounts": "^4.0.6",
-		"web3-eth-contract": "^4.1.0",
-		"web3-eth-ens": "^4.0.6",
-		"web3-eth-iban": "^4.0.6",
-		"web3-eth-personal": "^4.0.6",
-		"web3-net": "^4.0.6",
-		"web3-providers-http": "^4.0.6",
-		"web3-providers-ws": "^4.0.6",
-		"web3-rpc-methods": "^1.1.2",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6",
-		"web3-validator": "^2.0.2"
+		"web3-core": "^4.3.0",
+		"web3-errors": "^1.1.3",
+		"web3-eth": "^4.3.0",
+		"web3-eth-abi": "^4.1.3",
+		"web3-eth-accounts": "^4.1.0",
+		"web3-eth-contract": "^4.1.1",
+		"web3-eth-ens": "^4.0.7",
+		"web3-eth-iban": "^4.0.7",
+		"web3-eth-personal": "^4.0.7",
+		"web3-net": "^4.0.7",
+		"web3-providers-http": "^4.1.0",
+		"web3-providers-ws": "^4.0.7",
+		"web3-rpc-methods": "^1.1.3",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7",
+		"web3-validator": "^2.0.3"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.1.2' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.2.0' };

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -82,4 +82,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Dependencies updated
 
+## [1.0.6]
+
+### Changed
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,12 +45,12 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.7.4",
-		"web3": "^4.1.2",
-		"web3-core": "^4.2.0",
-		"web3-eth-abi": "^4.1.2",
-		"web3-eth-contract": "^4.1.0",
-		"web3-types": "^1.2.0",
-		"web3-utils": "^4.0.6"
+		"web3": "^4.2.0",
+		"web3-core": "^4.3.0",
+		"web3-eth-abi": "^4.1.3",
+		"web3-eth-contract": "^4.1.1",
+		"web3-types": "^1.3.0",
+		"web3-utils": "^4.0.7"
 	},
 	"peerDependencies": {
 		"web3-core": ">= 4.1.1 < 5",


### PR DESCRIPTION

## [4.2.0]

### Added

#### web3

-   Various web3 sub packages has new functions details are in root changelog

#### web3-eth

-   Added `ALL_EVENTS` and `ALL_EVENTS_ABI` constants, `SendTransactionEventsBase` type, `decodeEventABI` method (#6410)

#### web3-eth-accounts

-   Added public function `privateKeyToPublicKey`
-   Added exporting `BaseTransaction` from the package (#6493)
-   Added exporting `txUtils` from the package (#6493)

#### web3-types

-   Interface `EventLog` was added. (#6410)

#### web3-utils

-   As a replacment of the node EventEmitter, a custom `EventEmitter` has been implemented and exported. (#6398)

### Fixed

#### web3-core

-   Fix the issue: "Uncaught TypeError: Class extends value undefined is not a constructor or null #6371". (#6398)

#### web3-errors

-   Added new SchemaFormatError (#6434)

#### web3-eth

-   Ensure provider.supportsSubscriptions exists before watching by subscription (#6440)
-   Fixed param sent to `checkRevertBeforeSending` in `sendSignedTransaction` 
-   Fixed `defaultTransactionBuilder` for value issue (#6509)

#### web3-eth-abi

-   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)

#### web3-eth-accounts

-   Fixed `recover` function, `v` will be normalized to value 0,1 (#6344) 

#### web3-providers-http

-   Fix issue lquixada/cross-fetch#78, enabling to run web3.js in service worker (#6463)

#### web3-providers-ipc

-   Fixed bug in chunks processing logic (#6496)

#### web3-providers-ws

-   Fixed bug in chunks processing logic (#6496)

#### web3-utils

-   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
-   Fixed bug in chunks processing logic (#6496)

#### web3-validator

-   Multi-dimensional arrays are now handled properly when parsing ABIs (#6435)
-   Fix issue with default config with babel (and React): "TypeError: Cannot convert a BigInt value to a number #6187" (#6506)
-   Validator will now properly handle all valid numeric type sizes: intN / uintN where 8 <= N <= 256 and N % 8 == 0 (#6434)
-   Will now throw SchemaFormatError when unsupported format is passed to `convertToZod` method (#6434)

### Changed

#### web3

-   Dependencies updated

#### web3-core

-   defaultTransactionType is now type 0x2 instead of 0x0 (#6282)
-   Allows formatter to parse large base fee (#6456)
-   The package now uses `EventEmitter` from `web3-utils` that works in node envrioment as well as in the browser. (#6398)

#### web3-eth

-   Transactions will now default to type 2 transactions instead of type 0, similar to 1.x version. (#6282)

#### web3-eth-contract

-   The `events` property was added to the `receipt` object (#6410)

#### web3-eth-ens

-   Dependencies updated

#### web3-eth-iban

-   Dependencies updated

#### web3-eth-personal

-   Dependencies updated

#### web3-net

-   Dependencies updated

#### web3-providers-http

-   Bump cross-fetch to version 4 (#6463).

#### web3-rpc-methods

-   Dependencies updated
