### PR TITLE
Fixed a typo in the "Release Process" section of the documentation.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,7 @@ Further details about versioning can be found in the [semver 2.0.0 specification
     - It will prompt for new version , modify package metadata and run lifecycle scripts (in our case `version`), for bootstrapping lerna will use underlying yarn.
 5. Update each package's and also root `CHANGELOG.md`:
 
-    5.A. If there are any changes in package during release PR e.g. dependency updated that effects package, add entry in changelog under `## [Unreleased]` of that package's changelog.
+    5.A. If there are any changes in package during release PR e.g. dependency updated that affects package, add entry in changelog under `## [Unreleased]` of that package's changelog.
 
     5.B. For root `CHANGELOG.md` update, run command `yarn changelog sync`
 


### PR DESCRIPTION
### Fix typo: "effects" -> "affects" in release guidelines
**The original sentence read:**  
"5.A. If there are any changes in package during release PR e.g. dependency updated that effects package, add entry in changelog under ## [Unreleased] of that package's changelog."  
The updated sentence now reads:  
"5.A. If there are any changes in package during release PR e.g. dependency updated that affects package, add entry in changelog under ## [Unreleased] of that package's changelog."

> The_ typo could confuse readers unfamiliar with the intended meaning, as "effects" (meaning outcomes or results) is incorrect in this context. "Affects" (meaning influences or impacts) is the appropriate term, aligning with the technical intent of the sentence. This correction enhances the readability and professionalism of the documentation, which is critical for developers following the release process.
