### PR TITLE
fix(docs): correct broken link and variable name

### DIFF
--- a/docs/docs/guides/01_getting_started/quickstart.md
+++ b/docs/docs/guides/01_getting_started/quickstart.md
@@ -180,7 +180,7 @@ const address = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
 
 // you can find the complete ABI on etherscan.io
 // https://etherscan.io/address/0x1f9840a85d5af5bf1d1762f925bdaddc4201f984#code
-const ABI = [
+const abi = [
 	{
 		name: 'symbol',
 		outputs: [{ type: 'string' }],

--- a/docs/docs/guides/01_getting_started/quickstart.md
+++ b/docs/docs/guides/01_getting_started/quickstart.md
@@ -25,7 +25,7 @@ For projects using Yarn as a package manager, use:
 yarn add web3
 ```
 
-Note: Installing Web3.js in this way will bring in all Web3.js sub-[packages](/#packages). If you only need specific packages, it is recommended to install them individually (e.g, if you want the [Contract](/libdocs/Contract) package, use `npm i web3-eth-contract` instead)
+Note: Installing Web3.js in this way will bring in all Web3.js sub-[packages](/#packages--plugins). If you only need specific packages, it is recommended to install them individually (e.g, if you want the [Contract](/libdocs/Contract) package, use `npm i web3-eth-contract` instead)
 
 ## Importing Web3.js
 


### PR DESCRIPTION
## Description

- The link to the Web3.js sub-packages on [the Quickstart page](https://docs.web3js.org/guides/getting_started/quickstart/#installation) are incorrect, and I have fixed it.
- correct variable name for consistency

<!--
Optional if an issue is fixed:
Fixes #(issue)
-->

## Type of change

<!-- Please delete options that are not relevant. -->

-   [x] Documentation (changes that only address relatively minor typographical errors are not accepted)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [ ] I have commented my code, particularly in hard-to-understand areas.
-   [ ] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [ ] Any dependent changes have been merged and published in downstream modules.
-   [ ] I ran `npm run lint` with success and extended the tests and types if necessary.
-   [ ] I ran `npm run test:unit` with success.
-   [ ] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
-   [ ] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
-   [ ] I have tested my code on the live network.
-   [ ] I have checked the Deploy Preview and it looks correct.
-   [ ] I have updated the `CHANGELOG.md` file in the root folder.
-   [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
