### PR TITLE
release/v4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2444,7 +2444,7 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 -   Added `signature` to type `AbiFunctionFragment` (#6922)
 -   update type `Withdrawals`, `block` and `BlockHeaderOutput` to include properties of eip 4844, 4895, 4788 (#6933)
 
-## [Unreleased]
+## [4.9.0]
 
 ### Added
 
@@ -2525,3 +2525,5 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 #### web3-rpc-methods
 
 -   Change `estimateGas` method to add possibility pass Transaction type (#7000)
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2456,6 +2456,10 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   `defaultReturnFormat` was added to the configuration options. (#6947)
 
+#### web3-errors
+
+- Added `InvalidIntegerError` error for fromWei and toWei (#7052)
+
 #### web3-eth
 
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
@@ -2480,6 +2484,8 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 #### web3-utils
 
+- `toWei` add warning when using large numbers or large decimals that may cause precision loss (#6908)
+- `toWei` and `fromWei` now supports integers as a unit. (#7053)  
 
 ### Fixed
 
@@ -2489,9 +2495,17 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 #### web3-utils
 
+- `toWei` support numbers in scientific notation (#6908)
+- `toWei` and `fromWei` trims according to ether unit successfuly (#7044)
 
 #### web3-validator
 
+- The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
+-  `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)
+
+#### web3-core
+
+-   Set a try catch block if processesingError fails (#7022)
 
 ### Changed
 
@@ -2503,6 +2517,10 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Added parameter `customTransactionReceiptSchema` into methods `emitConfirmation`, `waitForTransactionReceipt`, `watchTransactionByPolling`, `watchTransactionBySubscription`, `watchTransactionForConfirmations` (#7000)
 -   Changed functionality: For networks that returns `baseFeePerGas===0x0` fill `maxPriorityFeePerGas` and `maxFeePerGas` by `getGasPrice` method (#7050)
+
+#### web3-eth-abi
+
+-   Dependencies updated
 
 #### web3-rpc-methods
 

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -217,3 +217,6 @@ Documentation:
 
 -   Interface `RequestManagerMiddleware` was changed (#7003)
 
+### Fixed
+
+-   Set a try catch block if processesingError fails (#7022)

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -207,7 +207,7 @@ Documentation:
 
 -	Web3config `contractDataInputFill` has been defaulted to `data`, istead of `input`. (#6622)
 
-## [Unreleased]
+## [4.4.0]
 
 ### Added
 
@@ -220,3 +220,5 @@ Documentation:
 ### Fixed
 
 -   Set a try catch block if processesingError fails (#7022)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -47,7 +47,7 @@
 		"web3-eth-iban": "^4.0.7",
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	},

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.3.2",
+	"version": "4.4.0",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -42,14 +42,14 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-errors": "^1.1.4",
+		"web3-errors": "^1.2.0",
+		"web3-eth-accounts": "^4.1.2",
 		"web3-eth-iban": "^4.0.7",
-		"web3-eth-accounts": "^4.1.0",
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
-		"web3-types": "^1.3.1",
-		"web3-utils": "^4.1.0",
-		"web3-validator": "^2.0.3"
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0",
+		"web3-validator": "^2.0.6"
 	},
 	"optionalDependencies": {
 		"web3-providers-ipc": "^4.0.7"

--- a/packages/web3-errors/CHANGELOG.md
+++ b/packages/web3-errors/CHANGELOG.md
@@ -166,8 +166,10 @@ Documentation:
 
 -   Fixed grammar and spelling in `transactionTimeoutHint` (#6559)
 
-## [Unreleased]
+## [1.2.0]
 
 ### Added
 
 - Added `InvalidIntegerError` error for fromWei and toWei (#7052)
+
+## [Unreleased]

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.7.0"
+		"web3-types": "^1.6.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-errors/package.json
+++ b/packages/web3-errors/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-errors",
-	"version": "1.1.4",
+	"version": "1.2.0",
 	"description": "This package has web3 error classes",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -41,7 +41,7 @@
 		"test:integration": "jest --config=./test/integration/jest.config.js --passWithNoTests"
 	},
 	"dependencies": {
-		"web3-types": "^1.3.1"
+		"web3-types": "^1.7.0"
 	},
 	"devDependencies": {
 		"@types/jest": "^28.1.6",

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -171,3 +171,7 @@ Documentation:
 -   Dependencies updated
 
 ## [Unreleased]
+
+### Changed
+
+-   Dependencies updated

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -170,8 +170,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.3.0]
 
 ### Changed
 
 -   Dependencies updated
+
+## [Unreleased]

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -170,7 +170,7 @@ Documentation:
 
 -   Dependencies updated
 
-## [4.3.0]
+## [4.2.2]
 
 ### Changed
 

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.3.0",
+	"version": "4.2.2",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.2.1",
+	"version": "4.3.0",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -43,10 +43,10 @@
 	},
 	"dependencies": {
 		"abitype": "0.7.1",
-		"web3-errors": "^1.1.4",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.2.3",
-		"web3-validator": "^2.0.5"
+		"web3-errors": "^1.2.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0",
+		"web3-validator": "^2.0.6"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -44,7 +44,7 @@
 	"dependencies": {
 		"abitype": "0.7.1",
 		"web3-errors": "^1.2.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	},

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -380,8 +380,10 @@ Documentation:
 -   Added a console warning in case of an ambiguous call to a solidity method with parameter overloading (#6942)
 -   Added contract.deploy(...).decodeData(...) and contract.decodeMethodData(...) that decode data based on the ABI (#6950)
 
-## [Unreleased]
+## [4.5.0]
 
 ### Added
 
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
+
+## [Unreleased]

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -48,7 +48,7 @@
 		"web3-core": "^4.4.0",
 		"web3-errors": "^1.2.0",
 		"web3-eth": "^4.7.0",
-		"web3-eth-abi": "^4.3.0",
+		"web3-eth-abi": "^4.2.2",
 		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -49,7 +49,7 @@
 		"web3-errors": "^1.2.0",
 		"web3-eth": "^4.7.0",
 		"web3-eth-abi": "^4.3.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	},

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.4.0",
+	"version": "4.5.0",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -45,13 +45,13 @@
 		"test:e2e:firefox": "npx cypress run --headless --browser firefox --env grep='ignore',invert=true"
 	},
 	"dependencies": {
-		"web3-core": "^4.3.2",
-		"web3-errors": "^1.1.4",
-		"web3-eth": "^4.6.0",
-		"web3-eth-abi": "^4.2.1",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.2.3",
-		"web3-validator": "^2.0.5"
+		"web3-core": "^4.4.0",
+		"web3-errors": "^1.2.0",
+		"web3-eth": "^4.7.0",
+		"web3-eth-abi": "^4.3.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0",
+		"web3-validator": "^2.0.6"
 	},
 	"devDependencies": {
 		"@humeris/espresso-shot": "^4.0.0",

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -153,8 +153,10 @@ Documentation:
 
 - Added function getText and getName in ENS and resolver classes (#6914)
 
-## [Unreleased]
+## [4.3.0]
 
 ### Added
 
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
+
+## [Unreleased]

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -156,4 +156,5 @@ Documentation:
 ## [Unreleased]
 
 ### Added
+
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -64,7 +64,7 @@
 		"web3-eth": "^4.7.0",
 		"web3-eth-contract": "^4.5.0",
 		"web3-net": "^4.1.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	}

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.2.0",
+	"version": "4.3.0",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,13 +59,13 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.3.2",
-		"web3-errors": "^1.1.4",
-		"web3-eth": "^4.5.0",
-		"web3-eth-contract": "^4.3.0",
-		"web3-net": "^4.0.7",
-		"web3-types": "^1.5.0",
-		"web3-utils": "^4.2.2",
-		"web3-validator": "^2.0.5"
+		"web3-core": "^4.4.0",
+		"web3-errors": "^1.2.0",
+		"web3-eth": "^4.7.0",
+		"web3-eth-contract": "^4.5.0",
+		"web3-net": "^4.1.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0",
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -232,7 +232,7 @@ Documentation:
 -   method `getBlock` now includes properties of eip 4844, 4895, 4788 when returning block (#6933)
 -   update type `withdrawalsSchema`, `blockSchema` and `blockHeaderSchema` schemas to include properties of eip 4844, 4895, 4788 (#6933)
 
-## [Unreleased]
+## [4.7.0]
 
 ### Added
 
@@ -247,3 +247,5 @@ Documentation:
 ### Fixed
 
 -   Fixed issue with simple transactions, Within `checkRevertBeforeSending` if there is no data set in transaction, set gas to be `21000` (#7043)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.6.0",
+	"version": "4.7.0",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,15 +63,15 @@
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.3.2",
-		"web3-errors": "^1.1.4",
-		"web3-eth-abi": "^4.2.1",
+		"web3-core": "^4.4.0",
+		"web3-errors": "^1.2.0",
+		"web3-eth-abi": "^4.3.0",
 		"web3-eth-accounts": "^4.1.2",
-		"web3-net": "^4.0.7",
+		"web3-net": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
-		"web3-rpc-methods": "^1.2.0",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.2.3",
-		"web3-validator": "^2.0.5"
+		"web3-rpc-methods": "^1.3.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0",
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -70,7 +70,7 @@
 		"web3-net": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	}

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -65,7 +65,7 @@
 		"setimmediate": "^1.0.5",
 		"web3-core": "^4.4.0",
 		"web3-errors": "^1.2.0",
-		"web3-eth-abi": "^4.3.0",
+		"web3-eth-abi": "^4.2.2",
 		"web3-eth-accounts": "^4.1.2",
 		"web3-net": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -144,4 +144,5 @@ Documentation:
 ## [Unreleased]
 
 ### Added
+
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)

--- a/packages/web3-net/CHANGELOG.md
+++ b/packages/web3-net/CHANGELOG.md
@@ -141,8 +141,10 @@ Documentation:
 
 -   Dependencies updated
 
-## [Unreleased]
+## [4.1.0]
 
 ### Added
 
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
+
+## [Unreleased]

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-net",
-	"version": "4.0.7",
+	"version": "4.1.0",
 	"description": "Web3 module to interact with the Ethereum nodes networking properties.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,9 +56,9 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.3.0",
-		"web3-rpc-methods": "^1.1.3",
-		"web3-types": "^1.3.0",
-		"web3-utils": "^4.0.7"
+		"web3-core": "^4.4.0",
+		"web3-rpc-methods": "^1.3.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0"
 	}
 }

--- a/packages/web3-net/package.json
+++ b/packages/web3-net/package.json
@@ -58,7 +58,7 @@
 	"dependencies": {
 		"web3-core": "^4.4.0",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0"
 	}
 }

--- a/packages/web3-rpc-methods/CHANGELOG.md
+++ b/packages/web3-rpc-methods/CHANGELOG.md
@@ -138,8 +138,10 @@ Documentation:
 
 -   Added `getMaxPriorityFeePerGas` method (#6748)
 
-## [Unreleased]
+## [1.3.0]
 
 ### Changed
 
 -   Change `estimateGas` method to add possibility pass Transaction type (#7000)
+
+## [Unreleased]

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -57,7 +57,7 @@
 	},
 	"dependencies": {
 		"web3-core": "^4.4.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-rpc-methods/package.json
+++ b/packages/web3-rpc-methods/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-methods",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Ethereum RPC methods for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -56,8 +56,8 @@
 		"typescript": "^4.7.4"
 	},
 	"dependencies": {
-		"web3-core": "^4.3.2",
-		"web3-types": "^1.5.0",
-		"web3-validator": "^2.0.4"
+		"web3-core": "^4.4.0",
+		"web3-types": "^1.7.0",
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -189,7 +189,7 @@ Documentation:
 
 -   Type `FeeData` to be filled by `await web3.eth.calculateFeeData()` to be used with EIP-1559 transactions (#6795)
 
-## [Unreleased]
+## [1.6.0]
 
 ### Added
 

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.7.0",
+	"version": "1.6.0",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -216,7 +216,7 @@ Documentation:
 - fixed toHex incorrectly hexing Uint8Arrays and Buffer (#6957)
 - fixed isUint8Array not returning true for Buffer (#6957)
 
-## [Unreleased]
+## [4.3.0]
 
 ### Added
 
@@ -227,3 +227,5 @@ Documentation:
 
 - `toWei` support numbers in scientific notation (#6908)
 - `toWei` and `fromWei` trims according to ether unit successfuly (#7044)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -66,7 +66,7 @@
 		"ethereum-cryptography": "^2.0.0",
 		"eventemitter3": "^5.0.1",
 		"web3-errors": "^1.2.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.2.3",
+	"version": "4.3.0",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -65,8 +65,8 @@
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
 		"eventemitter3": "^5.0.1",
-		"web3-errors": "^1.1.4",
-		"web3-types": "^1.6.0",
-		"web3-validator": "^2.0.5"
+		"web3-errors": "^1.2.0",
+		"web3-types": "^1.7.0",
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -172,5 +172,5 @@ Documentation:
 
 ### Fixed
 
-- The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings.
+- The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
 -  `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -168,9 +168,11 @@ Documentation:
 
 - Multi-dimensional arrays(with a fix length) are now handled properly when parsing ABIs (#6798)
 
-## [Unreleased]
+## [2.0.6]
 
 ### Fixed
 
 - The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
 -  `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)
+
+## [Unreleased]

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -47,7 +47,7 @@
 		"ethereum-cryptography": "^2.0.0",
 		"util": "^0.12.5",
 		"web3-errors": "^1.2.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-validator",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"description": "JSON-Schema compatible validator for web3",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -46,8 +46,8 @@
 	"dependencies": {
 		"ethereum-cryptography": "^2.0.0",
 		"util": "^0.12.5",
-		"web3-errors": "^1.1.4",
-		"web3-types": "^1.5.0",
+		"web3-errors": "^1.2.0",
+		"web3-types": "^1.7.0",
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -262,8 +262,10 @@ Documentation:
 -   Added `signature` to type `AbiFunctionFragment` (#6922)
 -   update type `Withdrawals`, `block` and `BlockHeaderOutput` to include properties of eip 4844, 4895, 4788 (#6933)
 
-## [Unreleased]
+## [4.9.0]
 
 ### Added
 
 -   Updated type `Web3EthInterface.accounts` to includes `privateKeyToAccount`,`privateKeyToAddress`,and `privateKeyToPublicKey` (#6762)
+
+## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -99,7 +99,7 @@
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-types": "^1.7.0",
+		"web3-types": "^1.6.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	}

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -89,7 +89,7 @@
 		"web3-core": "^4.4.0",
 		"web3-errors": "^1.2.0",
 		"web3-eth": "^4.7.0",
-		"web3-eth-abi": "^4.3.0",
+		"web3-eth-abi": "^4.2.2",
 		"web3-eth-accounts": "^4.1.2",
 		"web3-eth-contract": "^4.5.0",
 		"web3-eth-ens": "^4.3.0",

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.8.0",
+	"version": "4.9.0",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -86,21 +86,21 @@
 		"web3-providers-ipc": "^4.0.7"
 	},
 	"dependencies": {
-		"web3-core": "^4.3.2",
-		"web3-errors": "^1.1.4",
-		"web3-eth": "^4.6.0",
-		"web3-eth-abi": "^4.2.1",
+		"web3-core": "^4.4.0",
+		"web3-errors": "^1.2.0",
+		"web3-eth": "^4.7.0",
+		"web3-eth-abi": "^4.3.0",
 		"web3-eth-accounts": "^4.1.2",
-		"web3-eth-contract": "^4.4.0",
-		"web3-eth-ens": "^4.2.0",
+		"web3-eth-contract": "^4.5.0",
+		"web3-eth-ens": "^4.3.0",
 		"web3-eth-iban": "^4.0.7",
 		"web3-eth-personal": "^4.0.8",
-		"web3-net": "^4.0.7",
+		"web3-net": "^4.1.0",
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
-		"web3-rpc-methods": "^1.2.0",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.2.3",
-		"web3-validator": "^2.0.5"
+		"web3-rpc-methods": "^1.3.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0",
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.8.0' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.9.0' };


### PR DESCRIPTION

## [4.9.0]

### Added

#### web3

-   Updated type `Web3EthInterface.accounts` to includes `privateKeyToAccount`,`privateKeyToAddress`,and `privateKeyToPublicKey` (#6762)

#### web3-core

-   `defaultReturnFormat` was added to the configuration options. (#6947)

#### web3-errors

- Added `InvalidIntegerError` error for fromWei and toWei (#7052)

#### web3-eth

-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
-   `getTransactionFromOrToAttr`, `waitForTransactionReceipt`, `trySendTransaction`, `SendTxHelper` was exported (#7000)

#### web3-eth-contract

-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)

#### web3-eth-ens

-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)

#### web3-net

-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)

#### web3-utils

- `toWei` add warning when using large numbers or large decimals that may cause precision loss (#6908)
- `toWei` and `fromWei` now supports integers as a unit. (#7053)  

### Fixed

#### web3-eth

-   Fixed issue with simple transactions, Within `checkRevertBeforeSending` if there is no data set in transaction, set gas to be `21000` (#7043)

#### web3-utils

- `toWei` support numbers in scientific notation (#6908)
- `toWei` and `fromWei` trims according to ether unit successfuly (#7044)

#### web3-validator

- The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
-  `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)

#### web3-core

-   Set a try catch block if processesingError fails (#7022)

### Changed

#### web3-core

-   Interface `RequestManagerMiddleware` was changed (#7003)

#### web3-eth

-   Added parameter `customTransactionReceiptSchema` into methods `emitConfirmation`, `waitForTransactionReceipt`, `watchTransactionByPolling`, `watchTransactionBySubscription`, `watchTransactionForConfirmations` (#7000)
-   Changed functionality: For networks that returns `baseFeePerGas===0x0` fill `maxPriorityFeePerGas` and `maxFeePerGas` by `getGasPrice` method (#7050)

#### web3-eth-abi

-   Dependencies updated

#### web3-rpc-methods

-   Change `estimateGas` method to add possibility pass Transaction type (#7000)
