### PR TITLE
Fix a docs typo in subscribe migration guide

### DIFF
--- a/docs/docs/guides/15_web3_upgrade_guide/subscribe_migration_guide.md
+++ b/docs/docs/guides/15_web3_upgrade_guide/subscribe_migration_guide.md
@@ -42,7 +42,7 @@ In summary, the differences you need to be aware of when subscribing to blockcha
     -   It does not accept a callback function.
     -   It returns a subscription object that you can use to listen to `data` and `error` events.
 -   You should now use the `on`, or `once`, method on the newly returned subscription object to listen to `data` and `error` events, instead of passing a callback function directly.
--   You can have multiple event listeners, if you have, for example multiple `on` calls. And you can get the number of listeners in you code by calling `listenerCount(event_name)` or get the listeners with `listeners(event_name)`.
+-   You can have multiple event listeners, if you have, for example multiple `on` calls. And you can get the number of listeners in your code by calling `listenerCount(event_name)` or get the listeners with `listeners(event_name)`.
 
 Keep in mind that these differences apply to all blockchain event subscriptions, not just to the `newBlockHeaders` event.
 


### PR DESCRIPTION
## Description

Fixes [7324](https://github.com/web3/web3.js/issues/7324) Fixing a small typo in subscribe migration guide. 

<!--
Optional if an issue is fixed:
Fixes #([issue](https://github.com/web3/web3.js/issues/7324)) 
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran `npm run lint` with success and extended the tests and types if necessary.
- [x] I ran `npm run test:unit` with success.
- [x] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [x] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [x] I have linked Issue(s) with this PR in "Linked Issues" menu.
