### PR TITLE
doc: fix the word error

### DIFF
--- a/docs/docs/guides/hardhat_tutorial/index.md
+++ b/docs/docs/guides/hardhat_tutorial/index.md
@@ -127,7 +127,7 @@ Running the above command will generate a folder called `artifacts` containing t
 
 ![images](./asset/artifacts.png)
 
-To deploy the contract, we will modify the `script/deploy.ts` file as shown below.
+To deploy the contract, we will modify the `scripts/deploy.ts` file as shown below.
 
 First, we import the initialized web3 object from hardhat. Next we get the artifacts.
 


### PR DESCRIPTION
Here is script and down Here is scripts 

first
<img width="731" alt="image" src="https://github.com/user-attachments/assets/9d282651-b9a0-4cf0-9828-8c9a45411661">

second
<img width="838" alt="image" src="https://github.com/user-attachments/assets/2fa6ea30-6ffc-41c7-927e-fd5ec4184120">

[document link](https://docs.web3js.org/guides/hardhat_tutorial/)