### PR TITLE
add dist path for minified builds in validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2864,3 +2864,9 @@ If there are any bugs, improvements, optimizations or any new feature proposal f
 -   Updated Typescript version 4 -> 5 (#7272)
 
 ## [Unreleased]
+
+### Added
+
+#### web3-validator
+
+-   Add web3-validator dist path for react-native builds (#7416)

--- a/packages/web3-validator/CHANGELOG.md
+++ b/packages/web3-validator/CHANGELOG.md
@@ -176,3 +176,7 @@ Documentation:
 -   `browser` entry point that was pointing to a non-existing bundle file was removed from `package.json` (#7015)
 
 ## [Unreleased]
+
+### Added
+
+-   Add web3-validator dist path for react-native builds (#7416)

--- a/packages/web3-validator/package.json
+++ b/packages/web3-validator/package.json
@@ -11,6 +11,7 @@
 			"require": "./lib/commonjs/index.js"
 		}
 	},
+	"./dist/web3-validator.min.js": "./dist/web3-validator.min.js",
 	"repository": "https://github.com/ChainSafe/web3.js",
 	"author": "ChainSafe Systems",
 	"license": "LGPL-3.0",


### PR DESCRIPTION
## Description
#6247
Currently when trying to import Web3Validator, it does not exist in react-native due to the dist not being available in the package. This PR includes the path to Web3Validator in the package.json.
Please include a summary of the changes and be sure to follow our [Contribution Guidelines](https://github.com/web3/web3.js/blob/4.x/.github/CONTRIBUTING.md).

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation (changes that only address relatively minor typographical errors are not accepted)

## Checklist:

-   [ ] I have selected the correct base branch.
-   [ ] I have performed a self-review of my own code.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I have made corresponding changes to the documentation.
-   [ ] My changes generate no new warnings.
-   [ ] Any dependent changes have been merged and published in downstream modules.
-   [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
-   [ ] I ran `npm run test:unit` with success.
-   [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
-   [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
-   [ ] I have tested my code on the live network.
-   [ ] I have checked the Deploy Preview and it looks correct.
-   [ ] I have updated the `CHANGELOG.md` file in the root folder.
-   [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
