### PR TITLE
EIP6963 web3 provider update event

### DIFF
--- a/docs/docs/guides/web3_providers_guide/eip6963.md
+++ b/docs/docs/guides/web3_providers_guide/eip6963.md
@@ -9,7 +9,7 @@ sidebar_label: 'EIP-6963: Multi Injected Provider Discovery'
 
 EIP-6963 proposes the "Multi Injected Provider Discovery" standard, which aims to enhance the discoverability and interaction with multiple injected Ethereum providers in a browser environment. Injected providers refer to browser extensions or other injected scripts that provide access to an Ethereum provider within the context of a web application.
 
-Web3.js library has utility function for discovery of injected providers using `requestEIP6963Providers()` function. When `requestEIP6963Providers()` is used it returns `eip6963Providers` Map object. This Map object is in global scope so every time `requestEIP6963Providers()` function is called it will update Map object and return it. 
+Web3.js library has utility function for discovery of injected providers using `requestEIP6963Providers()` function. When `requestEIP6963Providers()` is called it returns Promise object that resolves to `Map<string, EIP6963ProviderDetail>` object containing list of providers. For updated providers `eip6963:providersMapUpdated` event is emitted and it has updated Map object.
 
 `eip6963Providers` Map object has provider's `UUID` as keys and `EIP6963ProviderDetail` as values. `EIP6963ProviderDetail` is:
 
@@ -40,8 +40,13 @@ Following code snippet demonstrates usage of `requestEIP6963Providers()` functio
 
 import { Web3 } from 'web3';
 
-const providers = Web3.requestEIP6963Providers();
+window.addEventListener('web3:providersMapUpdated', (event) => {
+  console.log(event.detail); // This will log the populated providers map object
+  // add logic here for updating UI of your DApp
+});
 
+// Call the function and wait for the promise to resolve
+let providers = await Web3.requestEIP6963Providers();
 for (const [key, value] of providers) {
     console.log(value);
 

--- a/docs/docs/guides/web3_providers_guide/eip6963.md
+++ b/docs/docs/guides/web3_providers_guide/eip6963.md
@@ -9,7 +9,9 @@ sidebar_label: 'EIP-6963: Multi Injected Provider Discovery'
 
 EIP-6963 proposes the "Multi Injected Provider Discovery" standard, which aims to enhance the discoverability and interaction with multiple injected Ethereum providers in a browser environment. Injected providers refer to browser extensions or other injected scripts that provide access to an Ethereum provider within the context of a web application.
 
-Web3.js library has utility function for discovery of injected providers using `requestEIP6963Providers()` function. When `requestEIP6963Providers()` is called it returns Promise object that resolves to `Map<string, EIP6963ProviderDetail>` object containing list of providers. For updated providers `eip6963:providersMapUpdated` event is emitted and it has updated Map object.
+Web3.js library has utility functions for discovery of injected providers using `requestEIP6963Providers()` and `onNewProviderDiscovered(eventDetails)`. 
+
+`onNewProviderDiscovered(eventDetails)` can be used to subscribe to events of provider discovery & providers map update and `requestEIP6963Providers()` returns Promise object that resolves to `Map<string, EIP6963ProviderDetail>` object containing list of providers. For updated providers `eip6963:providersMapUpdated` event is emitted and it has updated Map object. This event can be subscribed as mentioned earlier using `onNewProviderDiscovered(eventDetails)`
 
 `eip6963ProvidersMap` object has provider's `UUID` as keys and `EIP6963ProviderDetail` as values. `EIP6963ProviderDetail` is:
 
@@ -40,9 +42,11 @@ Following code snippet demonstrates usage of `requestEIP6963Providers()` functio
 
 import { Web3 } from 'web3';
 
-window.addEventListener('web3:providersMapUpdated', (event) => {
-  console.log(event.detail); // This will log the populated providers map object
-  // add logic here for updating UI of your DApp
+// Following will subscribe to event that will be triggered when providers map is updated.
+
+Web3.onNewProviderDiscovered((provider) => {
+  console.log(provider.detail); // This will log the populated providers map object, provider.detail has Map of all providers yet discovered
+   // add logic here for updating UI of your DApp
 });
 
 // Call the function and wait for the promise to resolve

--- a/docs/docs/guides/web3_providers_guide/eip6963.md
+++ b/docs/docs/guides/web3_providers_guide/eip6963.md
@@ -11,7 +11,7 @@ EIP-6963 proposes the "Multi Injected Provider Discovery" standard, which aims t
 
 Web3.js library has utility function for discovery of injected providers using `requestEIP6963Providers()` function. When `requestEIP6963Providers()` is called it returns Promise object that resolves to `Map<string, EIP6963ProviderDetail>` object containing list of providers. For updated providers `eip6963:providersMapUpdated` event is emitted and it has updated Map object.
 
-`eip6963Providers` Map object has provider's `UUID` as keys and `EIP6963ProviderDetail` as values. `EIP6963ProviderDetail` is:
+`eip6963ProvidersMap` object has provider's `UUID` as keys and `EIP6963ProviderDetail` as values. `EIP6963ProviderDetail` is:
 
 ```ts
 export interface EIP6963ProviderDetail {

--- a/packages/web3/src/providers.exports.ts
+++ b/packages/web3/src/providers.exports.ts
@@ -19,3 +19,4 @@ export { Eip1193Provider, SocketProvider } from 'web3-utils';
 
 export * as http from 'web3-providers-http';
 export * as ws from 'web3-providers-ws';
+export * from './web3_eip6963.js';

--- a/packages/web3/src/web3.ts
+++ b/packages/web3/src/web3.ts
@@ -44,7 +44,7 @@ import abi from './abi.js';
 import { initAccountsForContext } from './accounts.js';
 import { Web3EthInterface } from './types.js';
 import { Web3PkgInfo } from './version.js';
-import { requestEIP6963Providers } from './web3_eip6963.js';
+import { onNewProviderDiscovered, requestEIP6963Providers } from './web3_eip6963.js';
 
 export class Web3<
 	CustomRegisteredSubscription extends {
@@ -54,6 +54,7 @@ export class Web3<
 	public static version = Web3PkgInfo.version;
 	public static utils = utils;
 	public static requestEIP6963Providers = requestEIP6963Providers;
+	public static onNewProviderDiscovered = onNewProviderDiscovered;
 	public static modules = {
 		Web3Eth,
 		Iban,

--- a/packages/web3/src/web3_eip6963.ts
+++ b/packages/web3/src/web3_eip6963.ts
@@ -52,8 +52,8 @@ export interface EIP6963ProvidersMapUpdateEvent extends CustomEvent {
   detail: Map<string, EIP6963ProviderDetail>;
 }
 
-export const requestEIP6963Providers = () => {
-  return new Promise((resolve, reject) => {
+export const requestEIP6963Providers = async () => 
+   new Promise((resolve, reject) => {
     if (typeof window === 'undefined') {
       reject(new Error("window object not available, EIP-6963 is intended to be used within a browser"));
     }
@@ -80,6 +80,12 @@ export const requestEIP6963Providers = () => {
   window.dispatchEvent(new Event(Eip6963EventName.eip6963requestProvider));
 
   });
-}
 
+
+export const onNewProviderDiscovered = (callback: (providerEvent: EIP6963AnnounceProviderEvent) => void) => {
+  if (typeof window === 'undefined') {
+    throw new Error("window object not available, EIP-6963 is intended to be used within a browser");
+  }
+  window.addEventListener(web3ProvidersMapUpdated as any, callback );
+}
 

--- a/packages/web3/src/web3_eip6963.ts
+++ b/packages/web3/src/web3_eip6963.ts
@@ -44,28 +44,42 @@ export interface EIP6963RequestProviderEvent extends Event {
   type: Eip6963EventName.eip6963requestProvider;
 }
 
-export const eip6963Providers: Map<string, EIP6963ProviderDetail> = new Map();
+export const eip6963ProvidersMap: Map<string, EIP6963ProviderDetail> = new Map();
+
+export const web3ProvidersMapUpdated = "web3:providersMapUpdated";
+export interface EIP6963ProvidersMapUpdateEvent extends CustomEvent {
+  type: string;
+  detail: Map<string, EIP6963ProviderDetail>;
+}
 
 export const requestEIP6963Providers = () => {
-
-  if (typeof window === 'undefined')
-    throw new Error(
-      "window object not available, EIP-6963 is intended to be used within a browser"
-    );
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined') {
+      reject(new Error("window object not available, EIP-6963 is intended to be used within a browser"));
+    }
 
   window.addEventListener(
     Eip6963EventName.eip6963announceProvider as any,
     (event: EIP6963AnnounceProviderEvent) => {
 
-      eip6963Providers.set(
+      eip6963ProvidersMap.set(
         event.detail.info.uuid,
         event.detail);
+
+      const newEvent: EIP6963ProvidersMapUpdateEvent = new CustomEvent(
+        web3ProvidersMapUpdated,
+        { detail: eip6963ProvidersMap }
+        );
+
+      window.dispatchEvent(newEvent);
+      resolve(eip6963ProvidersMap);
+
     }
   );
 
   window.dispatchEvent(new Event(Eip6963EventName.eip6963requestProvider));
 
-  return eip6963Providers;
+  });
 }
 
 

--- a/packages/web3/test/unit/web3eip6963.test.ts
+++ b/packages/web3/test/unit/web3eip6963.test.ts
@@ -16,71 +16,48 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import {
-	EIP6963AnnounceProviderEvent,
-	EIP6963ProviderDetail,
-	Eip6963EventName,
-	eip6963Providers,
 	requestEIP6963Providers
 } from "../../src/web3_eip6963";
 
+
+
 describe('requestEIP6963Providers', () => {
+  it('should reject with an error if window object is not available', async () => {
+    // Mocking window object absence
+    (global as any).window = undefined;
 
-	it('should request EIP6963 providers and store them in eip6963Providers', () => {
+    await expect(requestEIP6963Providers()).rejects.toThrow("window object not available, EIP-6963 is intended to be used within a browser");
+  });
 
-		const mockProviderDetail: EIP6963ProviderDetail = {
-			info: {
-				uuid: '1',
-				name: 'MockProvider',
-				icon: 'icon-path',
-				rdns: 'mock.rdns'
-			},
+  it('should resolve with updated providers map when events are triggered', async () => {
+    class CustomEventPolyfill extends Event {
+      detail: any;
+      constructor(eventType: string, eventInitDict: any) {
+        super(eventType, eventInitDict);
+        this.detail = eventInitDict.detail;
+      }
+    }
+    
+    (global as any).CustomEvent = CustomEventPolyfill;
+    
+    const mockProviderDetail = {
+      info: { uuid: 'test-uuid', name: 'Test Provider', icon: 'test-icon', rdns: 'test-rdns' },
+      provider: {} // Mock provider object
+    };
 
-			provider: {} as any
-		};
+    const mockEvent = {
+      type: 'eip6963:announceProvider',
+      detail: mockProviderDetail
+    };
 
-		const mockAnnounceEvent: EIP6963AnnounceProviderEvent = {
-			type: Eip6963EventName.eip6963announceProvider,
-			detail: mockProviderDetail
-		} as any;
+    // Mock window methods
+    (global as any).window  = {
+      addEventListener: jest.fn().mockImplementation((_event, callback) => callback(mockEvent)),
+      dispatchEvent: jest.fn()
+    };
 
-		// Mock the window object
-		(global as any).window = {
-			addEventListener: jest.fn(),
-			dispatchEvent: jest.fn()
-		};
+    const result = await requestEIP6963Providers();
 
-		// Call the function
-		requestEIP6963Providers();
-
-		// Validate event listener setup and event dispatch
-		expect((global as any).window.addEventListener)
-			.toHaveBeenCalledWith(Eip6963EventName.eip6963announceProvider, expect.any(Function));
-
-		expect((global as any).window.dispatchEvent).toHaveBeenCalled();
-
-		// Simulate the announce event
-		// Access the mock function calls for addEventListener
-		const addEventListenerMockCalls = (global as any).window.addEventListener.mock.calls;
-
-		// Retrieve the first call to addEventListener and access its second argument
-		const eventListenerArg = addEventListenerMockCalls[0][1];
-
-		// Now "eventListenerArg" represents the function to be called when the event occurs
-		const announceEventListener = eventListenerArg;
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-		announceEventListener(mockAnnounceEvent);
-
-		// Validate if the provider detail is stored in the eip6963Providers map
-		expect(eip6963Providers.get('1')).toEqual(mockProviderDetail);
-	});
-
-	it('should throw an error if window object is not available', () => {
-		// Remove the window object
-		delete (global as any).window;
-
-		// Call the function and expect it to throw an error
-		expect(() => {
-			requestEIP6963Providers();
-		}).toThrow("window object not available, EIP-6963 is intended to be used within a browser");
-	});
+    expect(result).toEqual(new Map([['test-uuid', mockProviderDetail]]));
+  });
 });

--- a/packages/web3/test/unit/web3eip6963.test.ts
+++ b/packages/web3/test/unit/web3eip6963.test.ts
@@ -31,8 +31,8 @@ describe('requestEIP6963Providers', () => {
 
   it('should resolve with updated providers map when events are triggered', async () => {
     class CustomEventPolyfill extends Event {
-      detail: any;
-      constructor(eventType: string, eventInitDict: any) {
+      public detail: any;
+      public constructor(eventType: string, eventInitDict: any) {
         super(eventType, eventInitDict);
         this.detail = eventInitDict.detail;
       }
@@ -52,7 +52,9 @@ describe('requestEIP6963Providers', () => {
 
     // Mock window methods
     (global as any).window  = {
-      addEventListener: jest.fn().mockImplementation((_event, callback) => callback(mockEvent)),
+      addEventListener: jest.fn().mockImplementation(
+
+          (_event, callback) => callback(mockEvent)), // eslint-disable-line
       dispatchEvent: jest.fn()
     };
 

--- a/packages/web3/test/unit/web3eip6963.test.ts
+++ b/packages/web3/test/unit/web3eip6963.test.ts
@@ -16,16 +16,16 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import {
+  onNewProviderDiscovered,
 	requestEIP6963Providers
 } from "../../src/web3_eip6963";
-
-
 
 describe('requestEIP6963Providers', () => {
   it('should reject with an error if window object is not available', async () => {
     // Mocking window object absence
     (global as any).window = undefined;
 
+     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     await expect(requestEIP6963Providers()).rejects.toThrow("window object not available, EIP-6963 is intended to be used within a browser");
   });
 
@@ -62,4 +62,30 @@ describe('requestEIP6963Providers', () => {
 
     expect(result).toEqual(new Map([['test-uuid', mockProviderDetail]]));
   });
+
+  it('onNewProviderDiscovered should throw an error if window object is not available', () => {
+    // Mock the window object not being available
+    (global as any).window = undefined;
+
+    // Expect an error to be thrown
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onNewProviderDiscovered((_providerEvent) => {});
+    }).toThrow("window object not available, EIP-6963 is intended to be used within a browser");
+
+
+  });
+
+  it('onNewProviderDiscovered should add an event listener when window object is available', () => {
+    (global as any).window = {
+      addEventListener: jest.fn(),
+    };
+
+    const callback = jest.fn();
+    onNewProviderDiscovered(callback);
+
+    // Expect the callback to have been called when the event listener is added
+    expect(global.window.addEventListener).toHaveBeenCalledWith('web3:providersMapUpdated', callback);
+  });
+
 });


### PR DESCRIPTION
## Description

Related with: https://github.com/web3/web3.js/issues/6201
https://github.com/web3/web3.js/issues/6859
now `requestEIP6963Providers` return promise resolving to `Map<string, EIP6963ProviderDetail>` containing providers list, and it will emit `web3:providersMapUpdated` event for any update to above map obj

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
