### PR TITLE
release v4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2555,7 +2555,7 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 ### web3-rpc-providers
 
--   Alpha release 
+-   RC release
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2526,4 +2526,41 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Change `estimateGas` method to add possibility pass Transaction type (#7000)
 
+## [4.10.0]
+
+### Added
+
+#### web3
+
+-   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)
+
+#### web3-core
+
+-   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)
+
+#### web3-eth
+
+-   `sendTransaction` in `rpc_method_wrappers` accepts optional param of `TransactionMiddleware` (#7088)
+-   WebEth has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` (#7088)
+
+#### web3-eth-ens
+
+-   `getText` now supports first param Address
+-   `getName` has optional second param checkInterfaceSupport
+
+### web3-types
+
+-   Added `result` as optional `never` and `error` as optional `never in type `JsonRpcNotification` (#7091)
+-   Added `JsonRpcNotfication` as a union type in `JsonRpcResponse` (#7091)
+
+### web3-rpc-providers
+
+-   Alpha release 
+
+### Fixed
+
+#### web3-eth-ens
+
+-   `getName` reverse resolution
+
 ## [Unreleased]

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -221,8 +221,10 @@ Documentation:
 
 -   Set a try catch block if processesingError fails (#7022)
 
-## [Unreleased]
+## [4.5.0]
 
 ### Added
 
 -   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)
+
+## [Unreleased]

--- a/packages/web3-core/package.json
+++ b/packages/web3-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-core",
-	"version": "4.4.0",
+	"version": "4.5.0",
 	"description": "Web3 core tools for sub-packages. This is an internal package.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -47,7 +47,7 @@
 		"web3-eth-iban": "^4.0.7",
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
-		"web3-types": "^1.6.0",
+		"web3-types": "^1.7.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	},

--- a/packages/web3-eth-ens/CHANGELOG.md
+++ b/packages/web3-eth-ens/CHANGELOG.md
@@ -159,7 +159,7 @@ Documentation:
 
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
 
-## [Unreleased]
+## [4.4.0]
 
 ### Added
 
@@ -169,3 +169,5 @@ Documentation:
 ### Fixed
 
 -   `getName` reverse resolution
+
+## [Unreleased]

--- a/packages/web3-eth-ens/package.json
+++ b/packages/web3-eth-ens/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-ens",
-	"version": "4.3.0",
+	"version": "4.4.0",
 	"description": "This package has ENS functions for interacting with Ethereum Name Service.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -59,12 +59,12 @@
 	},
 	"dependencies": {
 		"@adraffy/ens-normalize": "^1.8.8",
-		"web3-core": "^4.4.0",
+		"web3-core": "^4.5.0",
 		"web3-errors": "^1.2.0",
-		"web3-eth": "^4.7.0",
+		"web3-eth": "^4.8.0",
 		"web3-eth-contract": "^4.5.0",
 		"web3-net": "^4.1.0",
-		"web3-types": "^1.6.0",
+		"web3-types": "^1.7.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	}

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -248,10 +248,12 @@ Documentation:
 
 -   Fixed issue with simple transactions, Within `checkRevertBeforeSending` if there is no data set in transaction, set gas to be `21000` (#7043)
 
-## [Unreleased]
+## [4.8.0]
 
 ### Added
 
 -   `sendTransaction` in `rpc_method_wrappers` accepts optional param of `TransactionMiddleware` (#7088)
 -   WebEth has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` (#7088)
 - `TransactionMiddleware` and `TransactionMiddleware` data types are exported (#7088)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.7.0",
+	"version": "4.8.0",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -63,14 +63,14 @@
 	},
 	"dependencies": {
 		"setimmediate": "^1.0.5",
-		"web3-core": "^4.4.0",
+		"web3-core": "^4.5.0",
 		"web3-errors": "^1.2.0",
 		"web3-eth-abi": "^4.2.2",
 		"web3-eth-accounts": "^4.1.2",
 		"web3-net": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-types": "^1.6.0",
+		"web3-types": "^1.7.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"
 	}

--- a/packages/web3-rpc-providers/CHANGELOG.md
+++ b/packages/web3-rpc-providers/CHANGELOG.md
@@ -35,4 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
+## [0.1.0-alpha.1]
+
+#### Added
+
+-   Alpha release 
+
 ## [Unreleased]

--- a/packages/web3-rpc-providers/CHANGELOG.md
+++ b/packages/web3-rpc-providers/CHANGELOG.md
@@ -35,10 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -->
 
-## [0.1.0-alpha.1]
+## [1.0.0.rc.0]
 
 #### Added
 
--   Alpha release 
+-   RC release 
 
 ## [Unreleased]

--- a/packages/web3-rpc-providers/package.json
+++ b/packages/web3-rpc-providers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-providers",
-	"version": "0.1.0",
+	"version": "1.0.0-alpha.0",
 	"description": "Web3 Providers package",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -58,7 +58,7 @@
 	"dependencies": {
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.2.3"
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0"
 	}
 }

--- a/packages/web3-rpc-providers/package.json
+++ b/packages/web3-rpc-providers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-providers",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-rc.0",
 	"description": "Web3 Providers package",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -195,3 +195,12 @@ Documentation:
 
 -   Added `signature` to type `AbiFunctionFragment` (#6922)
 -   update type `Withdrawals`, `block` and `BlockHeaderOutput` to include properties of eip 4844, 4895, 4788 (#6933)
+
+## [1.7.0]
+
+### Added
+
+- Added `result` as optional `never` and `error` as optional `never in type `JsonRpcNotification` (#7091)
+- Added `JsonRpcNotfication` as a union type in `JsonRpcResponse` (#7091)
+
+## [Unreleased]

--- a/packages/web3-types/package.json
+++ b/packages/web3-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-types",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"description": "Provide the common data structures and interfaces for web3 modules.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -266,12 +266,119 @@ Documentation:
 
 ### Added
 
+#### web3
+
 -   Updated type `Web3EthInterface.accounts` to includes `privateKeyToAccount`,`privateKeyToAddress`,and `privateKeyToPublicKey` (#6762)
 
-## [Unreleased]
+#### web3-core
+
+-   `defaultReturnFormat` was added to the configuration options. (#6947)
+
+#### web3-errors
+
+- Added `InvalidIntegerError` error for fromWei and toWei (#7052)
+
+#### web3-eth
+
+-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
+-   `getTransactionFromOrToAttr`, `waitForTransactionReceipt`, `trySendTransaction`, `SendTxHelper` was exported (#7000)
+
+#### web3-eth-contract
+
+-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
+
+#### web3-eth-ens
+
+-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
+
+#### web3-net
+
+-   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
+
+#### web3-types
+
+-   Added `signature` to type `AbiFunctionFragment` (#6922)
+-   update type `Withdrawals`, `block` and `BlockHeaderOutput` to include properties of eip 4844, 4895, 4788 (#6933)
+
+#### web3-utils
+
+- `toWei` add warning when using large numbers or large decimals that may cause precision loss (#6908)
+- `toWei` and `fromWei` now supports integers as a unit. (#7053)  
+
+### Fixed
+
+#### web3-eth
+
+-   Fixed issue with simple transactions, Within `checkRevertBeforeSending` if there is no data set in transaction, set gas to be `21000` (#7043)
+
+#### web3-utils
+
+- `toWei` support numbers in scientific notation (#6908)
+- `toWei` and `fromWei` trims according to ether unit successfuly (#7044)
+
+#### web3-validator
+
+- The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
+-  `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)
+
+#### web3-core
+
+-   Set a try catch block if processesingError fails (#7022)
+
+### Changed
+
+#### web3-core
+
+-   Interface `RequestManagerMiddleware` was changed (#7003)
+
+#### web3-eth
+
+-   Added parameter `customTransactionReceiptSchema` into methods `emitConfirmation`, `waitForTransactionReceipt`, `watchTransactionByPolling`, `watchTransactionBySubscription`, `watchTransactionForConfirmations` (#7000)
+-   Changed functionality: For networks that returns `baseFeePerGas===0x0` fill `maxPriorityFeePerGas` and `maxFeePerGas` by `getGasPrice` method (#7050)
+
+#### web3-eth-abi
+
+-   Dependencies updated
+
+#### web3-rpc-methods
+
+-   Change `estimateGas` method to add possibility pass Transaction type (#7000)
+
+## [4.10.0]
 
 ### Added
 
 #### web3
 
 -   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)
+
+#### web3-core
+
+-   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)
+
+#### web3-eth
+
+-   `sendTransaction` in `rpc_method_wrappers` accepts optional param of `TransactionMiddleware` (#7088)
+-   WebEth has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` (#7088)
+
+#### web3-eth-ens
+
+-   `getText` now supports first param Address
+-   `getName` has optional second param checkInterfaceSupport
+
+### web3-types
+
+-   Added `result` as optional `never` and `error` as optional `never in type `JsonRpcNotification` (#7091)
+-   Added `JsonRpcNotfication` as a union type in `JsonRpcResponse` (#7091)
+
+### web3-rpc-providers
+
+-   Alpha release 
+
+### Fixed
+
+#### web3-eth-ens
+
+-   `getName` reverse resolution
+
+## [Unreleased]

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -373,7 +373,7 @@ Documentation:
 
 ### web3-rpc-providers
 
--   Alpha release 
+-   RC release 
 
 ### Fixed
 

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.9.0",
+	"version": "4.10.0",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -86,22 +86,22 @@
 		"web3-providers-ipc": "^4.0.7"
 	},
 	"dependencies": {
-		"web3-core": "^4.4.0",
+		"web3-core": "^4.5.0",
 		"web3-errors": "^1.2.0",
-		"web3-eth": "^4.7.0",
+		"web3-eth": "^4.8.0",
 		"web3-eth-abi": "^4.2.2",
 		"web3-eth-accounts": "^4.1.2",
 		"web3-eth-contract": "^4.5.0",
-		"web3-eth-ens": "^4.3.0",
+		"web3-eth-ens": "^4.4.0",
 		"web3-eth-iban": "^4.0.7",
 		"web3-eth-personal": "^4.0.8",
 		"web3-net": "^4.1.0",
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-types": "^1.6.0",
+		"web3-rpc-providers": "^1.0.0-alpha.0",
+		"web3-types": "^1.7.0",
 		"web3-utils": "^4.3.0",
-		"web3-validator": "^2.0.6",
-		"web3-rpc-providers": "^0.1.0"
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -99,7 +99,7 @@
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.7",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-rpc-providers": "^1.0.0-alpha.0",
+		"web3-rpc-providers": "^1.0.0-rc.0",
 		"web3-types": "^1.7.0",
 		"web3-utils": "^4.3.0",
 		"web3-validator": "^2.0.6"

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.9.0' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.10.0' };

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -88,8 +88,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Dependencies updated
 
-## [Unreleased]
-
 ### Added
 
 Transaction middleware (#7088)
+
+## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.0.6",
+	"version": "1.1.0",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,19 +45,19 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^29.1.1",
 		"typescript": "^4.7.4",
-		"web3": "^4.3.0",
-		"web3-core": "^4.3.2",
-		"web3-eth-abi": "^4.1.4",
-		"web3-eth-contract": "^4.1.4",
-		"web3-types": "^1.3.1",
-		"web3-utils": "^4.1.0"
+		"web3": "^4.10.0",
+		"web3-core": "^4.5.0",
+		"web3-eth-abi": "^4.2.2",
+		"web3-eth-contract": "^4.5.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.0"
 	},
 	"peerDependencies": {
 		"web3-core": ">= 4.1.1 < 5",
+		"web3-eth": ">= 4.7.0 < 5",
 		"web3-eth-abi": ">= 4.1.1 < 5",
 		"web3-eth-contract": ">= 4.0.5 < 5",
 		"web3-types": ">= 1.1.1 < 5",
-		"web3-utils": ">= 4.0.5 < 5",
-		"web3-eth": ">= 4.7.0 < 5"
+		"web3-utils": ">= 4.0.5 < 5"
 	}
 }


### PR DESCRIPTION
## [4.10.0]

### Added

#### web3

-   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)

#### web3-core

-   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)

#### web3-eth

-   `sendTransaction` in `rpc_method_wrappers` accepts optional param of `TransactionMiddleware` (#7088)
-   WebEth has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` (#7088)

#### web3-eth-ens

-   `getText` now supports first param Address
-   `getName` has optional second param checkInterfaceSupport

### web3-types

-   Added `result` as optional `never` and `error` as optional `never in type `JsonRpcNotification` (#7091)
-   Added `JsonRpcNotfication` as a union type in `JsonRpcResponse` (#7091)

### web3-rpc-providers

-   RC release 

### Fixed

#### web3-eth-ens

-   `getName` reverse resolution