### PR TITLE
web3-eth-ens add gettext and getname

### DIFF
--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -148,3 +148,7 @@ Documentation:
 -   Added function `setAddress` in ENS and Resolver classes (#5956)
 
 ## [Unreleased]
+
+### Add
+
+- Added function getText and getName in ENS and resolver classes

--- a/packages/web3-eth-ens/src/config.ts
+++ b/packages/web3-eth-ens/src/config.ts
@@ -29,7 +29,7 @@ export const interfaceIds: { [T: string]: string } = {
 };
 
 /**
- * An object holding the functionsthat are supported by the ENS resolver contracts/interfaces.
+ * An object holding the functions that are supported by the ENS resolver contracts/interfaces.
  */
 export const methodsInInterface: { [T: string]: string } = {
 	setAddr: 'addr',
@@ -38,6 +38,8 @@ export const methodsInInterface: { [T: string]: string } = {
 	pubkey: 'pubkey',
 	setContenthash: 'contenthash',
 	contenthash: 'contenthash',
+	text: 'text',
+	name: 'name',
 };
 
 /**

--- a/packages/web3-eth-ens/src/ens.ts
+++ b/packages/web3-eth-ens/src/ens.ts
@@ -177,12 +177,12 @@ export class ENS extends Web3Context<EthExecutionAPI & Web3NetAPI> {
 
 
 	/**
-	 * Resolves an ENS name to an Ethereum address.
-	 * @param address - The address to resolve
-	 * @returns - The ENS name of the given address
+	 * Resolves the name of an ENS node.
+	 * @param ENSName - The node to resolve
+	 * @returns - The name
 	 */
-	public async getName(address: string): Promise<string> {
-		return this._resolver.getName(address);
+	public async getName(ENSName: string): Promise<string> {
+		return this._resolver.getName(ENSName);
 	}
 
 	/**

--- a/packages/web3-eth-ens/src/ens.ts
+++ b/packages/web3-eth-ens/src/ens.ts
@@ -166,6 +166,13 @@ export class ENS extends Web3Context<EthExecutionAPI & Web3NetAPI> {
 	}
 
 	/**
+	 * ERC-634 - Returns the text content stored in the resolver for the specified key.
+	 */
+	public async getText(ENSName: string, key: string): Promise<string> {
+		return this._resolver.text(ENSName, key);
+	}
+
+	/**
 	 * Returns the X and Y coordinates of the curve point for the public key.
 	 * @param ENSName - The ENS name
 	 * @returns - The X and Y coordinates of the curve point for the public key

--- a/packages/web3-eth-ens/src/ens.ts
+++ b/packages/web3-eth-ens/src/ens.ts
@@ -167,9 +167,22 @@ export class ENS extends Web3Context<EthExecutionAPI & Web3NetAPI> {
 
 	/**
 	 * ERC-634 - Returns the text content stored in the resolver for the specified key.
+	 * @param ENSName - The ENS name to resolve
+	 * @param key - The key to resolve https://github.com/ethereum/ercs/blob/master/ERCS/erc-634.md#global-keys
+	 * @returns - The value content stored in the resolver for the specified key
 	 */
 	public async getText(ENSName: string, key: string): Promise<string> {
-		return this._resolver.text(ENSName, key);
+		return this._resolver.getText(ENSName, key);
+	}
+
+
+	/**
+	 * Resolves an ENS name to an Ethereum address.
+	 * @param address - The address to resolve
+	 * @returns - The ENS name of the given address
+	 */
+	public async getName(address: string): Promise<string> {
+		return this._resolver.getName(address);
 	}
 
 	/**

--- a/packages/web3-eth-ens/src/resolver.ts
+++ b/packages/web3-eth-ens/src/resolver.ts
@@ -117,4 +117,25 @@ export class Resolver {
 			.setAddr(namehash(ENSName), address)
 			.send(txConfig);
 	}
+
+	public async getText(
+		ENSName: string,
+		key: string,
+	) {
+		const resolverContract = await this.getResolverContractAdapter(ENSName);
+		await this.checkInterfaceSupport(resolverContract, methodsInInterface.text);
+
+		return resolverContract.methods
+			.text(namehash(ENSName), key).call()
+	}
+
+	public async getName(
+		ENSName: string
+	) {
+		const resolverContract = await this.getResolverContractAdapter(ENSName);
+		await this.checkInterfaceSupport(resolverContract, methodsInInterface.name);
+
+		return resolverContract.methods
+			.name(namehash(ENSName)).call()
+	}
 }

--- a/packages/web3-eth-ens/src/resolver.ts
+++ b/packages/web3-eth-ens/src/resolver.ts
@@ -130,12 +130,12 @@ export class Resolver {
 	}
 
 	public async getName(
-		ENSName: string
+		address: string
 	) {
-		const resolverContract = await this.getResolverContractAdapter(ENSName);
+		const resolverContract = await this.getResolverContractAdapter(address);
 		await this.checkInterfaceSupport(resolverContract, methodsInInterface.name);
 
 		return resolverContract.methods
-			.name(namehash(ENSName)).call()
+			.name(namehash(address)).call()
 	}
 }

--- a/packages/web3-eth-ens/test/unit/resolver.test.ts
+++ b/packages/web3-eth-ens/test/unit/resolver.test.ts
@@ -211,6 +211,60 @@ describe('resolver', () => {
 		});
 	});
 
+	describe('text', () => {
+		it('getText', async () => {
+			const supportsInterfaceMock = jest
+				.spyOn(contract.methods, 'supportsInterface')
+				.mockReturnValue({
+					call: async () => Promise.resolve(true),
+				} as unknown as NonPayableMethodObject<any, any>);
+
+				const textMock = jest.spyOn(contract.methods, 'text').mockReturnValue({
+					call: jest.fn(),
+				} as unknown as NonPayableMethodObject<any, any>);
+
+				jest.spyOn(registry, 'getResolver').mockImplementation(async () => {
+					return new Promise(resolve => {
+						resolve(contract);
+					});
+				});
+	
+				await resolver.getText(ENS_NAME, "key");
+				expect(supportsInterfaceMock).toHaveBeenCalledWith(
+					interfaceIds[methodsInInterface.text],
+				);
+				expect(textMock).toHaveBeenCalledWith(namehash(ENS_NAME), "key");
+	})
+})
+
+	describe('name', () => {
+		it('getName', async () => {
+			const supportsInterfaceMock = jest
+				.spyOn(contract.methods, 'supportsInterface')
+				.mockReturnValue({
+					call: async () => Promise.resolve(true),
+				} as unknown as NonPayableMethodObject<any, any>);
+
+				const nameMock = jest.spyOn(contract.methods, 'name').mockReturnValue({
+					call: jest.fn(),
+				} as unknown as NonPayableMethodObject<any, any>);
+
+				jest.spyOn(registry, 'getResolver').mockImplementation(async () => {
+					return new Promise(resolve => {
+						resolve(contract);
+					});
+				});
+	
+				await resolver.getName(ENS_NAME);
+				expect(supportsInterfaceMock).toHaveBeenCalledWith(
+					interfaceIds[methodsInInterface.name],
+				);
+		
+				expect(nameMock).toHaveBeenCalledWith(namehash(ENS_NAME));
+		})
+	})
+	
+
 	describe('supportsInterface', () => {
 		it('check supportsInterface for non strict hex id', async () => {
 			const interfaceId = 'setAddr';


### PR DESCRIPTION
## Description
Adding resolver methods gettext and getname in the ens package neccesary for web3modal 
Please include a summary of the changes and be sure to follow our [Contribution Guidelines](https://github.com/web3/web3.js/blob/4.x/.github/CONTRIBUTING.md).

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
