### PR TITLE
fix: fix incorrect engine comparison in system test utility

### DIFF
--- a/scripts/system_tests_utils.ts
+++ b/scripts/system_tests_utils.ts
@@ -106,7 +106,7 @@ export const isIpc: boolean = getSystemTestProviderUrl().includes('ipc');
 export const isChrome: boolean = getSystemTestEngine() === 'chrome';
 export const isFirefox: boolean = getSystemTestEngine() === 'firefox';
 export const isElectron: boolean = getSystemTestEngine() === 'electron';
-export const isNode: boolean = getSystemTestEngine() === 'isNode';
+export const isNode: boolean = getSystemTestEngine() === 'node';
 export const isSyncTest: boolean = getEnvVar('TEST_OPTION') === 'sync';
 export const isSocket: boolean = isWs || isIpc;
 export const isBrowser: boolean = ['chrome', 'firefox'].includes(getSystemTestEngine());


### PR DESCRIPTION
## Description  
I noticed we were comparing `getSystemTestEngine()` with `'isNode'` instead of `'node'`. This fixes the comparison to correctly check if the engine is Node.js. The updated line now reads:  

```typescript
export const isNode: boolean = getSystemTestEngine() === 'node';
```  

This ensures the `isNode` flag works as intended.

## Type of change  

-   [x] Bug fix (non-breaking change which fixes an issue)  
-   [ ] New feature (non-breaking change which adds functionality)  
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
-   [ ] Documentation (changes that only address relatively minor typographical errors are not accepted)  

## Checklist:  

-   [x] I have selected the correct base branch.  
-   [x] I have performed a self-review of my own code.  
-   [x] I have commented my code, particularly in hard-to-understand areas.  
-   [ ] I have made corresponding changes to the documentation.  
-   [x] My changes generate no new warnings.  
-   [ ] Any dependent changes have been merged and published in downstream modules.  
-   [x] I ran `npm run lint` with success and extended the tests and types if necessary.  
-   [x] I ran `npm run test:unit` with success.  
-   [x] I ran `npm run test:coverage` and my test cases cover all the lines and branches of the added code.  
-   [x] I ran `npm run build` and tested `dist/web3.min.js` in a browser.  
-   [ ] I have tested my code on the live network.  
-   [ ] I have checked the Deploy Preview and it looks correct.  
-   [x] I have updated the `CHANGELOG.md` file in the root folder.  
-   [x] I have linked Issue(s) with this PR in "Linked Issues" menu.