### PR TITLE
docs: Fix typo on quickstart guide

### DIFF
--- a/docs/docs/guides/01_getting_started/quickstart.md
+++ b/docs/docs/guides/01_getting_started/quickstart.md
@@ -194,7 +194,7 @@ const ABI = [
 ];
 
 // instantiate the smart contract
-const uniswapToken = new web3.eth.Contract(abi, address);
+const uniswapToken = new web3.eth.Contract(ABI, address);
 ```
 
 ### Read Methods


### PR DESCRIPTION
## Description

On [this part](https://docs.web3js.org/guides/getting_started/quickstart#instantiate-a-smart-contract) of the quick start guide, there is a typo on the example when pass the abi constant to the `web3.eth.Contract` function as param. It is defined as `const ABI =...` but down is accessed will lowercase `abi`. This PR already fix it by  use the correct casing.

I hope this helps, happy coding👾

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation (changes that only address relatively minor typographical errors are not accepted)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
