### PR TITLE
Doc: Issue Typo

### DIFF
--- a/docs/docs/guides/17_migration_from_other_libs/index.md
+++ b/docs/docs/guides/17_migration_from_other_libs/index.md
@@ -347,7 +347,7 @@ const contract = new ethers.Contract(address, abi, signer);
 // for ambiguous functions (two functions with the same
 // name), the signature must also be specified
 message = await contract['getMessage(string)']('nice');
-// and to call the overladed method without a parameter:
+// and to call the overloaded method without a parameter:
 message = await contract['getMessage()']();
 
 // in v6
@@ -359,7 +359,7 @@ In web3.js:
 ```typescript
 // in web3.js the overloaded method implementation is automatically picked based on the passed datatype
 message = await contract.methods.getMessage('nice').call();
-// To call the overladed method without a parameter:
+// To call the overloaded method without a parameter:
 message = await contract.methods.getMessage().call();
 ```
 


### PR DESCRIPTION
There's a typo in the word "overladed", which should be "overloaded 