### PR TITLE
chore: fix error in JSDoc example for sha3Raw

### DIFF
--- a/packages/web3-utils/src/hash.ts
+++ b/packages/web3-utils/src/hash.ts
@@ -147,7 +147,7 @@ export const sha3 = (data: Bytes): string | undefined => {
  *
  * @example
  * ```ts
- * conosle.log(web3.utils.sha3Raw('web3.js'));
+ * console.log(web3.utils.sha3Raw('web3.js'));
  * > 0x63667efb1961039c9bb0d6ea7a5abdd223a3aca7daa5044ad894226e1f83919a
  *
  * console.log(web3.utils.sha3Raw(''));


### PR DESCRIPTION
## Description

I noticed a error in the JSDoc example for `sha3Raw`. The example had `conosle.log` instead of `console.log`, which could cause confusion or errors if copied as-is. Fixed it to ensure the example runs correctly.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

-   [x] I have selected the correct base branch.
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.
-   [x] I ran `npm run lint` with success and extended the tests and types if necessary.
-   [x] I ran `npm run test:unit` with success.
-   [x] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.
-   [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.
-   [x] I have tested my code on the live network.
-   [x] I have checked the Deploy Preview and it looks correct.
-   [x] I have updated the `CHANGELOG.md` file in the root folder.
-   [ ] I have linked Issue(s) with this PR in "Linked Issues" menu.
