### PR TITLE
fix: export Web3Account, Wallet and signature related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2803,3 +2803,9 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 -   Fix Contract methods input param type any[] (#7340)
 
 ## [Unreleased]
+
+### Fixed
+
+#### web3
+
+-   Export Web3Account, Wallet and signature related types. (#7374)

--- a/packages/web3-eth-accounts/CHANGELOG.md
+++ b/packages/web3-eth-accounts/CHANGELOG.md
@@ -190,3 +190,7 @@ Documentation:
 -   `hashMessage` now has a new optional param `skipPrefix` with a default value of `false`. A new function `signRaw` was added to sign a message without prefix. (#7346)
 
 ## [Unreleased]
+
+### Removed
+
+-   Move signature related types to web3-types. Re-export them for backwards compatibility. (#7374)

--- a/packages/web3-eth-accounts/src/account.ts
+++ b/packages/web3-eth-accounts/src/account.ts
@@ -69,6 +69,9 @@ import {
 	KeyStore,
 	PBKDF2SHA256Params,
 	ScryptParams,
+	SignatureObject,
+	SignResult,
+	SignTransactionResult,
 	Transaction,
 } from 'web3-types';
 import {
@@ -90,13 +93,7 @@ import { isHexStrict, isNullish, isString, validator } from 'web3-validator';
 import { secp256k1 } from './tx/constants.js';
 import { keyStoreSchema } from './schemas.js';
 import { TransactionFactory } from './tx/transactionFactory.js';
-import type {
-	SignatureObject,
-	SignTransactionResult,
-	TypedTransaction,
-	Web3Account,
-	SignResult,
-} from './types.js';
+import type { TypedTransaction, Web3Account } from './types.js';
 
 /**
  * Get the private key Uint8Array after the validation.

--- a/packages/web3-eth-accounts/src/types.ts
+++ b/packages/web3-eth-accounts/src/types.ts
@@ -16,37 +16,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { Web3BaseWalletAccount, HexString } from 'web3-types';
-import { FeeMarketEIP1559TxData, AccessListEIP2930TxData, TxData } from './tx/types.js';
 import { AccessListEIP2930Transaction, FeeMarketEIP1559Transaction, Transaction } from './tx';
-
-export type SignatureObject = {
-	messageHash: string;
-	r: string;
-	s: string;
-	v: string;
-};
-
-export type SignTransactionResult = SignatureObject & {
-	rawTransaction: string;
-	transactionHash: string;
-};
-
-export type SignTransactionFunction = (
-	transaction:
-		| TxData
-		| AccessListEIP2930TxData
-		| FeeMarketEIP1559TxData
-		| Record<string, unknown>,
-) => SignTransactionResult;
-
-export type SignResult = SignatureObject & {
-	message?: string;
-	signature: string;
-};
-
-export type SignFunction = (data: string, privateKey: string) => SignResult;
-
-// https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
 
 export interface Web3Account extends Web3BaseWalletAccount {
 	address: HexString;

--- a/packages/web3-eth-accounts/src/types.ts
+++ b/packages/web3-eth-accounts/src/types.ts
@@ -15,8 +15,16 @@ You should have received a copy of the GNU Lesser General Public License
 along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-import { Web3BaseWalletAccount, HexString } from 'web3-types';
+import {
+	HexString,
+	SignatureObject,
+	SignResult,
+	SignTransactionResult,
+	Web3BaseWalletAccount,
+} from 'web3-types';
 import { AccessListEIP2930Transaction, FeeMarketEIP1559Transaction, Transaction } from './tx';
+
+export { SignatureObject, SignResult, SignTransactionResult };
 
 export interface Web3Account extends Web3BaseWalletAccount {
 	address: HexString;

--- a/packages/web3-types/CHANGELOG.md
+++ b/packages/web3-types/CHANGELOG.md
@@ -221,3 +221,7 @@ Documentation:
 -   `FilterParams` type added (#7353)
 
 ## [Unreleased]
+
+#### Added
+
+-   Add signature related types. (#7374)

--- a/packages/web3-types/src/web3_base_wallet.ts
+++ b/packages/web3-types/src/web3_base_wallet.ts
@@ -60,26 +60,29 @@ export type KeyStore = {
 	address: string;
 };
 
+export type SignatureObject = {
+	messageHash: string;
+	r: string;
+	s: string;
+	v: string;
+};
+
+export type SignTransactionResult = SignatureObject & {
+	rawTransaction: string;
+	transactionHash: string;
+};
+
+export type SignResult = SignatureObject & {
+	message?: string;
+	signature: string;
+};
+
 export interface Web3BaseWalletAccount {
 	[key: string]: unknown;
 	readonly address: string;
 	readonly privateKey: string;
-	readonly signTransaction: (tx: Transaction) => Promise<{
-		readonly messageHash: HexString;
-		readonly r: HexString;
-		readonly s: HexString;
-		readonly v: HexString;
-		readonly rawTransaction: HexString;
-		readonly transactionHash: HexString;
-	}>;
-	readonly sign: (data: Record<string, unknown> | string) => {
-		readonly messageHash: HexString;
-		readonly r: HexString;
-		readonly s: HexString;
-		readonly v: HexString;
-		readonly message?: string;
-		readonly signature: HexString;
-	};
+	readonly signTransaction: (tx: Transaction) => Promise<SignTransactionResult>;
+	readonly sign: (data: Record<string, unknown> | string) => SignResult;
 	readonly encrypt: (password: string, options?: Record<string, unknown>) => Promise<KeyStore>;
 }
 

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -561,3 +561,9 @@ Documentation:
 -   Fix Contract methods input param type any[] (#7340)
 
 ## [Unreleased]
+
+### Fixed
+
+#### web3
+
+-   Export Web3Account, Wallet and signature related types. (#7374)

--- a/packages/web3/src/index.ts
+++ b/packages/web3/src/index.ts
@@ -364,4 +364,3 @@ export * as validator from 'web3-validator';
  */
 export * from 'web3-errors';
 export * from 'web3-types';
-export type { Web3Account, Wallet } from 'web3-eth-accounts';

--- a/packages/web3/src/index.ts
+++ b/packages/web3/src/index.ts
@@ -364,3 +364,4 @@ export * as validator from 'web3-validator';
  */
 export * from 'web3-errors';
 export * from 'web3-types';
+export type { Web3Account, Wallet } from 'web3-eth-accounts';

--- a/packages/web3/src/types.ts
+++ b/packages/web3/src/types.ts
@@ -42,6 +42,8 @@ import { Net } from 'web3-net';
 import { Iban } from 'web3-eth-iban';
 import { Personal } from 'web3-eth-personal';
 
+export type { Web3Account, Wallet } from 'web3-eth-accounts';
+
 /**
  * The Ethereum interface for main web3 object. It provides extra methods in addition to `web3-eth` interface.
  *

--- a/packages/web3/test/unit/accounts.test.ts
+++ b/packages/web3/test/unit/accounts.test.ts
@@ -17,7 +17,8 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 import * as eth from 'web3-eth';
 import * as ethAccounts from 'web3-eth-accounts';
-import { SignTransactionResult, Web3Account } from 'web3-eth-accounts';
+import { Web3Account } from 'web3-eth-accounts';
+import type { SignTransactionResult } from 'web3-types';
 import { Web3EthInterface } from '../../src/types';
 import { Web3 } from '../../src';
 


### PR DESCRIPTION
## Description

Export types that represent the return values of method calls but aren’t currently available as standalone types. Specifically, this includes `Web3Account`, `Wallet`, and signature-related types like `SignatureObject`, `SignResult`, and `SignTransactionResult`.

Fixes #7341


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
