### PR TITLE
Release/4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2225,9 +2225,32 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.2.2]
 ### Added
+
+#### web3-core
+
+-   Added `isMetaMaskProvider` function to check if provider is metamask (#6534)
 
 #### web3-types
 
+-   Interface `MetaMaskProvider` added and is part of `SupportedProviders` (#6534)
 -   `gasPrice` was added to `Transaction1559UnsignedAPI` type. (#6539)
+
+### Changed
+
+#### web3
+
+-   Dependencies updated
+
+### Fixed
+
+#### web3-errors
+
+-   Fixed grammar and spelling in `transactionTimeoutHint` (#6559)
+
+#### web3-eth-contract
+
+-	Will populate `data` for transactions in contract for metamask provider instead of `input` (#6534)
+
+## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -191,8 +191,10 @@ Documentation:
 
 -   Fix the issue: "Uncaught TypeError: Class extends value undefined is not a constructor or null #6371". (#6398)
 
-## [Unreleased]
+## [4.3.1]
 
 ### Added
 
 -   Added `isMetaMaskProvider` function to check if provider is metamask (#6534)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,11 +42,11 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.3",
+		"web3-errors": "^1.1.4",
 		"web3-eth-iban": "^4.0.7",
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
-		"web3-types": "^1.3.0",
+		"web3-types": "^1.3.1",
 		"web3-utils": "^4.0.7",
 		"web3-validator": "^2.0.3"
 	},

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -160,4 +160,10 @@ Documentation:
 
 -   Added new SchemaFormatError (#6434)
 
+## [1.1.4]
+
+### Fixed
+
+-   Fixed grammar and spelling in `transactionTimeoutHint` (#6559)
+
 ## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.3.0"
+		"web3-types": "^1.3.1"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -320,6 +320,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.3]
+
+### Fixed
 
 -	Will populate `data` for transactions in contract for metamask provider instead of `input` (#6534)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,11 +45,11 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.3.0",
-		"web3-errors": "^1.1.3",
+		"web3-core": "^4.3.1",
+		"web3-errors": "^1.1.4",
 		"web3-eth": "^4.3.1",
 		"web3-eth-abi": "^4.1.4",
-		"web3-types": "^1.3.0",
+		"web3-types": "^1.3.1",
 		"web3-utils": "^4.0.7",
 		"web3-validator": "^2.0.3"
 	},

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -170,9 +170,11 @@ Documentation:
 
 -   Interface `EventLog` was added. (#6410)
 
-## [Unreleased]
+## [1.3.1]
 
 ### Added
 
 -   Interface `MetaMaskProvider` added and is part of `SupportedProviders` (#6534)
 -   `gasPrice` was added to `Transaction1559UnsignedAPI` type. (#6539)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -167,4 +167,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.2.2]
+
+### Changed
+
+-   Dependencies updated ( details are in root changelog )
+
 ## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.2.1",
+	"version": "4.2.2",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -81,12 +81,12 @@
 		"web3-providers-ipc": "^4.0.7"
 	},
 	"dependencies": {
-		"web3-core": "^4.3.0",
-		"web3-errors": "^1.1.3",
+		"web3-core": "^4.3.1",
+		"web3-errors": "^1.1.4",
 		"web3-eth": "^4.3.1",
 		"web3-eth-abi": "^4.1.4",
 		"web3-eth-accounts": "^4.1.0",
-		"web3-eth-contract": "^4.1.2",
+		"web3-eth-contract": "^4.1.3",
 		"web3-eth-ens": "^4.0.8",
 		"web3-eth-iban": "^4.0.7",
 		"web3-eth-personal": "^4.0.8",
@@ -94,7 +94,7 @@
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
 		"web3-rpc-methods": "^1.1.3",
-		"web3-types": "^1.3.0",
+		"web3-types": "^1.3.1",
 		"web3-utils": "^4.0.7",
 		"web3-validator": "^2.0.3"
 	}

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.2.1' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.2.2' };


### PR DESCRIPTION
## [4.2.2]
### Added

#### web3-core

-   Added `isMetaMaskProvider` function to check if provider is metamask (#6534)

#### web3-types

-   Interface `MetaMaskProvider` added and is part of `SupportedProviders` (#6534)
-   `gasPrice` was added to `Transaction1559UnsignedAPI` type. (#6539)

### Changed

#### web3

-   Dependencies updated

### Fixed

#### web3-errors

-   Fixed grammar and spelling in `transactionTimeoutHint` (#6559)

#### web3-eth-contract

-	Will populate `data` for transactions in contract for metamask provider instead of `input` (#6534)
