### PR TITLE
add gas conditional if simple transaction

### DIFF
--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -242,3 +242,7 @@ Documentation:
 ### Changed
 
 -   Added parameter `customTransactionReceiptSchema` into methods `emitConfirmation`, `waitForTransactionReceipt`, `watchTransactionByPolling`, `watchTransactionBySubscription`, `watchTransactionForConfirmations` (#7000)
+
+### Fixed
+
+-   Fixed issue with simple transactions, Within `checkRevertBeforeSending` if there is no data set in transaction, set gas to be `21000` (#7043)

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -581,6 +581,7 @@ export function sendTransaction<
 							transaction,
 							transactionFormatted,
 						});
+						
 						await sendTxHelper.checkRevertBeforeSending(
 							transactionFormatted as TransactionCall,
 						);

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -575,7 +575,7 @@ export function sendTransaction<
 						},
 						ETH_DATA_FORMAT,
 					);
-					
+
 					try {
 						transactionFormatted = await sendTxHelper.populateGasPrice({
 							transaction,

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -581,7 +581,7 @@ export function sendTransaction<
 							transaction,
 							transactionFormatted,
 						});
-						
+
 						await sendTxHelper.checkRevertBeforeSending(
 							transactionFormatted as TransactionCall,
 						);

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -575,13 +575,12 @@ export function sendTransaction<
 						},
 						ETH_DATA_FORMAT,
 					);
-
+					
 					try {
 						transactionFormatted = await sendTxHelper.populateGasPrice({
 							transaction,
 							transactionFormatted,
 						});
-
 						await sendTxHelper.checkRevertBeforeSending(
 							transactionFormatted as TransactionCall,
 						);

--- a/packages/web3-eth/src/utils/send_tx_helper.ts
+++ b/packages/web3-eth/src/utils/send_tx_helper.ts
@@ -122,7 +122,14 @@ export class SendTxHelper<
 
 	public async checkRevertBeforeSending(tx: TransactionCall) {
 		if (this.options.checkRevertBeforeSending !== false) {
-			const reason = await getRevertReason(this.web3Context, tx, this.options.contractAbi);
+			let formatTx = tx;
+			if (tx.data === undefined && tx.gas === undefined) { // eth.call will run into an error if data isnt filled and gas is not defined, simple transaction so we fill it with 21000
+				formatTx = {
+					...tx,
+					gas: 21000
+				}
+			}
+			const reason = await getRevertReason(this.web3Context, formatTx, this.options.contractAbi);
 			if (reason !== undefined) {
 				throw await getTransactionError<ReturnFormat>(
 					this.web3Context,

--- a/packages/web3-eth/src/utils/send_tx_helper.ts
+++ b/packages/web3-eth/src/utils/send_tx_helper.ts
@@ -123,7 +123,7 @@ export class SendTxHelper<
 	public async checkRevertBeforeSending(tx: TransactionCall) {
 		if (this.options.checkRevertBeforeSending !== false) {
 			let formatTx = tx;
-			if (tx.data === undefined && tx.input && tx.gas === undefined) { // eth.call runs into error if data isnt filled and gas is not defined, its a simple transaction so we fill it with 21000
+			if (isNullish(tx.data) && isNullish(tx.input) && isNullish(tx.gas)) { // eth.call runs into error if data isnt filled and gas is not defined, its a simple transaction so we fill it with 21000
 				formatTx = {
 					...tx,
 					gas: 21000

--- a/packages/web3-eth/src/utils/send_tx_helper.ts
+++ b/packages/web3-eth/src/utils/send_tx_helper.ts
@@ -123,7 +123,7 @@ export class SendTxHelper<
 	public async checkRevertBeforeSending(tx: TransactionCall) {
 		if (this.options.checkRevertBeforeSending !== false) {
 			let formatTx = tx;
-			if (tx.data === undefined && tx.gas === undefined) { // eth.call will run into an error if data isnt filled and gas is not defined, simple transaction so we fill it with 21000
+			if (tx.data === undefined && tx.input && tx.gas === undefined) { // eth.call runs into error if data isnt filled and gas is not defined, its a simple transaction so we fill it with 21000
 				formatTx = {
 					...tx,
 					gas: 21000

--- a/packages/web3-eth/test/unit/send_tx_helper.test.ts
+++ b/packages/web3-eth/test/unit/send_tx_helper.test.ts
@@ -21,6 +21,7 @@ import {
 	JsonRpcResponse,
 	TransactionReceipt,
 	Web3BaseWalletAccount,
+	TransactionCall
 } from 'web3-types';
 import { Web3Context, Web3EventMap, Web3PromiEvent } from 'web3-core';
 import {
@@ -150,6 +151,29 @@ describe('sendTxHelper class', () => {
 		await sendTxHelper.handleError({ error, tx: receipt });
 		expect(f).toHaveBeenCalledWith(error);
 		promiEvent.off('error', f);
+	});
+
+	it('add gas to simple transaction in checkRevertBeforeSending', async () => {
+		const _sendTxHelper = new SendTxHelper({
+			web3Context,
+			promiEvent: promiEvent as PromiEvent,
+			options: {
+				checkRevertBeforeSending: true,
+			},
+			returnFormat: DEFAULT_RETURN_FORMAT,
+		});
+		jest.spyOn(utils, 'getRevertReason').mockResolvedValue(undefined);
+
+		const tx = {from:"0x"} as TransactionCall
+
+        await _sendTxHelper.checkRevertBeforeSending(tx);
+
+        const expectedTx = {
+            ...tx,
+            gas: 21000,
+        };
+		expect(utils.getRevertReason).toHaveBeenCalledWith(web3Context, expectedTx);
+
 	});
 	it('emit handleError with handleRevert', async () => {
 		const error = new ContractExecutionError({ code: 1, message: 'error' });

--- a/packages/web3-eth/test/unit/send_tx_helper.test.ts
+++ b/packages/web3-eth/test/unit/send_tx_helper.test.ts
@@ -162,7 +162,6 @@ describe('sendTxHelper class', () => {
 			},
 			returnFormat: DEFAULT_RETURN_FORMAT,
 		});
-		jest.spyOn(utils, 'getRevertReason').mockResolvedValue(undefined);
 
 		const tx = {from:"0x"} as TransactionCall
 
@@ -172,7 +171,7 @@ describe('sendTxHelper class', () => {
             ...tx,
             gas: 21000,
         };
-		expect(utils.getRevertReason).toHaveBeenCalledWith(web3Context, expectedTx);
+		expect(utils.getRevertReason).toHaveBeenCalledWith(web3Context, expectedTx, undefined);
 
 	});
 	it('emit handleError with handleRevert', async () => {


### PR DESCRIPTION
## Description
#7021 
There seems to be a bug when using sendTransaction with no gas property in the rpc method eth_call in `checkRevertBeforeSending`. Testing with both metamask and an infura provider, with a simple transaction (with no data or input so no contract call)
eth_call will revert and say there is insufficient funds when there should be easily enough funds to cover the gas and value. 
The transaction looks like 
```
const tx = {
        to: 0,
        value:1,
        from: accounts[0].address,
    }
```
```
InvalidResponseError: Returned error: err: insufficient funds for gas * price + value: address 0xBe1320eA9Fd1b34C0cf664eFbb29CF2dBD3cC81b have 100000000000000000 want 2859580732500000001 (supplied gas 50000000)
    at Web3RequestManager._processJsonRpcResponse (/Users/alexluu/practice/v4web3js/node_modules/web3/node_modules/web3-core/lib/commonjs/web3_request_manager.js:258:23)
    at Web3RequestManager.<anonymous> (/Users/alexluu/practice/v4web3js/node_modules/web3/node_modules/web3-core/lib/commonjs/web3_request_manager.js:156:29)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/alexluu/practice/v4web3js/node_modules/web3/node_modules/web3-core/lib/commonjs/web3_request_manager.js:21:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  innerError: {
    code: -32000,
    message: 'err: insufficient funds for gas * price + value: address 0xBe1320eA9Fd1b34C0cf664eFbb29CF2dBD3cC81b have 100000000000000000 want 2859580732500000001 (supplied gas 50000000)'
```  

## Solution


Within `checkRevertBeforeSending`, A simple fix to this is to check if the transaction does not have data set we explicitly set the gas to 21000  




Please include a summary of the changes and be sure to follow our [Contribution Guidelines](https://github.com/web3/web3.js/blob/4.x/.github/CONTRIBUTING.md).

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
