### PR TITLE
fix: regex spelling uniformity

### DIFF
--- a/packages/web3/test/integration/web3.accounts.test.ts
+++ b/packages/web3/test/integration/web3.accounts.test.ts
@@ -25,7 +25,7 @@ import {
 } from '../shared_fixtures/system_tests_utils';
 import Web3, { SupportedProviders } from '../../src/index';
 
-const hexRegx = /0[xX][0-9a-fA-F]+/;
+const hexRegex = /0[xX][0-9a-fA-F]+/;
 
 describe('web3.accounts', () => {
 	let clientUrl: string | SupportedProviders;
@@ -51,8 +51,8 @@ describe('web3.accounts', () => {
 
 			expect(account).toEqual(
 				expect.objectContaining({
-					address: expect.stringMatching(hexRegx),
-					privateKey: expect.stringMatching(hexRegx),
+					address: expect.stringMatching(hexRegex),
+					privateKey: expect.stringMatching(hexRegex),
 				}),
 			);
 		});
@@ -86,12 +86,12 @@ describe('web3.accounts', () => {
 
 				expect(signedTx).toEqual(
 					expect.objectContaining({
-						messageHash: expect.stringMatching(hexRegx),
-						rawTransaction: expect.stringMatching(hexRegx),
-						transactionHash: expect.stringMatching(hexRegx),
-						v: expect.stringMatching(hexRegx),
-						r: expect.stringMatching(hexRegx),
-						s: expect.stringMatching(hexRegx),
+						messageHash: expect.stringMatching(hexRegex),
+						rawTransaction: expect.stringMatching(hexRegex),
+						transactionHash: expect.stringMatching(hexRegex),
+						v: expect.stringMatching(hexRegex),
+						r: expect.stringMatching(hexRegex),
+						s: expect.stringMatching(hexRegex),
 					}),
 				);
 
@@ -163,12 +163,12 @@ describe('web3.accounts', () => {
 
 			expect(signedTx).toEqual(
 				expect.objectContaining({
-					messageHash: expect.stringMatching(hexRegx),
-					rawTransaction: expect.stringMatching(hexRegx),
-					transactionHash: expect.stringMatching(hexRegx),
-					v: expect.stringMatching(hexRegx),
-					r: expect.stringMatching(hexRegx),
-					s: expect.stringMatching(hexRegx),
+					messageHash: expect.stringMatching(hexRegex),
+					rawTransaction: expect.stringMatching(hexRegex),
+					transactionHash: expect.stringMatching(hexRegex),
+					v: expect.stringMatching(hexRegex),
+					r: expect.stringMatching(hexRegex),
+					s: expect.stringMatching(hexRegex),
 				}),
 			);
 


### PR DESCRIPTION
## Description

Regex spelling is unified with other files (/web3-eth/test/integration/helper.ts, web3-eth-abi/src/eip_712)

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
