### PR TITLE
6801 Fill gas price when baseFeePerGas==='0x0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2483,6 +2483,10 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 ### Fixed
 
+#### web3-eth
+
+-   Fixed issue with simple transactions, Within `checkRevertBeforeSending` if there is no data set in transaction, set gas to be `21000` (#7043)
+
 #### web3-utils
 
 
@@ -2498,6 +2502,7 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 #### web3-eth
 
 -   Added parameter `customTransactionReceiptSchema` into methods `emitConfirmation`, `waitForTransactionReceipt`, `watchTransactionByPolling`, `watchTransactionBySubscription`, `watchTransactionForConfirmations` (#7000)
+-   Changed functionality: For networks that returns `baseFeePerGas===0x0` fill `maxPriorityFeePerGas` and `maxFeePerGas` by `getGasPrice` method (#7050)
 
 #### web3-rpc-methods
 

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -242,6 +242,7 @@ Documentation:
 ### Changed
 
 -   Added parameter `customTransactionReceiptSchema` into methods `emitConfirmation`, `waitForTransactionReceipt`, `watchTransactionByPolling`, `watchTransactionBySubscription`, `watchTransactionForConfirmations` (#7000)
+-   Changed functionality: For networks that returns `baseFeePerGas===0x0` fill `maxPriorityFeePerGas` and `maxFeePerGas` by `getGasPrice` method (#7050)
 
 ### Fixed
 

--- a/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
+++ b/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
@@ -41,13 +41,14 @@ async function getEip1559GasPricing<ReturnFormat extends DataFormat>(
 	const block = await getBlock(web3Context, web3Context.defaultBlock, false, ETH_DATA_FORMAT);
 	if (isNullish(block.baseFeePerGas)) throw new Eip1559NotSupportedError();
 
+	let gasPrice: Numbers;
 	if (isNullish(transaction.gasPrice) && BigInt(block.baseFeePerGas) === BigInt(0)) {
-		transaction.gasPrice = (await getGasPrice(web3Context, returnFormat)) as string;
+		gasPrice = (await getGasPrice(web3Context, returnFormat)) as string;
 	}
-	if (!isNullish(transaction.gasPrice)) {
+	if (!isNullish(transaction.gasPrice) || !isNullish(gasPrice)) {
 		const convertedTransactionGasPrice = format(
 			{ format: 'uint' },
-			transaction.gasPrice as Numbers,
+			(transaction.gasPrice ?? gasPrice),
 			returnFormat,
 		);
 

--- a/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
+++ b/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
@@ -41,14 +41,14 @@ async function getEip1559GasPricing<ReturnFormat extends DataFormat>(
 	const block = await getBlock(web3Context, web3Context.defaultBlock, false, ETH_DATA_FORMAT);
 	if (isNullish(block.baseFeePerGas)) throw new Eip1559NotSupportedError();
 
-	let gasPrice: Numbers;
+	let gasPrice: Numbers | undefined = undefined;
 	if (isNullish(transaction.gasPrice) && BigInt(block.baseFeePerGas) === BigInt(0)) {
-		gasPrice = (await getGasPrice(web3Context, returnFormat)) as string;
+		gasPrice = await getGasPrice(web3Context, returnFormat);
 	}
 	if (!isNullish(transaction.gasPrice) || !isNullish(gasPrice)) {
 		const convertedTransactionGasPrice = format(
 			{ format: 'uint' },
-			(transaction.gasPrice ?? gasPrice),
+			transaction.gasPrice ?? gasPrice,
 			returnFormat,
 		);
 

--- a/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
+++ b/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
@@ -38,10 +38,12 @@ async function getEip1559GasPricing<ReturnFormat extends DataFormat>(
 	web3Context: Web3Context<EthExecutionAPI>,
 	returnFormat: ReturnFormat,
 ): Promise<FormatType<{ maxPriorityFeePerGas?: Numbers; maxFeePerGas?: Numbers }, ReturnFormat>> {
-	const block = await getBlock(web3Context, web3Context.defaultBlock, false, returnFormat);
-
+	const block = await getBlock(web3Context, web3Context.defaultBlock, false, ETH_DATA_FORMAT);
 	if (isNullish(block.baseFeePerGas)) throw new Eip1559NotSupportedError();
 
+	if (isNullish(transaction.gasPrice) && BigInt(block.baseFeePerGas) === BigInt(0)) {
+		transaction.gasPrice = (await getGasPrice(web3Context, returnFormat)) as string;
+	}
 	if (!isNullish(transaction.gasPrice)) {
 		const convertedTransactionGasPrice = format(
 			{ format: 'uint' },

--- a/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
+++ b/packages/web3-eth/src/utils/get_transaction_gas_pricing.ts
@@ -41,7 +41,7 @@ async function getEip1559GasPricing<ReturnFormat extends DataFormat>(
 	const block = await getBlock(web3Context, web3Context.defaultBlock, false, ETH_DATA_FORMAT);
 	if (isNullish(block.baseFeePerGas)) throw new Eip1559NotSupportedError();
 
-	let gasPrice: Numbers | undefined = undefined;
+	let gasPrice: Numbers | undefined;
 	if (isNullish(transaction.gasPrice) && BigInt(block.baseFeePerGas) === BigInt(0)) {
 		gasPrice = await getGasPrice(web3Context, returnFormat);
 	}

--- a/packages/web3-eth/test/unit/utils/get_transaction_gas_pricing.test.ts
+++ b/packages/web3-eth/test/unit/utils/get_transaction_gas_pricing.test.ts
@@ -1,0 +1,58 @@
+/*
+This file is part of web3.js.
+
+web3.js is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+web3.js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import { Web3Context } from 'web3-core';
+
+import * as RpcMethodWrappers from '../../../src/rpc_method_wrappers';
+import { getTransactionGasPricing } from '../../../src/utils/get_transaction_gas_pricing';
+import { FMT_BYTES, FMT_NUMBER } from 'web3-types';
+
+describe('getTransactionGasPricing', () => {
+	const web3Context = new Web3Context();
+
+	it('should use the call rpc wrapper', async () => {
+		const gasPrice = '0x123456';
+		const gasPriceSpy = jest
+			.spyOn(RpcMethodWrappers, 'getGasPrice')
+			.mockImplementation(async () => gasPrice);
+		const getBlockSpy = jest
+			.spyOn(RpcMethodWrappers, 'getBlock')
+			// @ts-ignore
+			.mockImplementation(async () => ({
+				baseFeePerGas: '0x0',
+			}));
+
+		const transaction = {
+			from: '0x4fec0a51024b13030d26e70904b066c6d41157a5',
+			to: '0x36361143b7e2c676f8ccd67743a89d26437f0529',
+			data: '0x819f48fe',
+			type: '0x2',
+		};
+
+		const res = await getTransactionGasPricing(transaction, web3Context, {
+			number: FMT_NUMBER.HEX,
+			bytes: FMT_BYTES.HEX,
+		});
+
+		expect(getBlockSpy).toHaveBeenCalled();
+		expect(gasPriceSpy).toHaveBeenCalled();
+		expect(res).toEqual({
+			gasPrice: undefined,
+			maxPriorityFeePerGas: gasPrice,
+			maxFeePerGas: gasPrice,
+		});
+	});
+});

--- a/packages/web3-eth/test/unit/utils/get_transaction_gas_pricing.test.ts
+++ b/packages/web3-eth/test/unit/utils/get_transaction_gas_pricing.test.ts
@@ -16,9 +16,9 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 import { Web3Context } from 'web3-core';
 
+import { FMT_BYTES, FMT_NUMBER } from 'web3-types';
 import * as RpcMethodWrappers from '../../../src/rpc_method_wrappers';
 import { getTransactionGasPricing } from '../../../src/utils/get_transaction_gas_pricing';
-import { FMT_BYTES, FMT_NUMBER } from 'web3-types';
 
 describe('getTransactionGasPricing', () => {
 	const web3Context = new Web3Context();
@@ -30,7 +30,7 @@ describe('getTransactionGasPricing', () => {
 			.mockImplementation(async () => gasPrice);
 		const getBlockSpy = jest
 			.spyOn(RpcMethodWrappers, 'getBlock')
-			// @ts-ignore
+			// @ts-expect-error only for testing purposes
 			.mockImplementation(async () => ({
 				baseFeePerGas: '0x0',
 			}));


### PR DESCRIPTION
## Description

Please include a summary of the changes and be sure to follow our [Contribution Guidelines](https://github.com/web3/web3.js/blob/4.x/.github/CONTRIBUTING.md).


Fixes #6801 

BSC chain returns `baseFeePerGas==='0x0'` but supports type 2 transactions.
Fix is set current `gasPrice` to `maxPriorityFeePerGas` and `maxFeePerGas`


```ts

const contract = new web3.eth.Contract(ERC20TokenAbi, '0x63C872fC0Add8129F3d18f7975aCbD335356e2aE')
const res = await contract.methods
        .transfer('0x8f3e9c1Bd65EB267d19B176A73217524DC21A5ca', 1)
        .send({
            from: acc.address,
        });
console.log(res);
```

```
{
  blockHash: '0x8cd5b444a0d556fea0c94c27dd596dd445a41768dde4a9efee0ed37d01f0ad5b',
  blockNumber: 40514564n,
  cumulativeGasUsed: 364295n,
  effectiveGasPrice: 5050000000n,
  from: '0xe4beef667408b99053dc147ed19592ada0d77f59',
  gasUsed: 52321n,
  logs: [
    {
      address: '0x63c872fc0add8129f3d18f7975acbd335356e2ae',
      topics: [Array],
      data: '0x0000000000000000000000000000000000000000000000000000000000000001',
      blockNumber: 40514564n,
      transactionHash: '0x0cc26c683e87e4c1792fb00de8fd8748e171d0c3e279b63731664dcdefaa6b60',
      transactionIndex: 2n,
      blockHash: '0x8cd5b444a0d556fea0c94c27dd596dd445a41768dde4a9efee0ed37d01f0ad5b',
      logIndex: 1n,
      removed: false
    }
  ],
  logsBloom: '0x00000000000000000000000000000000000000000000040000000000000000000000000000000010000000000000000000200000000004000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000100000000020000000000000',
  status: 1n,
  to: '0x63c872fc0add8129f3d18f7975acbd335356e2ae',
  transactionHash: '0x0cc26c683e87e4c1792fb00de8fd8748e171d0c3e279b63731664dcdefaa6b60',
  transactionIndex: 2n,
  type: 2n,
  events: {
    Transfer: {
      address: '0x63c872fc0add8129f3d18f7975acbd335356e2ae',
      topics: [Array],
      data: '0x0000000000000000000000000000000000000000000000000000000000000001',
      blockNumber: 40514564n,
      transactionHash: '0x0cc26c683e87e4c1792fb00de8fd8748e171d0c3e279b63731664dcdefaa6b60',
      transactionIndex: 2n,
      blockHash: '0x8cd5b444a0d556fea0c94c27dd596dd445a41768dde4a9efee0ed37d01f0ad5b',
      logIndex: 1n,
      removed: false,
      returnValues: [Object],
      event: 'Transfer',
      signature: '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
      raw: [Object]
    }
  }
}

```



## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
