### PR TITLE
Enable users to provide feedback page

### DIFF
--- a/docs/docs/guides/feedback/index.md
+++ b/docs/docs/guides/feedback/index.md
@@ -3,7 +3,7 @@ sidebar_position: 15
 sidebar_label: '🗣️ Feedback'
 ---
 
-# Web3.js Feedback
+# Web3.js Developer Feedback
 
 We highly value your feedback to continually improve our documentation and the web3.js library. Whether you have suggestions for improvement, requests for additional features, or simply want to let us know if the documentation has been helpful, please use the form linked below to provide your feedback.
 

--- a/docs/docs/guides/feedback/index.md
+++ b/docs/docs/guides/feedback/index.md
@@ -3,7 +3,7 @@ sidebar_position: 15
 sidebar_label: '🗣️ Feedback'
 ---
 
-# Documentation Feedback
+# Web3.js Feedback
 
 We highly value your feedback to continually improve our documentation and the web3.js library. Whether you have suggestions for improvement, requests for additional features, or simply want to let us know if the documentation has been helpful, please use the form linked below to provide your feedback.
 

--- a/docs/docs/guides/feedback/index.md
+++ b/docs/docs/guides/feedback/index.md
@@ -7,11 +7,11 @@ sidebar_label: '🗣️ Feedback'
 
 We highly value your feedback to continually improve our documentation and the web3.js library. Whether you have suggestions for improvement, requests for additional features, or simply want to let us know if the documentation has been helpful, please use the form linked below to provide your feedback.
 
-## How to Provide Feedback
+## How to provide feedback
 
 Please take a moment to fill out our [Web3.js User Feedback Form](https://forms.gle/7cWt1hPU43ayS53V9) to share your thoughts.
 
-## What We'll Do with Your Feedback
+## What we will do with your feedback
 
 We review all submissions regularly and use them to improve our documentation, address any gaps or issues, and ensure that our documentation and resources meets your needs effectively.
 

--- a/docs/docs/guides/feedback/index.md
+++ b/docs/docs/guides/feedback/index.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 15
+sidebar_label: '🗣️ Feedback'
+---
+
+# Documentation Feedback
+
+We highly value your feedback to continually improve our documentation and the web3.js library. Whether you have suggestions for improvement, requests for additional features, or simply want to let us know if the documentation has been helpful, please use the form linked below to provide your feedback.
+
+## How to Provide Feedback
+
+Please take a moment to fill out our [Web3.js User Feedback Form](https://forms.gle/7cWt1hPU43ayS53V9) to share your thoughts.
+
+## What We'll Do with Your Feedback
+
+We review all submissions regularly and use them to improve our documentation, address any gaps or issues, and ensure that our documentation and resources meets your needs effectively.
+
+Thank you for taking the time to help us improve!
+
+## Urgent questions or concerns
+
+Please reach out to us:
+
+[💬 Discord: `#web3js-general` channel](https://discord.gg/f5QhHUswtr)
+
+[🐦 Twitter: `@web3_js`](https://twitter.com/web3_js)
+
+


### PR DESCRIPTION
Created page in the docs for users to provide feedback, linked it to the [google form](https://docs.google.com/forms/d/e/1FAIpQLSd-lIheuoTxyBSpF0ttwTZaTGgc0y3QlrKGafrGp9HBWwabVg/viewform)

#6738 