### PR TITLE
fix: toHex not supporting Uint8Array

### DIFF
--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -206,3 +206,8 @@ Documentation:
 - fixed erroneous parsing of big numbers in the `toNumber(...)` function (#6880)
 
 ## [Unreleased]
+
+### Fixed
+
+- fixed toHex incorrectly hexing Uint8Arrays and Buffer (#6957)
+- fixed isUint8Array not returning true for Buffer

--- a/packages/web3-utils/src/converters.ts
+++ b/packages/web3-utils/src/converters.ts
@@ -362,6 +362,10 @@ export const toHex = (
 		return returnType ? 'bigint' : numberToHex(value);
 	}
 
+	if(value instanceof Uint8Array) {
+		return returnType ? 'bytes' : bytesToHex(value);
+	}
+
 	if (typeof value === 'object' && !!value) {
 		return returnType ? 'string' : utf8ToHex(JSON.stringify(value));
 	}

--- a/packages/web3-utils/src/converters.ts
+++ b/packages/web3-utils/src/converters.ts
@@ -362,7 +362,7 @@ export const toHex = (
 		return returnType ? 'bigint' : numberToHex(value);
 	}
 
-	if(value instanceof Uint8Array) {
+	if(isUint8Array(value)) {
 		return returnType ? 'bytes' : bytesToHex(value);
 	}
 

--- a/packages/web3-utils/src/uint8array.ts
+++ b/packages/web3-utils/src/uint8array.ts
@@ -18,7 +18,8 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 export function isUint8Array(data: unknown | Uint8Array): data is Uint8Array {
 	return (
 		data instanceof Uint8Array ||
-		(data as { constructor: { name: string } })?.constructor?.name === 'Uint8Array'
+		(data as { constructor: { name: string } })?.constructor?.name === 'Uint8Array' ||
+		(data as { constructor: { name: string } })?.constructor?.name === 'Buffer'
 	);
 }
 

--- a/packages/web3-utils/test/fixtures/converters.ts
+++ b/packages/web3-utils/test/fixtures/converters.ts
@@ -235,6 +235,22 @@ export const toHexValidData: [Numbers | Bytes | Address | boolean, [HexString, V
 	],
 	['-0x01', ['-0x1', 'int256']],
 	['123c', ['0x123c', 'bytes']],
+	[new Uint8Array([
+		221, 128, 128, 128, 148, 186, 248,
+		242, 159, 130, 231, 84, 254, 199,
+		252, 69, 21, 58, 104, 102, 201,
+		137, 255, 3, 196, 10, 128, 128,
+		128, 128
+		]), ['0xdd80808094baf8f29f82e754fec7fc45153a6866c989ff03c40a80808080', 'bytes']],
+	// this works but jest has bug since forever where they modify global Buffer object: https://github.com/jestjs/jest/issues/2549
+	// [Buffer.from([
+	// 	221, 128, 128, 128, 148, 186, 248,
+	// 	242, 159, 130, 231, 84, 254, 199,
+	// 	252, 69, 21, 58, 104, 102, 201,
+	// 	137, 255, 3, 196, 10, 128, 128,
+	// 	128, 128
+	// 	]), ['0xdd80808094baf8f29f82e754fec7fc45153a6866c989ff03c40a80808080', 'bytes']]
+
 ];
 
 export const toHexInvalidData: [any, string][] = [

--- a/packages/web3-utils/test/fixtures/converters.ts
+++ b/packages/web3-utils/test/fixtures/converters.ts
@@ -242,14 +242,13 @@ export const toHexValidData: [Numbers | Bytes | Address | boolean, [HexString, V
 		137, 255, 3, 196, 10, 128, 128,
 		128, 128
 		]), ['0xdd80808094baf8f29f82e754fec7fc45153a6866c989ff03c40a80808080', 'bytes']],
-	// this works but jest has bug since forever where they modify global Buffer object: https://github.com/jestjs/jest/issues/2549
-	// [Buffer.from([
-	// 	221, 128, 128, 128, 148, 186, 248,
-	// 	242, 159, 130, 231, 84, 254, 199,
-	// 	252, 69, 21, 58, 104, 102, 201,
-	// 	137, 255, 3, 196, 10, 128, 128,
-	// 	128, 128
-	// 	]), ['0xdd80808094baf8f29f82e754fec7fc45153a6866c989ff03c40a80808080', 'bytes']]
+	[Buffer.from([
+		221, 128, 128, 128, 148, 186, 248,
+		242, 159, 130, 231, 84, 254, 199,
+		252, 69, 21, 58, 104, 102, 201,
+		137, 255, 3, 196, 10, 128, 128,
+		128, 128
+		]), ['0xdd80808094baf8f29f82e754fec7fc45153a6866c989ff03c40a80808080', 'bytes']]
 
 ];
 

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -169,3 +169,7 @@ Documentation:
 - Multi-dimensional arrays(with a fix length) are now handled properly when parsing ABIs (#6798)
 
 ## [Unreleased]
+
+### Fixed
+
+- Nodejs Buffer is not recognized as valid bytes value

--- a/packages/web3-validator/src/validation/bytes.ts
+++ b/packages/web3-validator/src/validation/bytes.ts
@@ -23,7 +23,7 @@ import { isHexStrict } from './string.js';
  * checks input if typeof data is valid Uint8Array input
  */
 export const isUint8Array = (data: ValidInputTypes): data is Uint8Array =>
-	data instanceof Uint8Array || data?.constructor?.name === 'Uint8Array';
+	data instanceof Uint8Array || data?.constructor?.name === 'Uint8Array' || data?.constructor?.name === 'Buffer';
 
 export const isBytes = (
 	value: ValidInputTypes | Uint8Array | number[],

--- a/packages/web3-validator/test/fixtures/validation.ts
+++ b/packages/web3-validator/test/fixtures/validation.ts
@@ -647,6 +647,8 @@ export const validBytesData: any[] = [
 	[2, 3, 255],
 	new Uint8Array(hexToBytes('abce')),
 	new Uint8Array([0x91, 0x92]),
+	Buffer.from([0x91, 0x92]),
+
 ];
 
 export const validBytesDataWithSize: [any, number][] = [


### PR DESCRIPTION
## Description

Please include a summary of the changes and be sure to follow our [Contribution Guidelines](https://github.com/web3/web3.js/blob/4.x/.github/CONTRIBUTING.md).

Fixes #6957 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
