### PR TITLE
fix: contract method types should allow any param if abi type not supplied

### DIFF
--- a/packages/web3-eth-contract/src/contract.ts
+++ b/packages/web3-eth-contract/src/contract.ts
@@ -113,7 +113,7 @@ type ContractBoundMethod<
 	Abi extends AbiFunctionFragment,
 	Method extends ContractMethod<Abi> = ContractMethod<Abi>,
 > = (
-	...args: Method['Inputs']
+	...args: Method['Inputs'] extends undefined|unknown ? any[] : Method['Inputs']
 ) => Method['Abi']['stateMutability'] extends 'payable' | 'pure'
 	? PayableMethodObject<Method['Inputs'], Method['Outputs']>
 	: NonPayableMethodObject<Method['Inputs'], Method['Outputs']>;

--- a/packages/web3-eth-contract/test/integration/local_account/contract_overloaded_methods.test.ts
+++ b/packages/web3-eth-contract/test/integration/local_account/contract_overloaded_methods.test.ts
@@ -104,14 +104,12 @@ describe('contract ERC721 overloaded functions', () => {
 	it('transferFrom with 3 invalid arguments', () => {
 		expect(() =>
 			contractDeployed.methods
-				// @ts-expect-error-next-line
 				.safeTransferFrom(1, 2, 3),
 		).toThrow('Web3 validator');
 	});
 
 	it('transferFrom with 2 arguments', () => {
 		expect(() =>
-			// @ts-expect-error-next-line
 			contractDeployed.methods.safeTransferFrom(localAccount.address, localAccount.address),
 		).toThrow('Web3 validator');
 	});

--- a/packages/web3-eth-contract/test/unit/contract_typing.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract_typing.test.ts
@@ -30,7 +30,7 @@ describe('contract typing', () => {
 		const contractInstance = new Contract([]);
 
 		typecheck('should allow any input params', () => [
-			expectTypeOf<Parameters<typeof contractInstance.methods.test>>().not.toBe<[]>(),
+			expectTypeOf<Parameters<typeof contractInstance.methods.test>>().toBe<any[]>(),
 		]);
 
 	})

--- a/packages/web3-eth-contract/test/unit/contract_typing.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract_typing.test.ts
@@ -18,7 +18,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 /* eslint-disable jest/expect-expect */
 
 import { expectTypeOf, typecheck } from '@humeris/espresso-shot';
-import { Numbers } from 'web3-types';
+import { ContractConstructorArgs, Numbers } from 'web3-types';
 import { Contract } from '../../src/contract';
 import { erc20Abi, Erc20Interface } from '../fixtures/erc20';
 import { erc721Abi, Erc721Interface } from '../fixtures/erc721';
@@ -27,10 +27,23 @@ import { NonPayableMethodObject, PayableMethodObject } from '../../src';
 describe('contract typing', () => {
 
 	describe('no abi type', () => {
-		const contractInstance = new Contract([]);
+		const defaultContractInstance = new Contract([]);
+		// when using new web3.eth.Contract generic is any[] instead of never
+		const web3ContractInstance = new Contract<any[]>([]);
+
+		web3ContractInstance.deploy({
+			arguments: ["0x"]
+		})
+
+		typecheck('should allow any contract init params', () => [
+			expectTypeOf<ContractConstructorArgs<any[]>>().not.toBe<[]>(),
+			expectTypeOf<ContractConstructorArgs<never>>().not.toBe<[]>(),
+			expectTypeOf<ContractConstructorArgs<[]>>().not.toBe<[]>(),
+		]);
 
 		typecheck('should allow any input params', () => [
-			expectTypeOf<Parameters<typeof contractInstance.methods.test>>().toBe<any[]>(),
+			expectTypeOf<Parameters<typeof defaultContractInstance.methods.test>>().toBe<any[]>(),
+			expectTypeOf<Parameters<typeof web3ContractInstance.methods.test>>().toBe<any[]>(),
 		]);
 
 	})

--- a/packages/web3-eth-contract/test/unit/contract_typing.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract_typing.test.ts
@@ -25,6 +25,15 @@ import { erc721Abi, Erc721Interface } from '../fixtures/erc721';
 import { NonPayableMethodObject, PayableMethodObject } from '../../src';
 
 describe('contract typing', () => {
+
+	describe('no abi type', () => {
+		const contractInstance = new Contract([]);
+
+		typecheck('should allow any input params', () => [
+			expectTypeOf<Parameters<typeof contractInstance.methods.test>>().not.toBe<[]>(),
+		]);
+
+	})
 	describe('custom abi', () => {
 		const abi = [
 			{

--- a/packages/web3-eth-contract/test/unit/contract_typing.test.ts
+++ b/packages/web3-eth-contract/test/unit/contract_typing.test.ts
@@ -31,10 +31,6 @@ describe('contract typing', () => {
 		// when using new web3.eth.Contract generic is any[] instead of never
 		const web3ContractInstance = new Contract<any[]>([]);
 
-		web3ContractInstance.deploy({
-			arguments: ["0x"]
-		})
-
 		typecheck('should allow any contract init params', () => [
 			expectTypeOf<ContractConstructorArgs<any[]>>().not.toBe<[]>(),
 			expectTypeOf<ContractConstructorArgs<never>>().not.toBe<[]>(),

--- a/packages/web3-types/src/eth_abi_types.ts
+++ b/packages/web3-types/src/eth_abi_types.ts
@@ -316,7 +316,7 @@ export type ContractMethodInputParameters<Params extends ReadonlyArray<unknown> 
 			  [MatchPrimitiveType<H['type'], H['components']>, ...ContractMethodInputParameters<R>]
 			: ContractMethodInputParameters<R>
 		: Params extends undefined | unknown
-		? any[]
+		? []
 		: Params;
 
 export type ContractConstructor<Abis extends ContractAbi> = {

--- a/packages/web3-types/src/eth_abi_types.ts
+++ b/packages/web3-types/src/eth_abi_types.ts
@@ -316,7 +316,7 @@ export type ContractMethodInputParameters<Params extends ReadonlyArray<unknown> 
 			  [MatchPrimitiveType<H['type'], H['components']>, ...ContractMethodInputParameters<R>]
 			: ContractMethodInputParameters<R>
 		: Params extends undefined | unknown
-		? []
+		? any[]
 		: Params;
 
 export type ContractConstructor<Abis extends ContractAbi> = {


### PR DESCRIPTION
## Description

Previously type was [] (zero element tuple) instead of any[] which prevented passing parameters if contract aby type was not defined.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
