### PR TITLE
fix: web3-validator browser target removed

### DIFF
--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -173,3 +173,4 @@ Documentation:
 ### Fixed
 
 - The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings.
+-  `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -11,7 +11,6 @@
 			"require": "./lib/commonjs/index.js"
 		}
 	},
-	"browser": "./dist/web3-validator.min.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"author": "ChainSafe Systems",
 	"license": "LGPL-3.0",


### PR DESCRIPTION
## Description

- `browser` target was removed from `web3-validator` package since the referenced file is not included in the package

Fixes #7015 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
