### PR TITLE
fix(docs): header-nav

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -41,7 +41,7 @@ const packages = [
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-	title: 'web3.js',
+	title: 'Web3.js',
 	tagline: 'Powerful TypeScript libraries for Ethereum interaction and utility functions',
 	url: 'https://docs.web3js.org',
 	baseUrl: '/',
@@ -52,7 +52,7 @@ const config = {
 	// GitHub pages deployment config.
 	// If you aren't using GitHub pages, you don't need these.
 	organizationName: 'ChainSafe', // Usually your GitHub org/user name.
-	projectName: 'web3.js', // Usually your repo name.
+	projectName: 'Web3.js', // Usually your repo name.
 
 	// Even if you don't use internalization, you can use this field to set useful
 	// metadata like html lang. For example, if your site is Chinese, you may want
@@ -109,37 +109,36 @@ const config = {
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({
 			navbar: {
-				title: 'Web3.js Docs',
+                title: 'Web3.js Docs',
 				logo: {
 					src: 'img/web3js.svg',
 				},
 				items: [
 					{
-						to: '/',
-						activeBasePath: '/',
+						to: '/guides/getting_started/quickstart',
+						activeBasePath: '/guides',
 						label: 'Guides & Tutorials',
 						position: 'left',
 					},
 					{
 						to: '/libdocs/ABI',
-						activeBasePath: '/libdocs/',
+						activeBasePath: '/libdocs',
 						label: 'Documentation',
 						position: 'left',
 					},
 					{
-						to: 'api', // 'api' is the 'out' directory
+						to: '/api', // 'api' is the 'out' directory
 						label: 'API',
 						position: 'left',
 					},
 					{
-						to: 'glossary',
-						activeBasePath: '/glossary/',
+						to: '/glossary',
+						activeBasePath: '/glossary',
 						label: 'Glossary',
 						position: 'left',
 					},
 					{
 						to: '/web3_playground',
-						activeBasePath: '/',
 						label: 'Playground',
 						position: 'right',
 					},


### PR DESCRIPTION
I'm not convinced that this is "better" but it addresses some of the topics that were brought up in a meeting today with @mconnelly8 @jdevcs and @SantiagoDevRel
- The landing page is still "Introduction", this is also where the logo and "Web3.js Docs" link in the header point
- There is NO highlighted section in the header navbar when the  active page is the landing page ("Introduction")
- "Guides and Tutorials" in the header nav now links to the "Quickstart" page
- "Guides and Tutorials" is only highlighted when the active page actually falls under "Guides and Tutorials" (with the exception of "Guides and Tutorials" > "Getting Started" > "Introduction")