### PR TITLE
feat: make getEthereumjsTxDataFromTransaction not trim extra fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2728,3 +2728,9 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 -   The callback function provided to the static `Web3.onNewProviderDiscovered` function expects a parameter of type `EIP6963ProvidersMapUpdateEvent` as opposed to `EIP6963AnnounceProviderEvent`. (#7242)
 
 ## [Unreleased]
+
+### Changed
+
+#### web3-eth
+
+-   Allow `getEthereumjsTxDataFrom` to return additional fields that may be passed if using a `customTransactionSchema`.

--- a/packages/web3-eth/CHANGELOG.md
+++ b/packages/web3-eth/CHANGELOG.md
@@ -280,3 +280,7 @@ Documentation:
 -   Adds the same `{transactionSchema?: ValidationSchemaInput}` that exists in `formatTransaction` to `validateTransactionForSigning`
 
 ## [Unreleased]
+
+### Changed
+
+-   Allow `getEthereumjsTxDataFrom` to return additional fields that may be passed if using a `customTransactionSchema`.

--- a/packages/web3-eth/src/utils/prepare_transaction_for_signing.ts
+++ b/packages/web3-eth/src/utils/prepare_transaction_for_signing.ts
@@ -18,8 +18,6 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 import {
 	EthExecutionAPI,
 	HexString,
-	PopulatedUnsignedEip1559Transaction,
-	PopulatedUnsignedEip2930Transaction,
 	PopulatedUnsignedTransaction,
 	Transaction,
 	ValidChains,
@@ -36,25 +34,24 @@ import { transactionBuilder } from './transaction_builder.js';
 
 const getEthereumjsTxDataFromTransaction = (
 	transaction: FormatType<PopulatedUnsignedTransaction, typeof ETH_DATA_FORMAT>,
-) => ({
-	nonce: transaction.nonce,
-	gasPrice: transaction.gasPrice,
-	gasLimit: transaction.gasLimit ?? transaction.gas,
-	to: transaction.to,
-	value: transaction.value,
-	data: transaction.data ?? transaction.input,
-	type: transaction.type,
-	chainId: transaction.chainId,
-	accessList: (
-		transaction as FormatType<PopulatedUnsignedEip2930Transaction, typeof ETH_DATA_FORMAT>
-	).accessList,
-	maxPriorityFeePerGas: (
-		transaction as FormatType<PopulatedUnsignedEip1559Transaction, typeof ETH_DATA_FORMAT>
-	).maxPriorityFeePerGas,
-	maxFeePerGas: (
-		transaction as FormatType<PopulatedUnsignedEip1559Transaction, typeof ETH_DATA_FORMAT>
-	).maxFeePerGas,
-});
+) => {
+	const txData = { ...transaction };
+
+	const aliases = [
+		['input', 'data'],
+		['gas', 'gasLimit'],
+	] as const;
+
+	for (const [oldField, newField] of aliases) {
+		if (typeof txData[oldField] !== 'undefined') {
+			// @ts-expect-error
+			txData[newField] = txData[oldField];
+			delete txData[oldField];
+		}
+	}
+
+	return txData;
+};
 
 const getEthereumjsTransactionOptions = (
 	transaction: FormatType<PopulatedUnsignedTransaction, typeof ETH_DATA_FORMAT>,

--- a/packages/web3-eth/src/utils/prepare_transaction_for_signing.ts
+++ b/packages/web3-eth/src/utils/prepare_transaction_for_signing.ts
@@ -44,8 +44,7 @@ const getEthereumjsTxDataFromTransaction = (
 
 	for (const [oldField, newField] of aliases) {
 		if (typeof txData[oldField] !== 'undefined') {
-			// @ts-expect-error
-			txData[newField] = txData[oldField];
+			txData[newField] = txData[oldField]!;
 			delete txData[oldField];
 		}
 	}

--- a/packages/web3-eth/src/utils/prepare_transaction_for_signing.ts
+++ b/packages/web3-eth/src/utils/prepare_transaction_for_signing.ts
@@ -18,6 +18,8 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 import {
 	EthExecutionAPI,
 	HexString,
+	PopulatedUnsignedEip1559Transaction,
+	PopulatedUnsignedEip2930Transaction,
 	PopulatedUnsignedTransaction,
 	Transaction,
 	ValidChains,
@@ -34,23 +36,26 @@ import { transactionBuilder } from './transaction_builder.js';
 
 const getEthereumjsTxDataFromTransaction = (
 	transaction: FormatType<PopulatedUnsignedTransaction, typeof ETH_DATA_FORMAT>,
-) => {
-	const txData = { ...transaction };
-
-	const aliases = [
-		['input', 'data'],
-		['gas', 'gasLimit'],
-	] as const;
-
-	for (const [oldField, newField] of aliases) {
-		if (typeof txData[oldField] !== 'undefined') {
-			txData[newField] = txData[oldField]!;
-			delete txData[oldField];
-		}
-	}
-
-	return txData;
-};
+) => ({
+	...transaction,
+	nonce: transaction.nonce,
+	gasPrice: transaction.gasPrice,
+	gasLimit: transaction.gasLimit ?? transaction.gas,
+	to: transaction.to,
+	value: transaction.value,
+	data: transaction.data ?? transaction.input,
+	type: transaction.type,
+	chainId: transaction.chainId,
+	accessList: (
+		transaction as FormatType<PopulatedUnsignedEip2930Transaction, typeof ETH_DATA_FORMAT>
+	).accessList,
+	maxPriorityFeePerGas: (
+		transaction as FormatType<PopulatedUnsignedEip1559Transaction, typeof ETH_DATA_FORMAT>
+	).maxPriorityFeePerGas,
+	maxFeePerGas: (
+		transaction as FormatType<PopulatedUnsignedEip1559Transaction, typeof ETH_DATA_FORMAT>
+	).maxFeePerGas,
+});
 
 const getEthereumjsTransactionOptions = (
 	transaction: FormatType<PopulatedUnsignedTransaction, typeof ETH_DATA_FORMAT>,

--- a/packages/web3-eth/test/unit/prepare_transaction_for_signing.test.ts
+++ b/packages/web3-eth/test/unit/prepare_transaction_for_signing.test.ts
@@ -366,9 +366,7 @@ describe('prepareTransactionForSigning', () => {
 			context,
 		)) as TypedTransaction & { feeCurrency: string };
 
-		// @ts-expect-error
-		expect(spy.mock.lastCall[0].feeCurrency).toEqual(
-			'0x1234567890123456789012345678901234567890',
-		);
+		// @ts-expect-error feeCurrency is a custom field for testing here
+		expect(spy.mock.lastCall[0].feeCurrency).toBe('0x1234567890123456789012345678901234567890');
 	});
 });

--- a/packages/web3/test/integration/web3-plugin-add-tx.test.ts
+++ b/packages/web3/test/integration/web3-plugin-add-tx.test.ts
@@ -58,16 +58,20 @@ describe('Add New Tx as a Plugin', () => {
 			type: TRANSACTION_TYPE,
 			maxPriorityFeePerGas: BigInt(5000000),
 			maxFeePerGas: BigInt(5000000),
+			customField: BigInt(42),
 		};
 		const sub = web3.eth.sendTransaction(tx);
 
-		const waitForEvent: Promise<Transaction> = new Promise(resolve => {
-			// eslint-disable-next-line @typescript-eslint/no-floating-promises
-			sub.on('sending', txData => {
-				resolve(txData as unknown as Transaction);
-			});
-		});
+		const waitForEvent: Promise<Transaction & { customField: bigint }> = new Promise(
+			resolve => {
+				// eslint-disable-next-line @typescript-eslint/no-floating-promises
+				sub.on('sending', txData => {
+					resolve(txData as unknown as Transaction & { customField: bigint });
+				});
+			},
+		);
 		expect(Number((await waitForEvent).type)).toBe(TRANSACTION_TYPE);
+		expect(BigInt((await waitForEvent).customField)).toBe(BigInt(42));
 		await expect(sub).rejects.toThrow();
 	});
 });

--- a/packages/web3/test/integration/web3-plugin-add-tx.test.ts
+++ b/packages/web3/test/integration/web3-plugin-add-tx.test.ts
@@ -18,6 +18,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
 import { Transaction, Web3Account } from 'web3-eth-accounts';
+import { transactionSchema } from 'web3-eth';
 import { SupportedProviders, Web3, Web3PluginBase } from '../../src';
 import {
 	createAccount,
@@ -51,6 +52,14 @@ describe('Add New Tx as a Plugin', () => {
 	});
 	it('should receive correct type of tx', async () => {
 		web3.registerPlugin(new Eip4844Plugin());
+		web3.config.customTransactionSchema = {
+			type: 'object',
+			properties: {
+				...transactionSchema.properties,
+				customField: { format: 'string' },
+			},
+		};
+		web3.eth.config.customTransactionSchema = web3.config.customTransactionSchema;
 		const tx = {
 			from: account1.address,
 			to: account2.address,
@@ -70,8 +79,9 @@ describe('Add New Tx as a Plugin', () => {
 				});
 			},
 		);
-		expect(Number((await waitForEvent).type)).toBe(TRANSACTION_TYPE);
-		expect(BigInt((await waitForEvent).customField)).toBe(BigInt(42));
+		const { type, customField } = await waitForEvent;
+		expect(Number(type)).toBe(TRANSACTION_TYPE);
+		expect(BigInt(customField)).toBe(BigInt(42));
 		await expect(sub).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
## Description

This PR refactors `getEthereumjsTxDataFromTransaction` to not trim extra fields anymore whilst still aliasing `input` and `gasLimit`

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run lint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have linked Issue(s) with this PR in "Linked Issues" menu.


[ Closes #7273 ]
