### PR TITLE
Fix getblock.transactions 

### DIFF
--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -263,3 +263,7 @@ Documentation:
 -   Fixed geth issue when running a new instance, transactions will index when there are no blocks created (#7098)
 
 ## [Unreleased]
+
+### Fixed
+
+-   Adds transaction property to be an empty list rather than undefined when no transactions are included in the block (#7151)

--- a/packages/web3-eth/src/rpc_method_wrappers.ts
+++ b/packages/web3-eth/src/rpc_method_wrappers.ts
@@ -286,11 +286,21 @@ export async function getBlock<ReturnFormat extends DataFormat>(
 			hydrated,
 		);
 	}
-	return format(
+	const res = format(
 		blockSchema,
 		response as unknown as Block,
 		returnFormat ?? web3Context.defaultReturnFormat,
 	);
+
+	if (!isNullish(res)) {
+		const result = {
+			...res,
+			transactions: res.transactions ?? [],
+		}
+		return result;
+	}
+	
+	return res;
 }
 
 /**

--- a/packages/web3-eth/test/unit/rpc_method_wrappers/fixtures/get_block.ts
+++ b/packages/web3-eth/test/unit/rpc_method_wrappers/fixtures/get_block.ts
@@ -70,6 +70,10 @@ export const mockRpcResponseHydrated: Block = {
 	...mockRpcResponse,
 	transactions: [hydratedTransaction, hydratedTransaction, hydratedTransaction],
 };
+export const noTransactionBlock: Block = {
+	...mockRpcResponse,
+	transactions: [],
+}
 
 /**
  * Array consists of:

--- a/packages/web3-eth/test/unit/rpc_method_wrappers/get_block.test.ts
+++ b/packages/web3-eth/test/unit/rpc_method_wrappers/get_block.test.ts
@@ -92,7 +92,7 @@ describe('getBlock', () => {
 			const expectedReturnFormat = { number: FMT_NUMBER.STR, bytes: FMT_BYTES.UINT8ARRAY };
 			const expectedMockRpcResponse = noTransactionBlock;
 			// TODO: Fix format to default have a default in oneOf if no schema is matched
-			let formattedResult = format(
+			const formattedResult = format(
 				blockSchema,
 				expectedMockRpcResponse,
 				expectedReturnFormat,

--- a/packages/web3-eth/test/unit/rpc_method_wrappers/get_block.test.ts
+++ b/packages/web3-eth/test/unit/rpc_method_wrappers/get_block.test.ts
@@ -28,7 +28,7 @@ import { isBytes, isNullish } from 'web3-validator';
 import { ethRpcMethods } from 'web3-rpc-methods';
 
 import { getBlock } from '../../../src/rpc_method_wrappers';
-import { mockRpcResponse, mockRpcResponseHydrated, testData } from './fixtures/get_block';
+import { mockRpcResponse, mockRpcResponseHydrated, testData, noTransactionBlock } from './fixtures/get_block';
 import { blockSchema } from '../../../src/schemas';
 
 jest.mock('web3-rpc-methods');
@@ -73,6 +73,33 @@ describe('getBlock', () => {
 				expectedMockRpcResponse,
 				expectedReturnFormat,
 			);
+			const inputBlockIsBytes = isBytes(inputBlock as Bytes);
+			(
+				(inputBlockIsBytes
+					? ethRpcMethods.getBlockByHash
+					: ethRpcMethods.getBlockByNumber) as jest.Mock
+			).mockResolvedValueOnce(expectedMockRpcResponse);
+
+			const result = await getBlock(web3Context, ...inputParameters, expectedReturnFormat);
+			expect(result).toStrictEqual(expectedFormattedResult);
+		},
+	);
+
+	it.each(testData)(
+		`should format the block to include transactions as an empty array if no transactions are present\nTitle: %s\nInput parameters: %s\n`,
+		async (_, inputParameters) => {
+			const [inputBlock] = inputParameters;
+			const expectedReturnFormat = { number: FMT_NUMBER.STR, bytes: FMT_BYTES.UINT8ARRAY };
+			const expectedMockRpcResponse = noTransactionBlock;
+			// TODO: Fix format to default have a default in oneOf if no schema is matched
+			let formattedResult = format(
+				blockSchema,
+				expectedMockRpcResponse,
+				expectedReturnFormat,
+			);
+			const expectedFormattedResult  = {...formattedResult,
+				transactions: []
+			};
 			const inputBlockIsBytes = isBytes(inputBlock as Bytes);
 			(
 				(inputBlockIsBytes


### PR DESCRIPTION
## Description

#7090
when using eth.getBlock() and we recieve a block with no transactions block.transactions property should be an empty array but returns undefined. This is due to the format function not defaulting to an empty array not matching  any trasaction schemas. Will need to fix format function. relates to [this](https://github.com/web3/web3.js/issues/5370) 
Please include a summary of the changes and be sure to follow our [Contribution Guidelines](https://github.com/web3/web3.js/blob/4.x/.github/CONTRIBUTING.md).

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
