### PR TITLE
Fixes for Minor Typographical Errors are Not Accepted

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,35 +8,45 @@ If you face any issues while contributing or want any type of support, we encour
 
 ## Prerequisites
 
-- [NodeJS](https://nodejs.org/) (LTS)
-- [Yarn](https://yarnpkg.com/)
+-   [NodeJS](https://nodejs.org/) (LTS)
+-   [Yarn](https://yarnpkg.com/)
 
 ## Contributing to the docs
+
+> [!NOTE]
+> Contributions that only address relatively minor typographical errors are not accepted. If you believe you have identified an important typographical error that should be addressed, [please open an Issue](https://github.com/web3/web3.js/issues/new?assignees=&labels=Documentation&projects=&template=issue-template.md&title=[Typo]).
 
 1. **Fork the docs:** Start by forking our repository to your GitHub account.
 
 2. **Clone the repo:** Clone the forked repository to your local machine using the following command:
+
 ```bash
 git clone https://github.com/your-username/web3.js.git
 ```
+
 3. **Create a Branch:** Create a new branch for your changes with a descriptive name.
-    **NOTE: The branch name must include the issue number (if there is no issue created for your contribution, please create one).**
+   **NOTE: The branch name must include the issue number (if there is no issue created for your contribution, please create one).**
+
 ```bash
 git checkout -b issue-name-1234
 ```
+
 4. **Navigate to the docs folder:** `cd web3.js/docs/docs`
 
-5. **Install dependencies:** 
+5. **Install dependencies:**
+
 ```bash
 yarn
 ```
+
 6. **Make your changes:**...
 
 7. Check changes in the local environment: Run the command `yarn start` and you'll see a local environment in `localhost:3000` with the documents.
 
-8. **Commit your changes:** `git add .` and `git commit -m 'descriptive msg'` 
+8. **Commit your changes:** `git add .` and `git commit -m 'descriptive msg'`
 
 9. **Push your changes:**
+
 ```bash
 git push origin branch-name
 ```
@@ -96,4 +106,3 @@ Emergency releases are allowed to shorten waiting periods depending on the sever
 There is precedent set for this in the 1.2.6 release (see [#3351](https://github.com/ethereum/web3.js/pull/3351)), where the consensus view was to make the smallest change necessary to address the emergency while waiving the `rc` process (meaning many existing additions to master were excluded).
 
 This topic is under further org-wide discussion at [ethereum/js-organization#6](https://github.com/ethereum/js-organization/issues/6).
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,23 +11,24 @@ Fixes #(issue)
 
 <!-- Please delete options that are not relevant. -->
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+-   [ ] Bug fix (non-breaking change which fixes an issue)
+-   [ ] New feature (non-breaking change which adds functionality)
+-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+-   [ ] Documentation (changes that only address relatively minor typographical errors are not accepted)
 
 ## Checklist:
 
-- [ ] I have selected the correct base branch.
-- [ ] I have performed a self-review of my own code.
-- [ ] I have commented my code, particularly in hard-to-understand areas.
-- [ ] I have made corresponding changes to the documentation.
-- [ ] My changes generate no new warnings.
-- [ ] Any dependent changes have been merged and published in downstream modules.
-- [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
-- [ ] I ran `npm run test:unit` with success.
-- [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
-- [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
-- [ ] I have tested my code on the live network.
-- [ ] I have checked the Deploy Preview and it looks correct.
-- [ ] I have updated the `CHANGELOG.md` file in the root folder.
-- [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
+-   [ ] I have selected the correct base branch.
+-   [ ] I have performed a self-review of my own code.
+-   [ ] I have commented my code, particularly in hard-to-understand areas.
+-   [ ] I have made corresponding changes to the documentation.
+-   [ ] My changes generate no new warnings.
+-   [ ] Any dependent changes have been merged and published in downstream modules.
+-   [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
+-   [ ] I ran `npm run test:unit` with success.
+-   [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
+-   [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
+-   [ ] I have tested my code on the live network.
+-   [ ] I have checked the Deploy Preview and it looks correct.
+-   [ ] I have updated the `CHANGELOG.md` file in the root folder.
+-   [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.

--- a/packages/web3-core/CHANGELOG.md
+++ b/packages/web3-core/CHANGELOG.md
@@ -123,7 +123,7 @@ Documentation:
 
 ### Added
 
--   Web3Subscription constructor accept a Subscription Manager (as an alternative to accepting Request Manager that is now marked marked as deprecated) (#6210)
+-   Web3Subscription constructor accept a Subscription Manager (as an alternative to accepting Request Manager that is now marked as deprecated) (#6210)
 
 ### Changed
 
@@ -185,7 +185,7 @@ Documentation:
 
 -   defaultTransactionType is now type 0x2 instead of 0x0 (#6282)
 -   Allows formatter to parse large base fee (#6456)
--   The package now uses `EventEmitter` from `web3-utils` that works in node envrioment as well as in the browser. (#6398)
+-   The package now uses `EventEmitter` from `web3-utils` that works in node environment as well as in the browser. (#6398)
 
 ### Fixed
 
@@ -205,7 +205,7 @@ Documentation:
 
 ### Changed
 
--   Web3config `contractDataInputFill` has been defaulted to `data`, istead of `input`. (#6622)
+-   Web3config `contractDataInputFill` has been defaulted to `data`, instead of `input`. (#6622)
 
 ## [4.4.0]
 
@@ -225,7 +225,7 @@ Documentation:
 
 ### Added
 
--   Now when existing packages are added in web3, will be avalible for plugins via context. (#7088)
+-   Now when existing packages are added in web3, will be available for plugins via context. (#7088)
 
 ## [4.5.1]
 

--- a/packages/web3-utils/README.md
+++ b/packages/web3-utils/README.md
@@ -11,7 +11,7 @@
 
 This is a sub-package of [web3.js][repo].
 
-`web3-utils` This contains useful utility functions for Dapp developers.
+`web3-utils` contains useful utility functions for Dapp developers.
 
 ## Installation
 


### PR DESCRIPTION
Replaces #7405

Added to `.github/CONTRIBUTING.md`:

> [!NOTE]
> Contributions that only address relatively minor typographical errors are not accepted. If you believe you have identified an important typographical error that should be addressed, [please open an Issue](https://github.com/web3/web3.js/issues/new?assignees=&labels=Documentation&projects=&template=issue-template.md&title=[Typo]).

Added to `.github/PULL_REQUEST_TEMPLATE.md`:

> - [ ] Documentation (changes that only address relatively minor typographical errors are not accepted)