### PR TITLE
Typo Update infer_contract_types.md

### DIFF
--- a/docs/docs/guides/05_smart_contracts/infer_contract_types.md
+++ b/docs/docs/guides/05_smart_contracts/infer_contract_types.md
@@ -7,7 +7,7 @@ sidebar_label: 'Infer Contract Types from JSON Artifact (TypeScript)'
 
 :::tip
 📝 This article is for **TypeScript** developers. So, if you are using JavaScript, you do not need to read this.
-However, web3.js version 4.x has been rewritten in TypeScript. And we encorage you to use its strongly-typed features with TypeScript.
+However, web3.js version 4.x has been rewritten in TypeScript. And we encourage you to use its strongly-typed features with TypeScript.
 :::
 
 Web3.js is a popular library used for interacting with EVM blockchains. One of its key features is the ability to invoke EVM smart contracts deployed on the blockchain. In this blog post, we will show how to interact with the smart contract in **TypeScript**, with a special focus on how to infer types from JSON artifact files.


### PR DESCRIPTION
## Description

<img width="1025" alt="Снимок экрана 2024-11-11 в 20 16 22" src="https://github.com/user-attachments/assets/b0a2c8d5-acad-4f19-9f08-fd29efbe3fd4">

"encorage" should be "**encourage**"

Corrected.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)