### PR TITLE
Fix 6611 uncaught type error calling a contract's function with insufficient funds on Polygon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -704,4 +704,8 @@ Released with 1.0.0-beta.37 code base.
   - `web3-eth-accounts`: Bumped `@ethereumjs` dependencies (#6457)
   - Updated dependencies (#6491)
 
-  ## [Unreleased]
+
+## [Unreleased]
+
+### Fixed
+- Fixed uncaught exception _"TypeError: (intermediate value).data is undefined"_ calling a contract's function with insufficient funds on Polygon PoS (#6611).

--- a/packages/web3-core-method/src/index.js
+++ b/packages/web3-core-method/src/index.js
@@ -657,7 +657,10 @@ Method.prototype.buildCall = function () {
                     if (typeof err.data === 'object') {
                         // Ganache has no `originalError` sub-object unlike others
                         var originalError = err.data.originalError ?? err.data;
-                        reasonData = originalError.data.substring(10);
+                        // on Pologon PoS there is no error raison data for insufficient funds
+                        if (typeof originalError.data === 'string') {
+                            reasonData = originalError.data.substring(10);
+                        }
                     }
                     else {
                         reasonData = err.data.substring(10);

--- a/test/eth.call.revert.js
+++ b/test/eth.call.revert.js
@@ -94,5 +94,50 @@ describe('call revert', function () {
             assert.equal(error.reason, 'ImproperState');
         }
     });
+
+    it('Insufficient funds Errors on Polygon PoS through MetaMask', async function() {
+        let insufficientFundsErrorMsg = "err: insufficient funds for gas * price + value: address 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b have 78119475604576697598 want 100000000000000000000 (supplied gas 600000000)";
+        provider.injectRawError({
+            "code": -32603,
+            "message": "Internal JSON-RPC error.",
+            "data": {
+              "code": -32000,
+              "message": insufficientFundsErrorMsg
+            },
+            "stack": "Error@moz-extension://8de06240-0fd5-4f6d-8dca-318e48de4a2c/runtime-lavamoat.js:7554:17\n(...)\nr.createFetchMiddleware/<@moz-extension://8de06240-0fd5-4f6d-8dca-318e48de4a2c/background-0.js:7:45979\n"
+        });
+        provider.injectValidation(function (payload) {
+            assert.equal(payload.jsonrpc, '2.0');
+            assert.equal(payload.method, 'eth_call');
+            assert.deepEqual(
+                payload.params,
+                [{
+                    to: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+                    data: '0x23455654',
+                    value: web3.utils.toHex('100000000000000000000'),
+                    gas: '0xb',
+                    gasPrice: '0xb'
+                }, 'latest']
+            );
+        });
+
+        var options = {
+            to: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+            data: '0x23455654',
+            value: '100000000000000000000',
+            gas: 11,
+            gasPrice: 11
+        };
+
+        try {
+            await web3.eth.call(options, 'latest');
+            assert.fail('call should have failed!');
+        } catch (error) {
+            assert(error.message.startsWith("Internal JSON-RPC error."));
+            // recover internal data
+            let data = JSON.parse(error.message.slice(24));
+            assert.equal(data.message, insufficientFundsErrorMsg);
+        }
+    });
     
 });


### PR DESCRIPTION
## Description

Add a security in the the callback function of _"web3-core-methode / buildCall / send"_ in case there is no error raison data (as it can be seen for insufficient funds on Pologon PoS) to avoid throwing _"TypeError: (intermediate value).data is undefined"_ exception that can't be caught in user side.

Add a new unit test case about this to ensure non-regression.

Fixes issue #6611

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I ran `npm run lint` with success and extended the tests and types if necessary. --> Increased the function's cyclomatic complexity that was already too high.
- [x] I ran `npm run test:unit` with success. --> still 2 failing tests about re-connect
- [x] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code. --> _Missing script: "test:coverage"_. I tried `npm run test:cov` but I don't know how to interpret the result
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [x] I have tested my code on the live network. --> only on Polygon.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
