### PR TITLE
Release/4.11.0

### DIFF
--- a/.github/workflows/black_box_tests.yml
+++ b/.github/workflows/black_box_tests.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [18, 16]
+        node: [18]
     name: Build Packages
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +36,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          node: [18, 16]
+          node: [18]
           mode: ['http', 'ws']
           backend: ['geth', 'infura']
       steps:

--- a/.github/workflows/e2e_network_tests.yml
+++ b/.github/workflows/e2e_network_tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: yarn
       - run: yarn
       - run: tar -czf /tmp/web3-16.js.tar.gz --exclude="./.git" ./
@@ -41,7 +41,7 @@ jobs:
       steps:
         - uses: actions/setup-node@v3
           with:
-            node-version: 16
+            node-version: 18
         - uses: actions/download-artifact@v3
           with:
             name: web3-16.js.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2608,9 +2608,9 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Update dependancies (#7109)
 
-#### web3-rpc-providers
+#### web3-plugin-example
 
- - Change request return type `Promise<ResultType>` to `Promise<JsonRpcResponseWithResult<ResultType>>` (#7102)
+-   Dependencies updated
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2623,6 +2623,8 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
  - When error is returned with code 429, throw rate limit error (#7102)
 
-#### web3-utils
-
 #### web3
+
+-   `web3.eth.Contract` will get transaction middleware and use it, if `web3.eth` has transaction middleware. (#7138)
+
+## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2612,6 +2612,10 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   Dependencies updated
 
+#### web3-rpc-providers
+
+ - Change request return type `Promise<ResultType>` to `Promise<JsonRpcResponseWithResult<ResultType>>` (#7102)
+
 ### Added
 
 #### web3-eth-contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2581,3 +2581,48 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 -   `populateTransaction` was added to contract methods (#7124)
 -   Contract has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` for `deploy` and `send` functions (#7138)
+
+## [4.11.0]
+
+### Fixed
+
+#### web3-eth-abi
+
+-   fix encodedata in EIP-712 (#7095)
+
+#### web3-utils
+
+-   `_sendPendingRequests` will catch unhandled errors from `_sendToSocket` (#6968)
+
+#### web3-eth
+
+-   Fixed geth issue when running a new instance, transactions will index when there are no blocks created (#7098)
+
+### Changed
+
+#### web3-eth-accounts
+
+- baseTransaction method updated (#7095)
+
+#### web3-providers-ws
+
+-   Update dependancies (#7109)
+
+#### web3-rpc-providers
+
+ - Change request return type `Promise<ResultType>` to `Promise<JsonRpcResponseWithResult<ResultType>>` (#7102)
+
+### Added
+
+#### web3-eth-contract
+
+-   `populateTransaction` was added to contract methods (#7124)
+-   Contract has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` for `deploy` and `send` functions (#7138)
+
+#### web3-rpc-providers
+
+ - When error is returned with code 429, throw rate limit error (#7102)
+
+#### web3-utils
+
+#### web3

--- a/packages/web3-eth-abi/CHANGELOG.md
+++ b/packages/web3-eth-abi/CHANGELOG.md
@@ -176,4 +176,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.2.3]
+
+### Fixed
+
+-   fix encodedata in EIP-712 (#7095)
+
 ## [Unreleased]

--- a/packages/web3-eth-abi/package.json
+++ b/packages/web3-eth-abi/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-abi",
-	"version": "4.2.2",
+	"version": "4.2.3",
 	"description": "Web3 module encode and decode EVM in/output.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -44,8 +44,8 @@
 	"dependencies": {
 		"abitype": "0.7.1",
 		"web3-errors": "^1.2.0",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.3.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.1",
 		"web3-validator": "^2.0.6"
 	},
 	"devDependencies": {

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -162,4 +162,10 @@ Documentation:
 
 -   Dependencies updated
 
+## [4.1.3]
+
+### Changed
+
+- baseTransaction method updated (#7095)
+
 ## [Unreleased]

--- a/packages/web3-eth-accounts/package.json
+++ b/packages/web3-eth-accounts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-accounts",
-	"version": "4.1.2",
+	"version": "4.1.3",
 	"description": "Package for managing Ethereum accounts and signing",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -61,9 +61,9 @@
 		"@ethereumjs/rlp": "^4.0.1",
 		"crc-32": "^1.2.2",
 		"ethereum-cryptography": "^2.0.0",
-		"web3-errors": "^1.1.4",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.2.3",
-		"web3-validator": "^2.0.5"
+		"web3-errors": "^1.2.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.1",
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-eth-contract/CHANGELOG.md
+++ b/packages/web3-eth-contract/CHANGELOG.md
@@ -386,10 +386,12 @@ Documentation:
 
 -   `defaultReturnFormat` was added to all methods that have `ReturnType` param. (#6947)
 
-## [Unreleased]
+## [4.6.0]
 
 ### Added
 
 -   `populateTransaction` was added to contract methods (#7124)
-
 -   Contract has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` for `deploy` and `send` functions (#7138)
+
+## [Unreleased]
+

--- a/packages/web3-eth-contract/package.json
+++ b/packages/web3-eth-contract/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth-contract",
-	"version": "4.5.0",
+	"version": "4.6.0",
 	"description": "Web3 module to interact with Ethereum smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -46,12 +46,12 @@
 	},
 	"dependencies": {
 		"@ethereumjs/rlp": "^5.0.2",
-		"web3-core": "^4.4.0",
+		"web3-core": "^4.5.0",
 		"web3-errors": "^1.2.0",
-		"web3-eth": "^4.7.0",
-		"web3-eth-abi": "^4.2.2",
-		"web3-types": "^1.6.0",
-		"web3-utils": "^4.3.0",
+		"web3-eth": "^4.8.1",
+		"web3-eth-abi": "^4.2.3",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.1",
 		"web3-validator": "^2.0.6"
 	},
 	"devDependencies": {
@@ -69,7 +69,7 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^29.1.1",
 		"typescript": "^4.7.4",
-		"web3-eth-accounts": "^4.1.2",
-		"web3-providers-ws": "^4.0.7"
+		"web3-eth-accounts": "^4.1.3",
+		"web3-providers-ws": "^4.0.8"
 	}
 }

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -256,8 +256,10 @@ Documentation:
 -   WebEth has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` (#7088)
 - `TransactionMiddleware` and `TransactionMiddleware` data types are exported (#7088)
 
-## [Unreleased]
+## [4.8.1]
 
 ### Fixed
 
 -   Fixed geth issue when running a new instance, transactions will index when there are no blocks created (#7098)
+
+## [Unreleased]

--- a/packages/web3-eth/package.json
+++ b/packages/web3-eth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-eth",
-	"version": "4.8.0",
+	"version": "4.8.1",
 	"description": "Web3 module to interact with the Ethereum blockchain and smart contracts.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -65,13 +65,13 @@
 		"setimmediate": "^1.0.5",
 		"web3-core": "^4.5.0",
 		"web3-errors": "^1.2.0",
-		"web3-eth-abi": "^4.2.2",
-		"web3-eth-accounts": "^4.1.2",
+		"web3-eth-abi": "^4.2.3",
+		"web3-eth-accounts": "^4.1.3",
 		"web3-net": "^4.1.0",
-		"web3-providers-ws": "^4.0.7",
+		"web3-providers-ws": "^4.0.8",
 		"web3-rpc-methods": "^1.3.0",
 		"web3-types": "^1.7.0",
-		"web3-utils": "^4.3.0",
+		"web3-utils": "^4.3.1",
 		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-providers-ws/CHANGELOG.md
+++ b/packages/web3-providers-ws/CHANGELOG.md
@@ -122,11 +122,16 @@ Documentation:
 
 -   Dependencies updated
 
-
 ## [4.0.7]
 
 ### Fixed
 
 -   Fixed bug in chunks processing logic (#6496)
+
+## [4.0.8]
+
+### Changed
+
+-   Update dependancies (#7109)
 
 ## [Unreleased]

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-providers-ws",
-	"version": "4.0.7",
+	"version": "4.0.8",
 	"description": "Websocket provider for Web3 4.x.x",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -64,9 +64,9 @@
 	"dependencies": {
 		"@types/ws": "8.5.3",
 		"isomorphic-ws": "^5.0.0",
-		"web3-errors": "^1.1.3",
-		"web3-types": "^1.3.0",
-		"web3-utils": "^4.0.7",
+		"web3-errors": "^1.2.0",
+		"web3-types": "^1.7.0",
+		"web3-utils": "^4.3.1",
 		"ws": "^8.17.1"
 	}
 }

--- a/packages/web3-rpc-providers/CHANGELOG.md
+++ b/packages/web3-rpc-providers/CHANGELOG.md
@@ -37,10 +37,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0.rc.0]
 
-#### Added
+### Added
 
 -   RC release 
 
-## [Unreleased]
+## [1.1.0.rc.0]
+
+ ### Added
+ 
  - When error is returned with code 429, throw rate limit error (#7102)
+
+ ### Changed
+
  - Change request return type `Promise<ResultType>` to `Promise<JsonRpcResponseWithResult<ResultType>>` (#7102)
+
+## [Unreleased]

--- a/packages/web3-rpc-providers/CHANGELOG.md
+++ b/packages/web3-rpc-providers/CHANGELOG.md
@@ -41,10 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   RC release 
 
-## [1.1.0.rc.0]
+## [1.0.0.rc.1]
 
  ### Added
- 
+
  - When error is returned with code 429, throw rate limit error (#7102)
 
  ### Changed

--- a/packages/web3-rpc-providers/package.json
+++ b/packages/web3-rpc-providers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-providers",
-	"version": "1.1.0-rc.0",
+	"version": "1.0.0-rc.1",
 	"description": "Web3 Providers package",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",

--- a/packages/web3-rpc-providers/package.json
+++ b/packages/web3-rpc-providers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-rpc-providers",
-	"version": "1.0.0-rc.0",
+	"version": "1.1.0-rc.0",
 	"description": "Web3 Providers package",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -58,9 +58,9 @@
 	"dependencies": {
 		"web3-errors": "^1.2.0",
 		"web3-providers-http": "^4.1.0",
-		"web3-providers-ws": "^4.0.7",
-		"web3-validator": "^2.0.6",
+		"web3-providers-ws": "^4.0.8",
 		"web3-types": "^1.7.0",
-		"web3-utils": "^4.3.0"
+		"web3-utils": "^4.3.1",
+		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3-utils/CHANGELOG.md
+++ b/packages/web3-utils/CHANGELOG.md
@@ -228,6 +228,10 @@ Documentation:
 -   `toWei` support numbers in scientific notation (#6908)
 -   `toWei` and `fromWei` trims according to ether unit successfuly (#7044)
 
-## [Unreleased]
+## [4.3.1]
+
+### Fixed
 
 -   `_sendPendingRequests` will catch unhandled errors from `_sendToSocket` (#6968)
+
+## [Unreleased]

--- a/packages/web3-utils/package.json
+++ b/packages/web3-utils/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web3-utils",
 	"sideEffects": false,
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"description": "Collection of utility functions used in web3.js.",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -66,7 +66,7 @@
 		"ethereum-cryptography": "^2.0.0",
 		"eventemitter3": "^5.0.1",
 		"web3-errors": "^1.2.0",
-		"web3-types": "^1.6.0",
+		"web3-types": "^1.7.0",
 		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -388,3 +388,44 @@ Documentation:
 #### web3
 
 -   `web3.eth.Contract` will get transaction middleware and use it, if `web3.eth` has transaction middleware. (#7138)
+
+## [4.11.0]
+
+### Fixed
+
+#### web3-eth-abi
+
+-   fix encodedata in EIP-712 (#7095)
+
+#### web3-utils
+
+-   `_sendPendingRequests` will catch unhandled errors from `_sendToSocket` (#6968)
+
+#### web3-eth
+
+-   Fixed geth issue when running a new instance, transactions will index when there are no blocks created (#7098)
+
+### Changed
+
+#### web3-eth-accounts
+
+- baseTransaction method updated (#7095)
+
+#### web3-providers-ws
+
+-   Update dependancies (#7109)
+
+#### web3-rpc-providers
+
+ - Change request return type `Promise<ResultType>` to `Promise<JsonRpcResponseWithResult<ResultType>>` (#7102)
+
+### Added
+
+#### web3-eth-contract
+
+-   `populateTransaction` was added to contract methods (#7124)
+-   Contract has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` for `deploy` and `send` functions (#7138)
+
+#### web3-rpc-providers
+
+ - When error is returned with code 429, throw rate limit error (#7102)

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -408,20 +408,12 @@ Documentation:
 
 -   Update dependancies (#7109)
 
-#### web3-rpc-providers
-
- - Change request return type `Promise<ResultType>` to `Promise<JsonRpcResponseWithResult<ResultType>>` (#7102)
-
 ### Added
 
 #### web3-eth-contract
 
 -   `populateTransaction` was added to contract methods (#7124)
 -   Contract has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` for `deploy` and `send` functions (#7138)
-
-#### web3-rpc-providers
-
- - When error is returned with code 429, throw rate limit error (#7102)
 
 #### web3
 

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -381,13 +381,6 @@ Documentation:
 
 -   `getName` reverse resolution
 
-## [Unreleased]
-
-### Added
-
-#### web3
-
--   `web3.eth.Contract` will get transaction middleware and use it, if `web3.eth` has transaction middleware. (#7138)
 
 ## [4.11.0]
 
@@ -429,3 +422,9 @@ Documentation:
 #### web3-rpc-providers
 
  - When error is returned with code 429, throw rate limit error (#7102)
+
+#### web3
+
+-   `web3.eth.Contract` will get transaction middleware and use it, if `web3.eth` has transaction middleware. (#7138)
+
+## [Unreleased]

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -99,7 +99,7 @@
 		"web3-providers-http": "^4.1.0",
 		"web3-providers-ws": "^4.0.8",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-rpc-providers": "^1.1.0-rc.0",
+		"web3-rpc-providers": "^1.0.0-rc.1",
 		"web3-types": "^1.7.0",
 		"web3-utils": "^4.3.1",
 		"web3-validator": "^2.0.6"

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3",
-	"version": "4.10.0",
+	"version": "4.11.0",
 	"description": "Ethereum JavaScript API",
 	"main": "./lib/commonjs/index.js",
 	"module": "./lib/esm/index.js",
@@ -88,20 +88,20 @@
 	"dependencies": {
 		"web3-core": "^4.5.0",
 		"web3-errors": "^1.2.0",
-		"web3-eth": "^4.8.0",
-		"web3-eth-abi": "^4.2.2",
-		"web3-eth-accounts": "^4.1.2",
-		"web3-eth-contract": "^4.5.0",
+		"web3-eth": "^4.8.1",
+		"web3-eth-abi": "^4.2.3",
+		"web3-eth-accounts": "^4.1.3",
+		"web3-eth-contract": "^4.6.0",
 		"web3-eth-ens": "^4.4.0",
 		"web3-eth-iban": "^4.0.7",
 		"web3-eth-personal": "^4.0.8",
 		"web3-net": "^4.1.0",
 		"web3-providers-http": "^4.1.0",
-		"web3-providers-ws": "^4.0.7",
+		"web3-providers-ws": "^4.0.8",
 		"web3-rpc-methods": "^1.3.0",
-		"web3-rpc-providers": "^1.0.0-rc.0",
+		"web3-rpc-providers": "^1.1.0-rc.0",
 		"web3-types": "^1.7.0",
-		"web3-utils": "^4.3.0",
+		"web3-utils": "^4.3.1",
 		"web3-validator": "^2.0.6"
 	}
 }

--- a/packages/web3/src/version.ts
+++ b/packages/web3/src/version.ts
@@ -1,1 +1,1 @@
-/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.10.0' };
+/* eslint-disable header/header */ export const Web3PkgInfo = { version: '4.11.0' };

--- a/tools/web3-plugin-example/CHANGELOG.md
+++ b/tools/web3-plugin-example/CHANGELOG.md
@@ -92,4 +92,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Transaction middleware (#7088)
 
+## [1.1.1]
+
+### Changed 
+
+-   Dependencies updated
+
 ## [Unreleased]

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.1.0",
+	"version": "1.1.2",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {
@@ -45,12 +45,12 @@
 		"prettier": "^2.7.1",
 		"ts-jest": "^29.1.1",
 		"typescript": "^4.7.4",
-		"web3": "^4.10.0",
+		"web3": "^4.11.0",
 		"web3-core": "^4.5.0",
-		"web3-eth-abi": "^4.2.2",
-		"web3-eth-contract": "^4.5.0",
+		"web3-eth-abi": "^4.2.3",
+		"web3-eth-contract": "^4.6.0",
 		"web3-types": "^1.7.0",
-		"web3-utils": "^4.3.0"
+		"web3-utils": "^4.3.1"
 	},
 	"peerDependencies": {
 		"web3-core": ">= 4.1.1 < 5",

--- a/tools/web3-plugin-example/package.json
+++ b/tools/web3-plugin-example/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "web3-plugin-example",
-	"version": "1.1.2",
+	"version": "1.1.1",
 	"description": "Example implementations of Web3.js' 4.x plugin system",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"engines": {


### PR DESCRIPTION
#Changelog 
## [4.11.0]

### Fixed

#### web3-eth-abi

-   fix encodedata in EIP-712 (#7095)

#### web3-utils

-   `_sendPendingRequests` will catch unhandled errors from `_sendToSocket` (#6968)

#### web3-eth

-   Fixed geth issue when running a new instance, transactions will index when there are no blocks created (#7098)

### Changed

#### web3-eth-accounts

- baseTransaction method updated (#7095)

#### web3-providers-ws

-   Update dependancies (#7109)

#### web3-rpc-providers

 - Change request return type `Promise<ResultType>` to `Promise<JsonRpcResponseWithResult<ResultType>>` (#7102)

### Added

#### web3-eth-contract

-   `populateTransaction` was added to contract methods (#7124)
-   Contract has `setTransactionMiddleware` and `getTransactionMiddleware` for automatically passing to `sentTransaction` for `deploy` and `send` functions (#7138)

#### web3-rpc-providers

 - When error is returned with code 429, throw rate limit error (#7102)

#### web3

-   `web3.eth.Contract` will get transaction middleware and use it, if `web3.eth` has transaction middleware. (#7138)
