### PR TITLE
Typo Update events_listening.md

### DIFF
--- a/docs/docs/guides/02_web3_providers_guide/events_listening.md
+++ b/docs/docs/guides/02_web3_providers_guide/events_listening.md
@@ -5,7 +5,7 @@ sidebar_label: 'Providers Events Listening'
 
 # Providers Events Listening
 
-Some providers are, by design, always connected. Therefor, they can communicate changes with the user through events. Actually, among the 3 providers, `HttpProvider` is the only one that does not support event. And the other 2:
+Some providers are, by design, always connected. Therefore, they can communicate changes with the user through events. Actually, among the 3 providers, `HttpProvider` is the only one that does not support event. And the other 2:
 [WebSocketProvider](/api/web3-providers-ws/class/WebSocketProvider) and [IpcProvider](/api/web3-providers-ipc/class/IpcProvider) enable the user to listen to emitted events.
 
 Actually, the events can be categorized as follows ([according to EIP 1193](https://eips.ethereum.org/EIPS/eip-1193#rationale)):


### PR DESCRIPTION
### Fix typo: "Therefor" → "Therefore"

I found a typo in the following sentence:

- **"Therefor, they can communicate changes with the user through events."**

The word **"Therefor"** should be **"Therefore"**.

The corrected sentence is:

- **"Therefore, they can communicate changes with the user through events."**

"Therefore" is the correct word in this context, as it indicates a conclusion or result. "Therefor" is an incorrect spelling and does not fit the intended meaning. This change ensures the text is clear and grammatically correct.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
- [ ] I ran `npm run test:unit` with success.
- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
- [ ] I have tested my code on the live network.
- [ ] I have checked the Deploy Preview and it looks correct.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
