### PR TITLE
Add Support for Nethermind and Besu 'syncing' Subscription Payload Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2729,6 +2729,12 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 
 ## [Unreleased]
 
+### Added
+
+#### web3-eth
+
+-   `syncing` subscription now supports Besu and Nethermind payload format
+
 ### Changed
 
 #### web3-eth

--- a/packages/web3-eth/src/web3_subscriptions.ts
+++ b/packages/web3-eth/src/web3_subscriptions.ts
@@ -163,7 +163,7 @@ export class SyncingSubscription extends Web3Subscription<{
 			this.emit('changed', data);
 		} else {
 			const mappedData: SyncOutput = Object.fromEntries(
-				Object.entries(data.status).map(([key, value]) => [
+				Object.entries(data?.status || data).map(([key, value]) => [
 					key.charAt(0).toLowerCase() + key.substring(1),
 					value,
 				]),


### PR DESCRIPTION

## Description

Currently if I subscribe to Nethermind or Besu clients with 'syncing' subscription it throws the following error:

```
/node_modules/web3-eth/lib/commonjs/web3_subscriptions.js:132
            const mappedData = Object.fromEntries(Object.entries(data.status).map(([key, value]) => [
                                                                      ^

TypeError: Cannot read properties of undefined (reading 'status')
    at SyncingSubscription._processSubscriptionResult (/node_modules/web3-eth/lib/commonjs/web3_subscriptions.js:132:71) 
```

This is due to the response format differences. Here is an example of Besu or Nethermind response:

```js
{
  jsonrpc: '2.0',
  method: 'eth_subscription',
  params: {
    subscription: '0x5c68',
    result: {
      startingBlock: '0x9c1ff0',
      currentBlock: '0x9c1ff0',
      highestBlock: '0x9c2b6f'
    }
  }
}
```

While a Geth node wraps the extra details into one more depth level:

```js
{
  jsonrpc: '2.0',
  method: 'eth_subscription',
  params: {
    subscription: '0x46045714f4037459982d30f6f5c01d90',
    result: {
      syncing: true,
      status: {
        StartingBlock: 0,
        CurrentBlock: 1707865,
        HighestBlock: 6802712,
        PulledStates: 0,
        KnownStates: 0,
        SyncedAccounts: 895455,
        SyncedAccountBytes: 209815179,
        SyncedBytecodes: 105745,
        SyncedBytecodeBytes: 497828494,
        SyncedStorage: 7361882,
        SyncedStorageBytes: 1634789943,
        HealedTrienodes: 0,
        HealedTrienodeBytes: 0,
        HealedBytecodes: 0,
        HealedBytecodeBytes: 0,
        HealingTrienodes: 0,
        HealingBytecode: 0,
        TxIndexFinishedBlocks: 0,
        TxIndexRemainingBlocks: 1
      }
    }
  }
}

```


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
