### PR TITLE
Fix Typographical and Grammar Errors Across Documentation Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2501,7 +2501,7 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 #### web3-validator
 
 -   The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
--   `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)
+-   `browser` entry point that was pointing to a non-existing bundle file was removed from `package.json` (#7015)
 
 #### web3-core
 

--- a/docs/docs/guides/05_smart_contracts/tips_and_tricks.md
+++ b/docs/docs/guides/05_smart_contracts/tips_and_tricks.md
@@ -105,7 +105,7 @@ const ABI = [
 	// Calling the function that accepts an address
 	const res1 = await contract.methods['funcWithParamsOverloading(address)'](userAddress).call();
 
-	// Calling the function that accepts a uint256
+	// Calling the function that accepts an uint256
 	const res2 = await contract.methods['funcWithParamsOverloading(uint256)'](userId).call();
 })();
 ```

--- a/docs/docs/guides/12_web3_utils_module/index.md
+++ b/docs/docs/guides/12_web3_utils_module/index.md
@@ -199,7 +199,7 @@ console.log(web3.utils.soliditySha3({ type: 'string', value: 'hello web3' }));
 console.log(web3.utils.toChecksumAddress('0xa3286628134bad128faeef82f44e99aa64085c94'));
 // 0xA3286628134baD128faeef82F44e99AA64085C94
 
-// passing an wrong address
+// passing a wrong address
 console.log(web3.utils.toChecksumAddress('0xa3286628134bad128faeef82f44e99aa64085c9'));
 // InvalidAddressError: Invalid value given "0xa286628134bad128faeef82f44e99aa64085c94". Error: invalid ethereum address.
 ```

--- a/docs/docs/guides/17_migration_from_other_libs/index.md
+++ b/docs/docs/guides/17_migration_from_other_libs/index.md
@@ -326,7 +326,7 @@ In web3.js:
 const web3 = new Web3(provider);
 const contract = new web3.eth.Contract(ABI, CONTRACT_ADDRESS);
 
-// If the method was only to read form the Blockchain:
+// If the method was only to read from the Blockchain:
 const result = await contract.methods.someFunction().call();
 // Or, if the method would need a transaction to be sent:
 const result = await contract.methods.someFunction().send();

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -173,6 +173,6 @@ Documentation:
 ### Fixed
 
 -   The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
--   `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)
+-   `browser` entry point that was pointing to a non-existing bundle file was removed from `package.json` (#7015)
 
 ## [Unreleased]

--- a/packages/web3/CHANGELOG.md
+++ b/packages/web3/CHANGELOG.md
@@ -316,7 +316,7 @@ Documentation:
 #### web3-validator
 
 -   The JSON schema conversion process now correctly assigns an id when the `abi.name` is not available, for example, in the case of public mappings. (#6981)
--   `browser` entry point that was pointing to an non-existing bundle file was removed from `package.json` (#7015)
+-   `browser` entry point that was pointing to a non-existing bundle file was removed from `package.json` (#7015)
 
 #### web3-core
 


### PR DESCRIPTION
This PR addresses various typographical and grammatical issues across multiple documentation files. The changes include:

- Fixed usage of "from" instead of "form."
- Updated incorrect references such as "an wrong address" to "a wrong address."
- Minor spelling fixes across various files to enhance readability.

These updates aim to improve the clarity and professionalism of the documentation.

## Type of PR:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation improvement (fixes typos and grammatical errors)

## Checklist:
- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
